### PR TITLE
feat(slack-bot): 채널별 기본 프로젝트/CSN 고정 매핑 (channel-project.json)

### DIFF
--- a/slack-bot/channel-project.json
+++ b/slack-bot/channel-project.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "Slack 채널ID → 기본 프로젝트명(소문자) 고정 매핑. 이 채널에서 오는 모든 접두어 없는 메시지를 해당 프로젝트로 처리한다(작업 폴더 = PROJECTS_ROOT/<프로젝트명>, csn = project-csn.json[<프로젝트명>]). Rule 32(project prefix routing) 우선순위: 메시지 선두에 실폴더 또는 project-csn.json 등록 프로젝트 접두어가 명시되면 그 접두어가 이긴다(명시적 override). 접두어가 없을 때만 이 채널 고정 매핑이 기본값으로 적용된다. 비밀 아님(채널ID·프로젝트명뿐) → git 추적. Slack `giip channel set <프로젝트명> [채널ID]` / `giip channel list` / `giip channel del [채널ID]` 로 편집(재시작 불필요). 해석: config.resolveChannelProject(channelId)/applyChannelPin(channelId, parsed). ⚠️ csn 라우팅이 실제로 먹으려면 봇 유저가 그 csn 의 멤버여야 한다(tUserPerCorp) — 미가입이면 giip issue 게이트가 홈 csn 으로 클램프한다. 아래 map 은 템플릿이라 비어 있다; 배포처에서 `giip channel set` 으로 채운다.",
+  "map": {}
+}

--- a/slack-bot/config.js
+++ b/slack-bot/config.js
@@ -23,6 +23,7 @@ const HISTORY_FILE    = path.join(__dirname, '.conversations.json');
 const TASK_STATE_FILE = path.join(__dirname, '.task-state.json');
 const BOT_THREADS_FILE = path.join(__dirname, '.bot-threads.json');
 const PROJECT_CSN_FILE = path.join(__dirname, 'project-csn.json');
+const CHANNEL_PROJECT_FILE = path.join(__dirname, 'channel-project.json');
 
 // ── botUserId (main() で auth.test 後にセット、processMessage / socket handler で参照) ──
 let botUserId = null;
@@ -135,6 +136,86 @@ function deleteProjectCsn(name) {
   return false;
 }
 
+// ── チャンネル → 既定プロジェクト固定マッピング（channel-project.json 駆動） ──────
+// 「このチャンネルの発話はすべて <project> として扱う」を実現する。project-csn.json と同じく
+// 呼び出しごとに読み直す（再起動なしで反映）。giip csn とは独立に channelId → プロジェクト名を持つ。
+function loadChannelProjectMap() {
+  try {
+    const j = JSON.parse(fs.readFileSync(CHANNEL_PROJECT_FILE, 'utf8'));
+    return (j && j.map) || {};
+  } catch {
+    return {};
+  }
+}
+
+// channelId → プロジェクト名(小文字) or null。未登録なら null。
+function resolveChannelProject(channelId) {
+  if (!channelId) return null;
+  const v = loadChannelProjectMap()[channelId];
+  return v ? String(v).toLowerCase() : null;
+}
+
+// プロジェクト名 → workDir。PROJECTS_ROOT 直下に同名フォルダがあればそれ、無ければ BASE_DIR に
+// 安全フォールバック（存在しないフォルダを cwd にしない）。parseProjectPrefix のフォルダ解決と整合。
+function projectWorkDir(name) {
+  const candidate = String(name || '').trim().toLowerCase();
+  if (!candidate) return BASE_DIR;
+  const dir = path.join(PROJECTS_ROOT, candidate);
+  try { if (fs.statSync(dir).isDirectory()) return dir; } catch {}
+  return BASE_DIR;
+}
+
+// チャンネル固定マッピングを parseProjectPrefix の結果に適用する。
+//   優先順位（設計判断）: 明示的プロジェクト接頭辞 > チャンネル固定。
+//   メッセージ先頭に実フォルダ / project-csn.json 登録名の接頭辞があれば（parsed.projectName != null）
+//   それを尊重する（Rule 32 の絶対規則を維持）。接頭辞が無いときだけ、本来 BASE_DIR に
+//   潰れていた workDir/projectName をチャンネルの既定プロジェクトで埋める。cleanText は変更しない。
+function applyChannelPin(channelId, parsed) {
+  const p = parsed || { workDir: BASE_DIR, cleanText: '', projectName: null };
+  if (p.projectName) return p; // 明示接頭辞が優先
+  const pinned = resolveChannelProject(channelId);
+  if (!pinned) return p;
+  return { ...p, workDir: projectWorkDir(pinned), projectName: pinned };
+}
+
+// ── channel-project.json の読み書き（Slack `giip channel` コマンドから利用） ────
+function readChannelProjectFile() {
+  try {
+    const j = JSON.parse(fs.readFileSync(CHANNEL_PROJECT_FILE, 'utf8'));
+    return (j && typeof j === 'object') ? j : {};
+  } catch {
+    return {};
+  }
+}
+function writeChannelProjectFile(obj) {
+  fs.writeFileSync(CHANNEL_PROJECT_FILE, JSON.stringify(obj, null, 2) + '\n', 'utf8');
+}
+function listChannelProject() { return loadChannelProjectMap(); }
+// channelId → プロジェクト名 を追加/更新。プロジェクト名は小文字化して保存。
+function setChannelProject(channelId, name) {
+  const key = String(channelId || '').trim();
+  const val = String(name || '').trim().toLowerCase();
+  if (!key) throw new Error('channelId 가 필요합니다.');
+  if (!val) throw new Error('프로젝트명이 필요합니다.');
+  const j = readChannelProjectFile();
+  if (!j.map || typeof j.map !== 'object') j.map = {};
+  j.map[key] = val;
+  writeChannelProjectFile(j);
+  return { channelId: key, project: val };
+}
+// channelId のマッピングを削除。存在して削除したら true、無ければ false。
+function deleteChannelProject(channelId) {
+  const key = String(channelId || '').trim();
+  if (!key) return false;
+  const j = readChannelProjectFile();
+  if (j.map && Object.prototype.hasOwnProperty.call(j.map, key)) {
+    delete j.map[key];
+    writeChannelProjectFile(j);
+    return true;
+  }
+  return false;
+}
+
 module.exports = {
   BOT_TOKEN,
   CHANNEL_IDS,
@@ -154,4 +235,10 @@ module.exports = {
   listProjectCsn,
   setProjectCsn,
   deleteProjectCsn,
+  resolveChannelProject,
+  projectWorkDir,
+  applyChannelPin,
+  listChannelProject,
+  setChannelProject,
+  deleteChannelProject,
 };

--- a/slack-bot/giip-commands.js
+++ b/slack-bot/giip-commands.js
@@ -83,6 +83,50 @@ async function handleGiipCommand(rawText, channelId) {
     }
   }
 
+  // ── giip channel ... — 채널 → 기본 프로젝트 고정 매핑(channel-project.json, 재시작 불필요) ──
+  //   「이 채널의 발화는 모두 <project> 로 처리」. giip 계정과 무관하므로 account 게이트보다 먼저 처리.
+  //   채널ID 생략 시 현재 채널에 적용. Rule 32 우선순위: 명시적 접두어 > 채널 고정.
+  if (sub === 'channel' || sub === 'ch') {
+    const cm = rest.match(/^(set|del|delete|rm|remove|list|ls|show)?\s*([\s\S]*)$/i);
+    const action = (cm && cm[1] ? cm[1].toLowerCase() : 'list');
+    const cargs = cm ? (cm[2] || '').trim() : '';
+    const USAGE = '사용법: `giip channel set <프로젝트명> [채널ID]` | `giip channel list` | `giip channel del [채널ID]`';
+    try {
+      if (action === 'set') {
+        // `set <프로젝트명> [채널ID]` — 채널ID 생략 시 현재 채널.
+        const sm = cargs.match(/^(\S+)(?:\s+(\S+))?$/);
+        if (!sm) return { handled: true, text: USAGE };
+        const project = sm[1];
+        const target = sm[2] || channelId;
+        if (!target) return { handled: true, text: '채널ID를 확인할 수 없습니다. `giip channel set <프로젝트명> <채널ID>` 로 명시하세요.' };
+        const { channelId: cid, project: pj } = config.setChannelProject(target, project);
+        const csn = config.resolveProjectCsn(pj);
+        return {
+          handled: true,
+          text: `✅ 채널 고정 매핑 저장: \`${cid}\` → \`${pj}\`${csn != null ? ` (csn ${csn})` : ' (project-csn.json 미등록 → account 기본 csn)'}\n이제 이 채널의 접두어 없는 메시지는 모두 \`${pj}\` 로 처리됩니다(봇 재시작 불필요). 명시적 프로젝트 접두어는 계속 우선합니다.`,
+        };
+      }
+      if (action === 'del' || action === 'delete' || action === 'rm' || action === 'remove') {
+        const target = cargs.split(/\s+/)[0] || channelId;
+        if (!target) return { handled: true, text: USAGE };
+        const ok = config.deleteChannelProject(target);
+        return { handled: true, text: ok ? `✅ 채널 매핑 삭제: \`${target}\`` : `⚠️ \`${target}\` 매핑이 없습니다.` };
+      }
+      // list / ls / show / (인자 없음)
+      const map = config.listChannelProject();
+      const keys = Object.keys(map);
+      const body = keys.length
+        ? keys.map((k) => {
+            const csn = config.resolveProjectCsn(map[k]);
+            return `• \`${k}\` → \`${map[k]}\`${csn != null ? ` (csn ${csn})` : ''}${k === channelId ? ' ← 현재 채널' : ''}`;
+          }).join('\n')
+        : '(등록된 매핑 없음)';
+      return { handled: true, text: `📌 채널 → 기본 프로젝트 매핑 (channel-project.json)\n${body}\n\n${USAGE}` };
+    } catch (e) {
+      return { handled: true, text: `❌ ${e.message}\n${USAGE}` };
+    }
+  }
+
   const acct = accounts.resolve(channelId);
   if (!acct) {
     return {

--- a/slack-bot/handlers.js
+++ b/slack-bot/handlers.js
@@ -996,7 +996,11 @@ async function processMessage({ channelId, msg, isDM, conversations, threadTs })
     .trim();
 
   // プロジェクトプレフィックス検出: "giipprj 何か" → giipprj フォルダに切り替え
-  const { workDir, cleanText, projectName } = parseProjectPrefix(rawCleanText);
+  //   さらにチャンネル固定マッピング(channel-project.json)を適用: 明示接頭辞が無ければ
+  //   このチャンネルの既定プロジェクトへ workDir/projectName を固定する。
+  //   優先順位: 明示接頭辞(Rule 32) > チャンネル固定。cleanText は不変。
+  const { workDir, cleanText, projectName } =
+    config.applyChannelPin(channelId, parseProjectPrefix(rawCleanText));
 
   const hasFiles = msg.files && msg.files.length > 0;
   if (hasFiles && !cleanText) {


### PR DESCRIPTION
## 요약
Lowyworkenv/slack-bot 의 giip-724(채널 대화 → 프로젝트 고정 라우팅) 기능을 이 템플릿 봇에 포팅합니다. "이 채널의 접두어 없는 메시지는 모두 <프로젝트>로 처리"를 채널 단위로 설정할 수 있게 합니다.

## 동작
- `config.applyChannelPin(channelId, parseProjectPrefix(text))` — 명시적 프로젝트 접두어(Rule 32)가 있으면 그대로 우선, 없을 때만 채널 고정 프로젝트로 workDir/projectName 을 채움. `cleanText` 불변.
- csn 은 `project-csn.json[<프로젝트>]` 로 라우팅 → **전역 default csn 은 건드리지 않음(채널 단위 격리)**.
- Slack 커맨드: `giip channel set <프로젝트명> [채널ID]` / `giip channel list` / `giip channel del [채널ID]` (account 게이트보다 먼저 처리, 봇 재시작 불필요).

## 변경 파일
- `slack-bot/config.js` — channel-project.json 로드/해석/CRUD + `applyChannelPin` + exports
- `slack-bot/giip-commands.js` — `giip channel …` 커맨드 블록
- `slack-bot/handlers.js` — `processMessage` 에서 `applyChannelPin` 적용
- `slack-bot/channel-project.json` — 템플릿(빈 map; 배포처에서 `giip channel set` 으로 채움)

## 검증
- `node -e require` / `node --check` 문법 통과(3파일)
- 로직 스모크: 명시 접두어 우선 ✅ / 채널 핀 채움 ✅ / 미등록 채널 불변 ✅

## 주의
- csn 라우팅이 실제로 먹으려면 봇 유저가 그 csn 의 멤버여야 함(tUserPerCorp). 미가입이면 홈 csn 으로 클램프됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)