### PR TITLE
fix(slack-bot): reconcile 보완 — orphan pending 스윕 + 주기 reconcile

### DIFF
--- a/slack-bot/index.js
+++ b/slack-bot/index.js
@@ -48,29 +48,53 @@ function killDuplicateBots() {
   });
 }
 
-// ── 起動時 stale タスク状態のクリーンアップ ──────────────────────────────────
-// ボットが再起動した際、running 状態のまま残っているタスクを reconcile する
-// - done/ または cancel/ フォルダにファイルがあれば → running から除去
-// - tasks/ にもファイルがなければ → 行方不明として running から除去
-function reconcileTaskState() {
+// ── stale タスク状態のクリーンアップ（起動時 + 定期実行） ─────────────────────
+// ボットが再起動した際・稼働中定期的に、残存タスク状態を reconcile する。
+// - running: done/·cancel/ にファイルあれば除去(完了/取消)。tasks/ にも無い＝行方不明は
+//   起動時(staleMinutes=0)は即除去、定期実行は staleMinutes 経過分のみ(生存実行を保護)。
+// - pending(신규): done/·cancel/ で既に해소된 orphan pending を掃除。
+//   (従来 reconcile は running のみ触り pending が無限累積した — Lowyworkenv 라이브본과 동일 보완.)
+//   ※ tasks/ 直下に残る＝未着手 backlog は触らない(手動処理待ちを尊重)。
+function reconcileTaskState({ staleMinutes = 0 } = {}) {
   const taskState = loadJSON(TASK_STATE_FILE, { pending: {}, running: {} });
-  const runningEntries = Object.entries(taskState.running || {});
-  if (!runningEntries.length) return;
-
   const TASKS_DIR = path.join(AGENT_DIR, 'tasks');
+  const nowMs = Date.now();
   let changed = false;
 
-  for (const [key, entry] of runningEntries) {
+  // ── pending 스윕 ──
+  const isResolved = (tid) =>
+    fs.existsSync(path.join(TASKS_DIR, 'done', `${tid}.md`)) ||
+    fs.existsSync(path.join(TASKS_DIR, 'cancel', `${tid}.md`));
+  for (const [key, entry] of Object.entries(taskState.pending || {})) {
+    if (entry && entry.taskId && isResolved(entry.taskId)) {
+      delete taskState.pending[key];
+      changed = true;
+      console.log(`[Bot] reconcile: stale pending ${entry.taskId} 제거 (done/cancel 로 이미 해소)`);
+    }
+  }
+
+  // ── running reconcile ──
+  for (const [key, entry] of Object.entries(taskState.running || {})) {
     const taskId = entry.taskId;
     const inDone   = fs.existsSync(path.join(TASKS_DIR, 'done',   `${taskId}.md`));
     const inCancel = fs.existsSync(path.join(TASKS_DIR, 'cancel', `${taskId}.md`));
     const inPending = fs.existsSync(path.join(TASKS_DIR, `${taskId}.md`));
 
-    if (inDone || inCancel || !inPending) {
-      const reason = inDone ? 'done' : inCancel ? 'cancelled' : 'missing';
+    if (inDone || inCancel) {
+      const reason = inDone ? 'done' : 'cancelled';
       console.log(`[Bot] reconcile: task ${taskId} (${reason}) — removing from running`);
       delete taskState.running[key];
       tm.updateTasklistEntry(taskId, { status: inDone ? 'completed' : 'cancelled' });
+      changed = true;
+    } else if (!inPending) {
+      // tasks/·done/·cancel/ 어디에도 없음 = 행방불명. 재시작 직후엔 서브프로세스가 죽어
+      // 즉시 정리, 정기 실행 땐 staleMinutes 경과분만(생존 실행 보호).
+      const started = entry.startedAt ? Date.parse(entry.startedAt) : NaN;
+      const ageMin = isNaN(started) ? Infinity : (nowMs - started) / 60000;
+      if (ageMin < staleMinutes) continue;
+      console.log(`[Bot] reconcile: task ${taskId} (missing) — removing from running`);
+      delete taskState.running[key];
+      tm.updateTasklistEntry(taskId, { status: 'cancelled' });
       changed = true;
     }
   }
@@ -95,7 +119,19 @@ async function main() {
   console.log(`[Bot] 監視チャンネル: ${CHANNEL_IDS.join(', ') || '(DM のみ)'}`);
 
   killDuplicateBots();
-  reconcileTaskState();
+  // 起動時: 再起動で孤児化した running を即 reconcile + orphan pending 스윕
+  reconcileTaskState({ staleMinutes: 0 });
+
+  // 定期 reconcile: 30分以上 running 滞留(異常終了 등)を最終化 + pending 누적 정리。
+  const RECONCILE_INTERVAL_MS = 10 * 60 * 1000; // 10分ごと
+  const RECONCILE_STALE_MIN = 30;               // 30分以上経過した missing running が対象
+  setInterval(() => {
+    try {
+      reconcileTaskState({ staleMinutes: RECONCILE_STALE_MIN });
+    } catch (e) {
+      console.error('[Bot] periodic reconcile error:', e.message);
+    }
+  }, RECONCILE_INTERVAL_MS);
 
   const conversations = loadJSON(HISTORY_FILE, {});
 


### PR DESCRIPTION
## 배경
Lowyworkenv 라이브본의 task 큐 동결 진단(PR LowyShin/Lowyworkenv#407)에서 드러난 것과 **동일 부류**의 취약이 이 템플릿에도 존재.

기존 `reconcileTaskState()` 는 **`running` 만** 청소하고 기동 시 1회만 실행:
- **(1) orphan pending 무한 누적** — done/cancel 로 이미 해소된 pending 항목을 정리하지 않음.
- **(2) 이상 종료 running 미회수** — 주기 reconcile 이 없어 기동 후 남은 stale running 이 방치.

## 변경 (`slack-bot/index.js`)
- **pending 스윕**: `done/`·`cancel/` 로 해소된 orphan pending 제거. 미착수 backlog(파일이 `tasks/` 직하)는 불가침.
- **`staleMinutes` 파라미터 + 10분 주기 reconcile**: missing running 은 기동 직후(staleMinutes=0) 즉시, 정기 실행은 30분 경과분만 정리(생존 실행 보호).

## 범위 주석
fde-agent 는 큐/직렬 드레인(`queuedBehind`/`drainNextQueued`) 메커니즘이 **없어** ghost-occupier freeze(점유태스크 재시작 시 대기태스크 영구동결)는 애초에 발생하지 않음 → 라이브본의 `recoverQueuedOnStartup` 은 **해당 없음(미포팅)**.

## 검증
`node --check slack-bot/index.js` 통과. 기동 시(staleMinutes=0) 동작은 종전과 동등, 추가로 pending 스윕·주기 reconcile 만 신설.

🤖 Generated with [Claude Code](https://claude.com/claude-code)