### PR TITLE
feat(slack-bot): MiniMax/OpenClaw 버전별 slack-bot 변형 추가

### DIFF
--- a/slack-bot-minimax/.env.example
+++ b/slack-bot-minimax/.env.example
@@ -1,0 +1,25 @@
+# Slack Bot Token
+# api.slack.com/apps → OAuth & Permissions → Bot User OAuth Token
+SLACK_BOT_TOKEN=xoxb-your-bot-token-here
+
+# App-Level Token (Socket Mode 必須)
+# api.slack.com/apps → Socket Mode → App-Level Tokens → Generate（Scope: connections:write）
+SLACK_APP_TOKEN=xapp-your-app-token-here
+
+# GitHub Issues (30분 캐시)
+# GitHub → Settings → Developer settings → Personal access tokens → repo 권한
+GITHUB_TOKEN=ghp_your-token-here
+GITHUB_REPO=LowyShin/smartorder-works
+
+# 모니터할 채널 ID (쉼표 구분, 없으면 DM만)
+# 채널 ID 확인: 채널 우클릭 → View channel details → 하단 Channel ID
+SLACK_CHANNEL_IDS=C0XXXXXXXXX,C0YYYYYYYYY
+
+# 폴링 간격 (기본 60초)
+POLL_INTERVAL_MS=60000
+
+# MiniMax Token Plan Subscription Key (sk-cp-...) — 선택사항.
+# Claude 전 계정(claude-accounts.json) 사용량 한도 소진 시 최종 폴백 실행 엔진으로 사용.
+# 발급: platform.minimax.io → Console → Account/Token Plan (일반 API Key 아닌 Subscription Key, sk-cp- 접두 필수)
+# MINIMAX_API_KEY=sk-cp-your-subscription-key-here
+# MINIMAX_MODEL=MiniMax-M2.7

--- a/slack-bot-minimax/README.md
+++ b/slack-bot-minimax/README.md
@@ -1,0 +1,259 @@
+# Slack Bot — MiniMax 우선 버전
+
+> `lowyworkenv/slack-bot`(2026-07-27 시점)을 그대로 복사한 변형본. MiniMax Token Plan(Anthropic
+> Messages 호환 엔드포인트)을 1순위 실행 엔진으로 쓰고, 한도 소진 시에만 Claude 계정 풀로 폴백한다
+> (`minimax-accounts.js` + `task-manager.js`/`claude-cli.js`의 폴백 로직 참조).
+> `slack-bot`(기본, Claude 전용) 폴더와 나란히 두는 독립 배포본이다.
+
+Claude CLI(또는 MiniMax Anthropic 호환 엔드포인트)를 호출해 태스크 분석·실행·Q&A를 채널에서 조작할 수 있다.
+
+---
+
+# SmartOrder Slack Bot (원본 설명)
+
+Vegetrade SmartOrder プロジェクト用 Slack Bot。  
+Claude CLI を呼び出してタスク分析・実行・Q&A をチャンネルから操作できる。
+
+## 機能概要
+
+| 機能 | 説明 |
+|---|---|
+| タスク管理 | `@bot 作業依頼` → 分析 → `go <ID>` で専用ブランチ作成→サブエージェント実行→PR 自動生成 |
+| 質問応答 | `@bot 質問` → K-Layer + GitHub Issues を参照して即答 |
+| DM 会話 | 会話履歴付き Q&A、`!issues` / `!klayer` コマンド |
+| git 操作 | `@bot git push/pull` → 実行して結果を返信 |
+| 全リポジトリ状況 | push 漏れ自動チェック・報告 |
+
+---
+
+## 前提条件
+
+- Node.js 18 以上
+- [Claude Code CLI](https://claude.ai/code) インストール済み・PATH 登録済み  
+  （`claude --version` が通ること）
+- Slack App 作成済み（Socket Mode 有効、Bot Token + App-Level Token 取得済み）  
+  → **[Slack App セットアップ手順](SLACK_APP_SETUP.md)** を参照（初回のみ）
+
+---
+
+## セットアップ
+
+### 1. 依存パッケージインストール
+
+```bash
+cd slack-bot
+npm install
+```
+
+### 2. 環境変数設定
+
+```bash
+cp .env.example .env
+```
+
+`.env` を編集:
+
+```env
+SLACK_BOT_TOKEN=xoxb-...        # Bot User OAuth Token
+SLACK_APP_TOKEN=xapp-...        # App-Level Token (Socket Mode 用)
+GITHUB_TOKEN=ghp_...            # GitHub PAT (repo 権限)
+GITHUB_REPO=LowyShin/smartorder-works
+SLACK_CHANNEL_IDS=C0XXXXXXXXX  # 監視チャンネル ID (カンマ区切り)
+```
+
+> **チャンネル ID の確認方法**: Slack でチャンネルを右クリック → View channel details → 最下部に表示
+
+### 3. Claude 구독 계정 라우팅（任意 / 複数アカウント時）
+
+봇이 spawn하는 모든 `claude` 호출을 여러 **구독 계정**에 플랜 가중치대로 고르게 분산한다(Smooth Weighted Round-Robin). 사용량 한도에 걸린 계정은 자동으로 잠시 제외(쿨다운)되고, 회복되면 다시 투입된다.
+
+- **설정 파일 없으면**: 현재 로그인된 계정 1개로 그대로 동작(추가 설정 불필요).
+- **계정을 늘리려면**: 계정별로 별도 `CLAUDE_CONFIG_DIR`에 로그인해 두고, `claude-accounts.json`에 항목을 추가한다. 코드 변경·봇 재시작 불필요(파일 변경 시 자동 반영).
+
+```bash
+# 계정별 1회 로그인 (예: 계정 B)
+CLAUDE_CONFIG_DIR="C:/claude-accounts/B" claude auth login --email <계정B이메일>
+```
+
+```jsonc
+// slack-bot/claude-accounts.json  (git-ignored, claude-accounts.example.json 참고)
+[
+  { "name": "main",  "dir": "C:/claude-accounts/main", "weight": 1,  "email": "..." },
+  { "name": "maxB",  "dir": "C:/claude-accounts/B",    "weight": 20, "email": "..." }
+]
+// weight: 플랜 비중 상대값 (Pro=1, Max5x=5, Max20x=20 식). 비율대로 요청 분산.
+// dir   : 그 계정으로 로그인해 둔 CLAUDE_CONFIG_DIR 경로.
+```
+
+> **주의**: 순수 throughput 증량 목적의 구독 다중화는 Anthropic 소비자 약관 리스크가 있음. 파일에 계정 경로가 들어가므로 `claude-accounts.json`은 git 관리 대상이 아님(`.gitignore` 등록).
+
+---
+
+## 起動方法
+
+### 通常起動（開発・テスト用）
+
+```bash
+cd slack-bot
+node index.js
+# または
+npm start
+```
+
+### pm2 で管理（推奨）
+
+```bash
+# 初回登録
+pm2 start index.js --name slack-bot --cwd C:\Users\lowyshin\Downloads\projects\smartorder-works\slack-bot
+
+# プロセス保存（リカバリ用）
+pm2 save
+
+# 状態確認
+pm2 list
+
+# ログ確認
+pm2 logs slack-bot
+
+# 再起動
+pm2 restart slack-bot
+
+# 停止
+pm2 stop slack-bot
+```
+
+> **現在の pm2 パス**: `C:\Users\lowyshin\AppData\Roaming\npm\pm2.cmd`  
+> PATH に通っていない場合は `npm install -g pm2` でグローバルインストール済み
+
+### PC 再起動後の自動起動（設定済み）
+
+Windows Task Scheduler に `PM2-SlackBot-Resurrect` タスクが登録済み。  
+`lowyshin` でログオン時に自動的に `pm2 resurrect` が実行される。
+
+手動で再登録する場合（管理者 PowerShell で実行）:
+
+```powershell
+schtasks /Create /TN "PM2-SlackBot-Resurrect" ^
+  /TR "cmd /c C:\Users\lowyshin\AppData\Roaming\npm\pm2.cmd resurrect" ^
+  /SC ONLOGON /RU "lowyshin" /RL HIGHEST /F
+```
+
+---
+
+## コマンド一覧
+
+### チャンネル（@bot メンション）
+
+| コマンド | 動作 |
+|---|---|
+| `@bot <作業依頼>` | Task 分析 → 確認 → `go <ID>` で実行 |
+| `@bot <質問>` | K-Layer + Issues 参照して即答 |
+| `<プロジェクト名> issue 등록 <内容>` | 内容をそのまま giip issue に登録。プロジェクトが `project-csn.json` に登録済みならその **CSN** で登録（例: `caci-mimity issue 등록 …` → CSN 70422）。未登録なら account 既定 CSN |
+| `giip project set <프로젝트명> <csn>` | プロジェクト名 → CSN マッピングを追加/更新（`project-csn.json` に反映・**再起動不要**） |
+| `giip project list` | 登録済みのプロジェクト → CSN マッピング一覧 |
+| `giip project del <프로젝트명>` | マッピングを削除 |
+| `giip channel set <프로젝트명> [채널ID]` | このチャンネルの既定プロジェクトを固定（`channel-project.json`・**再起動不要**）。接頭辞なしメッセージは全てこのプロジェクトで処理。채널ID 省略時は現在チャンネル |
+| `giip channel list` | 채널 → 既定プロジェクト固定マッピング一覧 |
+| `giip channel del [채널ID]` | 채널固定マッピングを削除 |
+| `go <Task番号>` | 指定 Task を実行 |
+| `go <Task番号>` + 改行後にコメント | 指定 Task を実行。**改行以降のテキストは「追加指示」として Task の .md に追記**してから実行する（コメントは任意 — あってもなくても可） |
+| `go` | 待機中 Task 一覧を表示 |
+| `cancel <Task番号>` | 指定 Task をキャンセル |
+| `tasklist` | 待機中 Task 一覧 |
+| `tasklist all` | 全 Task 一覧（完了・キャンセル含む） |
+| `<14桁数字>` | Task ステータス確認 |
+| `@bot git push` | smartorder-works を git push |
+| `@bot git pull` | smartorder-works を git pull |
+| `!issues` | GitHub Issue 一覧 |
+| `!issues refresh` | Issue 強制更新 |
+| `!klayer <キーワード>` | K-Layer 知識検索 |
+| `!help` | ヘルプ表示 |
+
+> **rule — プロジェクト別 CSN ルーティング**: `<プロジェクト名> issue 등록 <内容>` の CSN 対応は `slack-bot/project-csn.json` の `map` で管理する（コード変更不要）。編集は Slack から `giip project set <프로젝트명> <csn>` / `giip project list` / `giip project del <프로젝트명>` で行える（`config.js` の `setProjectCsn`/`listProjectCsn`/`deleteProjectCsn` が `map` だけ更新し `_comment` を保存、読み込みは毎回読み直すので**再起動不要**）。プロジェクト名が `PROJECTS_ROOT` 直下の同名フォルダなら作業フォルダ切替も兼ね、フォルダが無くても map にあれば名前だけで CSN ルーティングされる（その場合 workDir は lowyworkenv に安全フォールバック）。解決は `config.resolveProjectCsn(projectName || workDir)`。map に無ければ account 既定 CSN にフォールバック。
+>
+> **rule — チャンネル固定プロジェクトルーティング (task giip-724)**: 「このチャンネルの発話はすべて `<project>` として処理」を `slack-bot/channel-project.json` の `map`（`channelId → プロジェクト名`）で管理する。編集は Slack から `giip channel set <프로젝트명> [채널ID]` / `giip channel list` / `giip channel del [채널ID]`（`config.js` の `setChannelProject`/`listChannelProject`/`deleteChannelProject`、読み込みは毎回読み直すので**再起動不要**）。適用は `processMessage` で `config.applyChannelPin(channelId, parseProjectPrefix(text))`。**優先順位（設計判断）**: メッセージ先頭に実フォルダ / `project-csn.json` 登録名の**明示的プロジェクト接頭辞があればそれが勝つ**（Rule 32 の絶対規則を維持）。接頭辞が無いときだけチャンネルの既定プロジェクトが適用され、本来 `lowyworkenv` に潰れていた workDir/projectName（→ CSN）をそのプロジェクトで埋める。既定値: `C0B5TV2T43S → ecokaku-aidc`（CSN 70417）。⚠️ CSN ルーティングが実際に効くには bot ユーザ(uSn 29)がその CSN のメンバである必要がある（`giip project set` が自動付与）。
+>
+> **rule — `go <番号>` の追加指示 (D-2026-07-15)**: `go <Task番号>` の後ろ（同一メッセージ・改行以降でも可）に続けたテキストは、その Task 専用の「追加指示」として扱う。実行直前に Task の `.agent/tasks/<ID>.md` へ `## 추가 지시 (Slack, …)` ブロックとして追記され、サブエージェントが必ず読む。**コメントは任意** — 付ければ反映し `📎 追加指示 … 反映しました` と返信、無ければ従来どおり素の `go` として実行する。判定正規式は末尾 `$` を張らず `\b` 止まり（`handlers.js` の `goWithId`）。旧仕様（`$` 固定）ではコメントを付けると bare `go` に落ちて Task 一覧が出るバグがあった（PR #306 で修正）。
+
+### DM
+
+| コマンド | 動作 |
+|---|---|
+| `<質問>` | 会話履歴付き Q&A |
+| `<14桁数字>` | Task ステータス確認 |
+| `!issues` | GitHub Issue 一覧 |
+| `!klayer <キーワード>` | K-Layer 知識検索 |
+| `!reset` | 会話履歴リセット |
+| `!help` | ヘルプ表示 |
+
+---
+
+## Task ワークフロー
+
+```
+1. @bot で作業依頼
+       ↓
+2. Claude が Task ファイル (.agent/tasks/{ID}.md) を分析・作成
+       ↓
+3. Slack に Task 内容と「go <ID>」を提示
+       ↓
+4. ユーザーが「go <ID>」を送信
+       ↓
+5. claude -p サブエージェントが作業実行
+       ↓
+6. 完了 → 専用ブランチ `bot/task-<ID>`(最新 origin/base 起点)へ commit・push
+       → base(master/main) へ PR 自動生成 → PR URL を Slack に報告
+```
+
+> **ブランチ/PR 方針** (D-2026-07-09): `go <ID>` は每回 `git fetch origin <base>` 直後に
+> `origin/<base>` を起点とした専用ブランチ `bot/task-<ID>` を作って作業する。作業ツリーは共有のため
+> 1 タスクずつ直列実行され、完了後は元のブランチに復元される。サブエージェントは git を触らず、
+> commit・push・PR は Bot(`task-manager.js`)が確定的に行う。常に最新 base 起点なので
+> 「ブランチ作成時 merge conflict」は起きない。
+
+---
+
+## ファイル構成
+
+```
+slack-bot/
+├── index.js              # メインエントリポイント
+├── task-manager.js       # Task 作成・実行管理
+├── claude-accounts.js    # 구독 계정 Weighted Round-Robin 라우터
+├── claude-accounts.json  # 계정 라우팅 설정（git 管理外・任意）
+├── claude-accounts.example.json # 계정 라우팅 설定テンプレート
+├── k-layer.js            # K-Layer 知識検索
+├── github-issues.js      # GitHub Issues キャッシュ
+├── .env                  # 環境変数（git 管理外）
+├── .env.example          # 環境変数テンプレート
+├── .conversations.json   # DM 会話履歴（自動生成）
+├── .task-state.json      # Task 実行状態（自動生成）
+├── .bot-threads.json     # Bot 関与スレッド記録（自動生成）
+├── register-startup.ps1  # Task Scheduler 登録スクリプト（管理者権限要）
+└── package.json
+```
+
+---
+
+## トラブルシューティング
+
+**Bot が起動しない**
+```bash
+pm2 logs slack-bot --lines 50
+```
+よくある原因: `.env` の `SLACK_BOT_TOKEN` / `SLACK_APP_TOKEN` が未設定、`claude` CLI が PATH にない
+
+**PC 再起動後に Bot が起動しない**
+```powershell
+# Task Scheduler 確認
+schtasks /Query /TN "PM2-SlackBot-Resurrect" /FO LIST
+
+# 手動で resurrect
+C:\Users\lowyshin\AppData\Roaming\npm\pm2.cmd resurrect
+```
+
+**重複起動**  
+`index.js` 起動時に自動で同一プロセスを検出・終了する。手動で止める場合:
+```bash
+pm2 stop slack-bot
+```

--- a/slack-bot-minimax/SLACK_APP_SETUP.md
+++ b/slack-bot-minimax/SLACK_APP_SETUP.md
@@ -1,0 +1,127 @@
+# Slack App セットアップガイド — SmartOrder Slack Bot
+
+このボットは **Socket Mode** で動作します。
+Polling 方式の `codex-bot` とは別の Slack App を用意してください。
+
+---
+
+## 1. Slack App を作成する
+
+1. [https://api.slack.com/apps](https://api.slack.com/apps) を開く
+2. **Create New App** → **From scratch** を選択
+3. App Name（例: `SmartOrder Bot`）と対象 Workspace を入力して **Create App**
+
+---
+
+## 2. Bot Token Scopes を追加する
+
+**OAuth & Permissions** → **Scopes** → **Bot Token Scopes** に以下を追加:
+
+| Scope | 用途 |
+|---|---|
+| `chat:write` | メッセージ送信 |
+| `app_mentions:read` | `@ボット名` メンション受信 |
+| `channels:history` | パブリックチャンネルのメッセージ読み取り |
+| `channels:read` | チャンネル情報取得 |
+| `groups:history` | プライベートチャンネルのメッセージ読み取り |
+| `groups:read` | プライベートチャンネル情報取得 |
+| `im:history` | DM メッセージ読み取り |
+| `im:read` | DM 情報取得 |
+| `im:write` | DM 送信 |
+| `users:read` | ユーザー表示名の取得（スレッド要約で「誰が何を言ったか」を実名表示） |
+
+> **`users:read` について**: このスコープが無くてもスレッド本文の読み取り・要約は正常に動作する。
+> 無い場合はスレッド要約の話者名が Slack ユーザー ID（例: `UM8P5UALQ`）で表示され、
+> 追加すると実名（表示名）で表示される。`conversations.replies` でスレッド全体を取得後、
+> `users.info` で各発言者名を解決するために使う。
+
+> **スコープを追加・変更した後は必ず Reinstall が必要** (後述 §5 参照)
+
+---
+
+## 3. Socket Mode を有効にする
+
+1. 左メニュー **Socket Mode** → **Enable Socket Mode** をオン
+2. **App-Level Token** を生成する画面が開く:
+   - Token Name: 任意（例: `socket-mode-token`）
+   - Scope: `connections:write` にチェック
+   - **Generate** ボタン → `xapp-` で始まるトークンが表示される → コピーして保存
+
+---
+
+## 4. Event Subscriptions を有効にする
+
+**Event Subscriptions** → **Enable Events** をオン
+
+**Subscribe to bot events** に以下を追加:
+
+| Event | 用途 |
+|---|---|
+| `app_mention` | チャンネルでの @メンション受信 |
+| `message.im` | DM メッセージ受信 |
+| `message.channels` | パブリックチャンネルのスレッド返信受信 |
+| `message.groups` | プライベートチャンネルのスレッド返信受信 |
+
+> Socket Mode では Request URL 不要。URL 欄は空のままで OK。
+
+---
+
+## 5. Workspace にインストールする
+
+**OAuth & Permissions** → **Install to Workspace** → **Allow**
+
+インストール後に **Bot User OAuth Token**（`xoxb-` から始まる）が表示される → コピー
+
+---
+
+## 6. チャンネルにボットを招待する
+
+監視したいチャンネルで:
+```
+/invite @SmartOrder Bot
+```
+
+チャンネル ID の確認方法:
+- Slack でチャンネルを右クリック → **View channel details** → 最下部に `C0XXXXXXXXX` 形式で表示
+
+---
+
+## 7. .env に設定する
+
+```bash
+cp slack-bot/.env.example slack-bot/.env
+```
+
+```env
+SLACK_BOT_TOKEN=xoxb-...          # §5 で取得した Bot User OAuth Token
+SLACK_APP_TOKEN=xapp-...          # §3 で取得した App-Level Token
+GITHUB_TOKEN=ghp_...              # GitHub PAT（repo 権限）
+GITHUB_REPO=LowyShin/smartorder-works
+SLACK_CHANNEL_IDS=C0XXXXXXXXX,C0YYYYYYYYY  # §6 で確認したチャンネル ID（カンマ区切り）
+POLL_INTERVAL_MS=60000
+```
+
+設定後:
+```bash
+cd slack-bot
+pm2 restart slack-bot
+pm2 logs slack-bot  # "[Bot] Socket Mode 接続完了" が出れば OK
+```
+
+---
+
+## トラブルシューティング
+
+**`missing_scope` エラー**  
+→ §2 のスコープ追加 → §5 の Reinstall を必ず実施
+
+**`invalid_auth` / `token_revoked`**  
+→ トークンを再取得。Bot Token と App-Level Token を混同していないか確認
+
+**DM が届かない**  
+→ `im:history` と `im:read` スコープを追加して Reinstall  
+→ Event Subscriptions に `message.im` が含まれているか確認
+
+**チャンネルメンションに反応しない**  
+→ ボットをチャンネルに招待済みか確認（`/invite @ボット名`）  
+→ `SLACK_CHANNEL_IDS` にそのチャンネル ID が含まれているか確認

--- a/slack-bot-minimax/channel-project.json
+++ b/slack-bot-minimax/channel-project.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "Slack 채널ID → 기본 프로젝트명(소문자) 고정 매핑. 이 채널에서 오는 모든 메시지를 해당 프로젝트로 처리한다(작업 폴더 = PROJECTS_ROOT/<프로젝트명>, csn = project-csn.json[<프로젝트명>]). Rule 32(project prefix routing) 와의 우선순위: 메시지 선두에 실폴더 또는 project-csn.json 에 등록된 프로젝트 접두어가 명시되면 그 접두어가 이긴다(명시적 override, Rule 32 절대 규칙 유지). 접두어가 없을 때만 이 채널 고정 매핑이 기본값으로 적용된다(그렇지 않으면 lowyworkenv 로 폴백했을 자리를 채운다). 비밀 아님(채널ID·프로젝트명뿐) → git 추적. Slack `giip channel set <프로젝트명> [채널ID]` / `giip channel list` / `giip channel del [채널ID]` 로 편집(재시작 불필요). 해석: config.resolveChannelProject(channelId)/applyChannelPin(channelId, parsed). ⚠️ csn 라우팅이 실제로 먹으려면 봇 유저(uSn 29)가 그 csn 의 멤버여야 한다(tUserPerCorp) — 미가입이면 pApiGiipIssuePutbyAK 게이트가 홈 csn(47)으로 클램프한다. 멤버십은 `giip project set <프로젝트명> <csn>` 이 자동 부여한다.",
+  "map": {
+    "C0B71CYBZ0C": "ecokaku-aidc",
+    "C0BK27TSYVD": "ssm"
+  }
+}

--- a/slack-bot-minimax/check_stock_db.js
+++ b/slack-bot-minimax/check_stock_db.js
@@ -1,0 +1,35 @@
+const { Client } = require('pg');
+const c = new Client({
+  host: 'pg-vgt-restore-20260601.postgres.database.azure.com',
+  port: 5432, database: 'stock', user: 'vgtadmin',
+  password: 'VgYLW.-Mc53_c.MCyk8GEd7nPS9_',
+  ssl: { rejectUnauthorized: false }
+});
+
+c.connect().then(async () => {
+  // 1. user/auth 関連テーブル一覧
+  const t = await c.query(
+    "SELECT table_name FROM information_schema.tables WHERE table_schema='public' AND (table_name LIKE '%user%' OR table_name LIKE '%auth%') ORDER BY table_name"
+  );
+  console.log('User関連テーブル:', t.rows.map(r => r.table_name).join(', ') || '(なし)');
+
+  // 2. Django migrations 件数
+  try {
+    const m = await c.query('SELECT COUNT(*) as cnt FROM public.django_migrations');
+    console.log('マイグレーション件数:', m.rows[0].cnt);
+  } catch(e) { console.log('migrations テーブルなし:', e.message); }
+
+  // 3. demo@vegetrade.jp の存在確認
+  try {
+    const u = await c.query("SELECT id, email, is_active FROM public.main_system_customuser WHERE email='demo@vegetrade.jp'");
+    console.log('ローカルユーザー:', u.rows.length ? JSON.stringify(u.rows[0]) : '存在しない');
+  } catch(e) { console.log('ユーザーテーブルエラー:', e.message); }
+
+  // 4. VT_AUTH_APIが何に設定されているかを確認するため、auth_user も確認
+  try {
+    const a = await c.query("SELECT COUNT(*) as cnt FROM public.auth_user");
+    console.log('auth_user件数:', a.rows[0].cnt);
+  } catch(e) { console.log('auth_user なし'); }
+
+  await c.end();
+}).catch(e => console.error('DB接続エラー:', e.message));

--- a/slack-bot-minimax/claude-accounts.example.json
+++ b/slack-bot-minimax/claude-accounts.example.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "main",
+    "dir": "C:/claude-accounts/main",
+    "weight": 1,
+    "email": "yusuke.shikatani@bloomin.world"
+  }
+]

--- a/slack-bot-minimax/claude-accounts.js
+++ b/slack-bot-minimax/claude-accounts.js
@@ -1,0 +1,140 @@
+/**
+ * claude-accounts.js — 구독 계정 Weighted Round-Robin 라우터
+ *
+ * slack-bot이 spawn하는 모든 `claude` 호출의 계정(CLAUDE_CONFIG_DIR)을
+ * 플랜 가중치(weight) 비율대로 고르게 분산(Smooth WRR, nginx 방식)하고,
+ * 사용량 한도(usage limit)에 걸린 계정은 쿨다운으로 잠시 제외한다.
+ *
+ * 설정: slack-bot/claude-accounts.json (git-ignored, 머신 로컬)
+ *   [{ "name": "main", "dir": "C:/claude-accounts/main", "weight": 1, "email": "..." }, ...]
+ *   - dir  : 그 계정으로 `claude auth login` 해 둔 CLAUDE_CONFIG_DIR 경로
+ *   - weight: 플랜 비중 (Pro=1, Max5x=5, Max20x=20 식으로 상대값, 기본 1)
+ *   - email: (선택) 재인증 시 --email 로 전달
+ *
+ * 파일이 없거나 비어 있으면 → 기본 로그인(현재 계정) 1개로 동작(dir:null, CLAUDE_CONFIG_DIR 미설정).
+ * 계정 추가는 이 JSON에 항목만 넣으면 되고 코드 변경은 불필요하다.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const CONFIG_FILE = path.join(__dirname, 'claude-accounts.json');
+const DEFAULT_COOLDOWN_MS = 5 * 60 * 60 * 1000; // 5h — 구독 롤링 한도 리셋 근사치
+
+let accounts = null; // [{ name, dir, weight, email, current, cooldownUntil }]
+let cachedMtimeMs = -1;
+
+// JSON을 읽어 계정 목록을 만든다. mtime 기반 핫리로드 — 봇 재시작 없이 계정 추가 반영.
+function loadAccounts() {
+  let mtimeMs = 0;
+  let raw = [];
+  try {
+    mtimeMs = fs.statSync(CONFIG_FILE).mtimeMs;
+    if (accounts && mtimeMs === cachedMtimeMs) return accounts; // 변경 없음 → 캐시
+    raw = JSON.parse(fs.readFileSync(CONFIG_FILE, 'utf8'));
+  } catch {
+    // 파일 없음/파싱 실패 → 기본 계정 1개로 폴백. 최초 1회만 구성.
+    if (accounts && cachedMtimeMs === 0) return accounts;
+    mtimeMs = 0;
+    raw = [];
+  }
+
+  const list = (Array.isArray(raw) ? raw : [])
+    .filter(a => a && a.dir)
+    .map(a => ({
+      name: String(a.name || path.basename(String(a.dir))),
+      dir: String(a.dir),
+      weight: Math.max(1, Number(a.weight) || 1),
+      email: a.email ? String(a.email) : null,
+    }));
+
+  if (list.length === 0) {
+    // 기본 계정 — CLAUDE_CONFIG_DIR 미설정(현재 로그인 그대로 사용)
+    list.push({ name: 'default', dir: null, weight: 1, email: null });
+  }
+
+  // 이전 SWRR 상태(current)/쿨다운을 이름 기준으로 보존 (핫리로드 시 분산 연속성 유지)
+  const prev = new Map((accounts || []).map(a => [a.name, a]));
+  accounts = list.map(a => ({
+    ...a,
+    current: prev.get(a.name)?.current || 0,
+    cooldownUntil: prev.get(a.name)?.cooldownUntil || 0,
+  }));
+  cachedMtimeMs = mtimeMs;
+  return accounts;
+}
+
+function count() {
+  return loadAccounts().length;
+}
+
+// Smooth Weighted Round Robin (nginx 방식) + 쿨다운 제외.
+// weight 비율대로 고르게 섞어 반환. 전부 쿨다운이면 null.
+function pickAccount() {
+  const all = loadAccounts();
+  const now = Date.now();
+  const pool = all.filter(a => !a.cooldownUntil || a.cooldownUntil < now);
+  if (pool.length === 0) return null;
+
+  const total = pool.reduce((s, a) => s + a.weight, 0);
+  let best = null;
+  for (const a of pool) {
+    a.current += a.weight;
+    if (!best || a.current > best.current) best = a;
+  }
+  best.current -= total;
+  return best;
+}
+
+// 계정에 맞는 spawn env. dir이 없으면(기본 계정) 현재 env 그대로.
+function envFor(account) {
+  if (!account || !account.dir) return process.env;
+  return { ...process.env, CLAUDE_CONFIG_DIR: account.dir };
+}
+
+// "usage limit"/"rate limit" 같은 옛 문구뿐 아니라 실제 CLI가 내는
+// "You've hit your weekly limit · resets Jul 28, 6am (Asia/Tokyo)" 류(= "...limit"와
+// "reset(s)"가 근처에 같이 나오는 문구)도 잡는다. giip-759: 이 문구가 안 잡혀 계정
+// 로테이션이 전혀 발동하지 않고 task가 그냥 실패로 끝났다.
+const USAGE_LIMIT_RE = /usage limit|rate limit|weekly limit|session limit|too many requests|\b429\b|quota exceeded|\blimit\b[\s\S]{0,40}\breset/i;
+function isUsageLimit(text) {
+  return USAGE_LIMIT_RE.test(text || '');
+}
+
+// 메시지 중 "resets <Mon> <D>, <H>(am|pm)" 형태에서 리셋 시각을 추정해 쿨다운 ms를 구한다.
+// 파싱 실패 시: "weekly" 한도면 옛 5h 쿨다운으로는 매번 헛 재시도만 반복하므로 24h로,
+// 그 외는 기존 기본값(5h)으로 폴백한다.
+function parseResetCooldownMs(text) {
+  const m = /resets?\s+([A-Za-z]{3,9}\s+\d{1,2}),?\s*(\d{1,2})\s*(am|pm)/i.exec(text || '');
+  if (m) {
+    let hour = parseInt(m[2], 10) % 12;
+    if (/pm/i.test(m[3])) hour += 12;
+    const guess = new Date(`${m[1]} ${new Date().getFullYear()} ${String(hour).padStart(2, '0')}:00:00`);
+    if (!Number.isNaN(guess.getTime())) {
+      const ms = guess.getTime() - Date.now() + 5 * 60 * 1000; // +5분 여유
+      if (ms > 0) return ms;
+    }
+  }
+  return /weekly/i.test(text || '') ? 24 * 60 * 60 * 1000 : DEFAULT_COOLDOWN_MS;
+}
+
+// 한도 걸린 계정을 쿨다운 처리. text(= claude 출력)에서 실제 리셋 시각을 추정해 쓰고,
+// 못 구하면 기존처럼 기본 쿨다운(weekly 문구면 24h, 아니면 5h)으로 폴백한다.
+function noteUsageLimit(account, text = '') {
+  if (!account) return;
+  const a = loadAccounts().find(x => x.name === account.name);
+  if (a) {
+    const cooldownMs = parseResetCooldownMs(text);
+    a.cooldownUntil = Date.now() + cooldownMs;
+    console.log(`[claude-accounts] ${a.name} usage limit → cooldown ${Math.round(cooldownMs / 3600000)}h`);
+  }
+}
+
+module.exports = {
+  loadAccounts,
+  count,
+  pickAccount,
+  envFor,
+  isUsageLimit,
+  noteUsageLimit,
+  DEFAULT_COOLDOWN_MS,
+};

--- a/slack-bot-minimax/claude-cli.js
+++ b/slack-bot-minimax/claude-cli.js
@@ -1,0 +1,151 @@
+// claude-cli.js — claude CLI 呼び出し（非同期 spawn ラッパ + 認証 + callClaude）
+// index.js から behavior-preserving で切り出し（ロジック変更なし）。
+
+const { spawn } = require('child_process');
+const accounts = require('./claude-accounts');
+const minimax = require('./minimax-accounts');
+const { getAgentDir, BASE_DIR, PROJECTS_ROOT } = require('./config');
+
+// ── spawn → Promise 래퍼 (이벤트 루프 비차단) ────────────────────────────────
+function spawnAsync(cmd, args, opts = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      cwd: opts.cwd,
+      env: opts.env || process.env, // 계정 라우팅: CLAUDE_CONFIG_DIR 주입용
+      windowsHide: opts.windowsHide !== false, // 기본 true; false 명시 시 브라우저 팝업 허용
+    });
+    // opts.input 이 있으면 프롬프트를 argv 대신 stdin 으로 전달한다.
+    // (긴 프롬프트를 커맨드라인에 실으면 Windows 길이 한계로 spawn ENAMETOOLONG 발생)
+    if (opts.input != null && child.stdin) {
+      child.stdin.on('error', () => {}); // 자식이 먼저 종료하면 EPIPE — 무시
+      child.stdin.end(opts.input);
+    }
+    const stdout = [], stderr = [];
+    if (child.stdout) child.stdout.on('data', d => stdout.push(d));
+    if (child.stderr) child.stderr.on('data', d => stderr.push(d));
+    let timer;
+    if (opts.timeout) {
+      timer = setTimeout(() => {
+        child.kill();
+        const e = new Error('ETIMEDOUT'); e.code = 'ETIMEDOUT';
+        reject(e);
+      }, opts.timeout);
+    }
+    child.on('error', err => { clearTimeout(timer); reject(err); });
+    child.on('close', code => {
+      clearTimeout(timer);
+      resolve({
+        status: code,
+        stdout: Buffer.concat(stdout).toString('utf8'),
+        stderr: Buffer.concat(stderr).toString('utf8'),
+      });
+    });
+  });
+}
+
+// ── Claude 인증 상태 확인 (계정별 env) ─────────────────────────────────────────
+async function isClaudeAuthed(env = process.env) {
+  try {
+    const r = await spawnAsync('claude', ['auth', 'status'], { timeout: 10000, env });
+    return JSON.parse(r.stdout || '{}').loggedIn === true;
+  } catch { return true; } // 확인 실패 시 인증됨으로 간주
+}
+
+// ── Claude 웹 재인증 (브라우저 팝업, 계정별) ───────────────────────────────────
+async function reAuthClaude(account = null) {
+  const label = account?.name || 'default';
+  const email = account?.email || 'yusuke.shikatani@bloomin.world';
+  console.log(`[Auth] claude(${label}) 인증 만료 감지 — 브라우저 인증 시작...`);
+  try {
+    const r = await spawnAsync('claude', ['auth', 'login', '--email', email], {
+      timeout: 5 * 60 * 1000,
+      windowsHide: false, // 브라우저가 열릴 수 있도록
+      env: accounts.envFor(account),
+    });
+    const ok = r.status === 0;
+    console.log(`[Auth] 재인증 ${ok ? '성공' : '실패'} (exit ${r.status})`);
+    return ok;
+  } catch (e) {
+    console.log(`[Auth] 재인증 오류: ${e.message}`);
+    return false;
+  }
+}
+
+// ── claude CLI (비동기 — 이벤트 루프 비차단) ──────────────────────────────────
+async function callClaude(prompt, workDir = BASE_DIR) {
+  const agentDir = getAgentDir(workDir);
+  const baseArgs = [
+    '-p', // プロンプトは argv ではなく stdin で渡す（ENAMETOOLONG 回避）→ spawnAsync opts.input
+    // callClaude は Q&A（answerInChannel / handleDM）専用。ファイル変更は
+    // 管理タスク経路（tm.createTaskFile 等）でのみ行う。ここで書込系ツールを
+    // 禁止し、質問に誤分類された作業依頼がサブエージェント経由で番号未発給の
+    // ままファイルを作ってしまう事故を防ぐ。（variadic → 次フラグ --model で停止）
+    '--disallowedTools', 'Write', 'Edit', 'NotebookEdit',
+    // このbotはユーザー指示専用 → Q&A経路も権限プロンプト無しで全ツール素通し
+    // (スクリプト/DB/読取すべて実行可、権限punt廃止)。書込系(Write/Edit/NotebookEdit)
+    // だけは上のdisallowedToolsで無効のまま = 番号未発給のファイル作成事故だけ防ぐ。
+    '--dangerously-skip-permissions',
+    '--add-dir', workDir,        // プロジェクトディレクトリ (サンドボックスに明示追加)
+    '--add-dir', agentDir,       // roles/rules/skills/workflows アクセス
+    '--add-dir', PROJECTS_ROOT,  // 全プロジェクト横断アクセス
+  ];
+  // 우선순위(사용자 지정): MiniMax 먼저 시도 → 실패해야만 Claude 계정 풀로 폴백.
+  let mmExhausted = false;
+  const mm = minimax.resolve();
+  if (mm) {
+    console.log(`[Bot] MiniMax(${mm.model}) 로 실행(Q&A)`);
+    const result = await spawnAsync('claude', [...baseArgs, '--model', mm.model], {
+      cwd: workDir,
+      timeout: 20 * 60 * 1000,
+      env: minimax.envFor(mm),
+      input: prompt,
+    });
+    if (result.status === 0) return (result.stdout || '').trim();
+    const mmOut = `${result.stdout || ''}\n${result.stderr || ''}`;
+    if (minimax.isUsageLimit(mmOut)) minimax.noteUsageLimit();
+    mmExhausted = true;
+    console.log('[Bot] MiniMax 실패 → Claude 폴백으로 전환');
+  }
+
+  // 계정 라우팅: weight 비율대로 계정 선택 → 한도면 다음 계정, 인증 만료면 1회 재인증
+  const maxTries = accounts.count() + 1; // 계정 수 + 인증 재시도 여유분
+  let authRetried = false;
+  for (let attempt = 0; attempt < maxTries; attempt++) {
+    const acct = accounts.pickAccount();
+    if (!acct) break; // 전 계정 쿨다운
+    const env = accounts.envFor(acct);
+    const args = [...baseArgs, '--model', 'claude-opus-4-8'];
+
+    const result = await spawnAsync('claude', args, {
+      cwd: workDir,
+      timeout: 20 * 60 * 1000, // 20分
+      env,
+      input: prompt, // 프롬프트는 stdin 으로 (ENAMETOOLONG 회피)
+    }); // ETIMEDOUT 등은 그대로 throw
+
+    if (result.status === 0) return (result.stdout || '').trim();
+
+    // 사용량 한도 → 해당 계정 쿨다운 후 다음 계정으로
+    // 한도 메시지("You've hit your weekly limit ...")는 stderr가 아니라 stdout에
+    // 찍히는 경우가 있어(giip-759) 두 스트림을 모두 확인한다.
+    const combinedOut = `${result.stdout || ''}\n${result.stderr || ''}`;
+    if (accounts.isUsageLimit(combinedOut)) {
+      accounts.noteUsageLimit(acct, combinedOut);
+      continue;
+    }
+    // 그 외 실패 — 인증 만료 여부 확인 후 자동 재인증 (계정별 1회)
+    if (!authRetried && !(await isClaudeAuthed(env))) {
+      authRetried = true;
+      const ok = await reAuthClaude(acct);
+      if (!ok) throw new Error(`claude(${acct.name}) 인증 재시도 실패 — CLAUDE_CONFIG_DIR=${acct.dir || 'default'} 로 \`claude auth login\` 실행 필요`);
+      continue;
+    }
+    throw new Error(`claude exit ${result.status}: ${(result.stderr || '').slice(0, 200)}`);
+  }
+
+  if (mmExhausted) throw new Error('claude 호출 실패 — MiniMax + Claude 전 계정/재시도 소진');
+
+  throw new Error('claude 호출 실패 — 모든 계정/재시도 소진');
+}
+
+module.exports = { spawnAsync, isClaudeAuthed, reAuthClaude, callClaude };

--- a/slack-bot-minimax/config.js
+++ b/slack-bot-minimax/config.js
@@ -1,0 +1,246 @@
+// config.js — 共有定数 + プロジェクトパスヘルパ + 可変 botUserId アクセサ
+// index.js から behavior-preserving で切り出し（ロジック変更なし）。
+
+const fs = require('fs');
+const path = require('path');
+
+// ── 設定 ─────────────────────────────────────────────────────────────────────
+const BOT_TOKEN = process.env.SLACK_BOT_TOKEN;
+const CHANNEL_IDS = (process.env.SLACK_CHANNEL_IDS || '').split(',').map(s => s.trim()).filter(Boolean);
+const SLACK_APP_TOKEN = process.env.SLACK_APP_TOKEN;
+
+const PROJECTS_ROOT   = 'C:\\Users\\lowys\\Downloads\\projects';
+const BASE_DIR        = path.join(PROJECTS_ROOT, 'lowyworkenv'); // 기본 작업 폴더
+const AGENT_DIR       = path.join(BASE_DIR, '.agent');            // 기본 .agent (lowyworkenv/.agent)
+const HISTORY_FILE    = path.join(__dirname, '.conversations.json');
+const TASK_STATE_FILE = path.join(__dirname, '.task-state.json');
+const BOT_THREADS_FILE = path.join(__dirname, '.bot-threads.json');
+const PROJECT_CSN_FILE = path.join(__dirname, 'project-csn.json');
+const CHANNEL_PROJECT_FILE = path.join(__dirname, 'channel-project.json');
+
+// ── 可変ランタイム: BOT_USER_ID を getter/setter で共有 ───────────────────────
+// main() 内の auth.test 後に setBotUserId で設定し、複数モジュールから getBotUserId で読む。
+let botUserId = null;
+function getBotUserId() { return botUserId; }
+function setBotUserId(id) { botUserId = id; }
+
+// 봇끼리 대화 허용(2026-07-26, giip-773 후속) 시 "자기 자신이 보낸 메시지"만 걸러 무한루프를 막기 위한 bot_id.
+let selfBotId = null;
+function getSelfBotId() { return selfBotId; }
+function setSelfBotId(id) { selfBotId = id; }
+
+// ── プロジェクトの .agent ディレクトリを解決 ─────────────────────────────────
+// workDir 内に .agent があればそれを使い、なければ lowyworkenv/.agent にフォールバック
+function getAgentDir(workDir) {
+  const d = path.join(workDir, '.agent');
+  return fs.existsSync(d) ? d : AGENT_DIR;
+}
+
+// ── プロジェクトプレフィックス検出 ────────────────────────────────────────────
+// メッセージの先頭がプロジェクト名（PROJECTS_ROOT 直下のフォルダ名）なら
+// そのフォルダを workDir として返し、プレフィックスを除去した本文を返す
+function parseProjectPrefix(text) {
+  const words = text.trim().split(/\s+/);
+  if (words.length < 1) return { workDir: BASE_DIR, cleanText: text, projectName: null };
+  // 助詞・接尾語を除去してプロジェクト名を抽出 (giipprj에서 → giipprj)
+  const raw = words[0];
+  const candidate = raw.toLowerCase().replace(/(에서|에서는|에서도|에서만|에게서|한테서|의|에|는|이|가|를|을|로|으로|와|과|도|만|까지|부터|처럼|라고|이라고|에서라도|에도)$/u, '');
+  const projectDir = path.join(PROJECTS_ROOT, candidate);
+  // 認識したプレフィックス（助詞含む）を除いた本文を返すヘルパ
+  const stripPrefix = () => {
+    const suffix = raw.slice(candidate.length); // 除去した助詞部分
+    const rest = suffix ? [suffix, ...words.slice(1)] : words.slice(1);
+    return rest.join(' ').trim() || text;
+  };
+  try {
+    if (fs.statSync(projectDir).isDirectory()) {
+      console.log(`[Bot] プロジェクト切り替え: ${projectDir}`);
+      return { workDir: projectDir, cleanText: stripPrefix(), projectName: candidate };
+    }
+  } catch {}
+  // フォルダは無いが project-csn.json に登録済みのプロジェクト名なら、CSN ルーティング用に
+  // projectName だけ解決する。workDir は cwd として使われるため安全な BASE_DIR に固定し、
+  // コマンド実行が存在しないフォルダを cwd にするのを防ぐ（CSN ルーティングのみ有効化）。
+  if (candidate && Object.prototype.hasOwnProperty.call(loadProjectCsnMap(), candidate)) {
+    console.log(`[Bot] プロジェクト名(フォルダ無し) 認識: ${candidate} → CSN ルーティング`);
+    return { workDir: BASE_DIR, cleanText: stripPrefix(), projectName: candidate };
+  }
+  return { workDir: BASE_DIR, cleanText: text, projectName: null };
+}
+
+// ── プロジェクト名 → giip csn マッピング（設定ファイル駆動） ──────────────────
+// Slack で最初に言及したプロジェクト名（= parseProjectPrefix が解決する workDir の
+// フォルダ名）を giip csn に対応づける。ハードコードせず project-csn.json で管理し、
+// giip-accounts.js と同様に呼び出しごとに読み直す（再起動なしで反映）。
+function loadProjectCsnMap() {
+  try {
+    const j = JSON.parse(fs.readFileSync(PROJECT_CSN_FILE, 'utf8'));
+    return (j && j.map) || {};
+  } catch {
+    return {};
+  }
+}
+
+// workDir（またはプロジェクト名）→ csn(Number) or null。
+// 未登録なら null を返し、呼び出し側は issueCreate 内の `csn ?? account.csn` で
+// 既定 csn にフォールバックする。
+function resolveProjectCsn(workDirOrName) {
+  if (!workDirOrName) return null;
+  const name = path.basename(String(workDirOrName)).toLowerCase();
+  const v = loadProjectCsnMap()[name];
+  return (v === 0 || v) ? Number(v) : null;
+}
+
+// ── project-csn.json の読み書き（Slack `giip project` コマンドから利用） ──────
+// _comment 等 map 以外のフィールドを保存したまま map だけ更新する。書き込みは
+// loadProjectCsnMap と同じく呼び出しごとに読み直すので再起動なしで即時反映される。
+function readProjectCsnFile() {
+  try {
+    const j = JSON.parse(fs.readFileSync(PROJECT_CSN_FILE, 'utf8'));
+    return (j && typeof j === 'object') ? j : {};
+  } catch {
+    return {};
+  }
+}
+function writeProjectCsnFile(obj) {
+  fs.writeFileSync(PROJECT_CSN_FILE, JSON.stringify(obj, null, 2) + '\n', 'utf8');
+}
+
+// 全マッピングを { name: csn } で返す。
+function listProjectCsn() {
+  return loadProjectCsnMap();
+}
+
+// プロジェクト名 → csn を追加/更新。name は小文字化して保存（parseProjectPrefix と整合）。
+function setProjectCsn(name, csn) {
+  const key = String(name || '').trim().toLowerCase();
+  const n = Number(csn);
+  if (!key) throw new Error('프로젝트명이 필요합니다.');
+  if (!Number.isInteger(n)) throw new Error('csn 은 정수여야 합니다.');
+  const j = readProjectCsnFile();
+  if (!j.map || typeof j.map !== 'object') j.map = {};
+  j.map[key] = n;
+  writeProjectCsnFile(j);
+  return { name: key, csn: n };
+}
+
+// プロジェクト名のマッピングを削除。存在して削除したら true、無ければ false。
+function deleteProjectCsn(name) {
+  const key = String(name || '').trim().toLowerCase();
+  if (!key) return false;
+  const j = readProjectCsnFile();
+  if (j.map && Object.prototype.hasOwnProperty.call(j.map, key)) {
+    delete j.map[key];
+    writeProjectCsnFile(j);
+    return true;
+  }
+  return false;
+}
+
+// ── チャンネル → 既定プロジェクト固定マッピング（channel-project.json 駆動） ──────
+// 「このチャンネルの発話はすべて <project> として扱う」を実現する。project-csn.json と同じく
+// 呼び出しごとに読み直す（再起動なしで反映）。giip csn とは独立に channelId → プロジェクト名を持つ。
+function loadChannelProjectMap() {
+  try {
+    const j = JSON.parse(fs.readFileSync(CHANNEL_PROJECT_FILE, 'utf8'));
+    return (j && j.map) || {};
+  } catch {
+    return {};
+  }
+}
+
+// channelId → プロジェクト名(小文字) or null。未登録なら null。
+function resolveChannelProject(channelId) {
+  if (!channelId) return null;
+  const v = loadChannelProjectMap()[channelId];
+  return v ? String(v).toLowerCase() : null;
+}
+
+// プロジェクト名 → workDir。PROJECTS_ROOT 直下に同名フォルダがあればそれ、無ければ BASE_DIR に
+// 安全フォールバック（存在しないフォルダを cwd にしない）。parseProjectPrefix のフォルダ解決と整合。
+function projectWorkDir(name) {
+  const candidate = String(name || '').trim().toLowerCase();
+  if (!candidate) return BASE_DIR;
+  const dir = path.join(PROJECTS_ROOT, candidate);
+  try { if (fs.statSync(dir).isDirectory()) return dir; } catch {}
+  return BASE_DIR;
+}
+
+// チャンネル固定マッピングを parseProjectPrefix の結果に適用する。
+//   優先順位（設計判断・task giip-724）: 明示的プロジェクト接頭辞 > チャンネル固定。
+//   メッセージ先頭に実フォルダ / project-csn.json 登録名の接頭辞があれば（parsed.projectName != null）
+//   それを尊重する（Rule 32 の絶対規則を維持）。接頭辞が無いときだけ、本来 BASE_DIR(lowyworkenv) に
+//   潰れていた workDir/projectName をチャンネルの既定プロジェクトで埋める。cleanText は変更しない。
+function applyChannelPin(channelId, parsed) {
+  const p = parsed || { workDir: BASE_DIR, cleanText: '', projectName: null };
+  if (p.projectName) return p; // 明示接頭辞が優先
+  const pinned = resolveChannelProject(channelId);
+  if (!pinned) return p;
+  return { ...p, workDir: projectWorkDir(pinned), projectName: pinned };
+}
+
+// ── channel-project.json の読み書き（Slack `giip channel` コマンドから利用） ────
+function readChannelProjectFile() {
+  try {
+    const j = JSON.parse(fs.readFileSync(CHANNEL_PROJECT_FILE, 'utf8'));
+    return (j && typeof j === 'object') ? j : {};
+  } catch {
+    return {};
+  }
+}
+function writeChannelProjectFile(obj) {
+  fs.writeFileSync(CHANNEL_PROJECT_FILE, JSON.stringify(obj, null, 2) + '\n', 'utf8');
+}
+function listChannelProject() { return loadChannelProjectMap(); }
+// channelId → プロジェクト名 を追加/更新。プロジェクト名は小文字化して保存。
+function setChannelProject(channelId, name) {
+  const key = String(channelId || '').trim();
+  const val = String(name || '').trim().toLowerCase();
+  if (!key) throw new Error('channelId 가 필요합니다.');
+  if (!val) throw new Error('프로젝트명이 필요합니다.');
+  const j = readChannelProjectFile();
+  if (!j.map || typeof j.map !== 'object') j.map = {};
+  j.map[key] = val;
+  writeChannelProjectFile(j);
+  return { channelId: key, project: val };
+}
+// channelId のマッピングを削除。存在して削除したら true、無ければ false。
+function deleteChannelProject(channelId) {
+  const key = String(channelId || '').trim();
+  if (!key) return false;
+  const j = readChannelProjectFile();
+  if (j.map && Object.prototype.hasOwnProperty.call(j.map, key)) {
+    delete j.map[key];
+    writeChannelProjectFile(j);
+    return true;
+  }
+  return false;
+}
+
+module.exports = {
+  BOT_TOKEN,
+  CHANNEL_IDS,
+  SLACK_APP_TOKEN,
+  PROJECTS_ROOT,
+  BASE_DIR,
+  AGENT_DIR,
+  HISTORY_FILE,
+  TASK_STATE_FILE,
+  BOT_THREADS_FILE,
+  getBotUserId,
+  setBotUserId,
+  getSelfBotId,
+  setSelfBotId,
+  getAgentDir,
+  parseProjectPrefix,
+  resolveProjectCsn,
+  listProjectCsn,
+  setProjectCsn,
+  deleteProjectCsn,
+  resolveChannelProject,
+  projectWorkDir,
+  applyChannelPin,
+  listChannelProject,
+  setChannelProject,
+  deleteChannelProject,
+};

--- a/slack-bot-minimax/dashboard.js
+++ b/slack-bot-minimax/dashboard.js
@@ -1,0 +1,289 @@
+/**
+ * dashboard.js
+ * LOWY_ACTION_DASHBOARD.md 의 "slack-bot 요청 처리 현황" 섹션을 봇이 자동 갱신한다.
+ *
+ * 요구사항(사용자 지시):
+ *   - slack-bot 이 처리한 요청(태스크)을 Lowy 가 체크할 수 있게 체크리스트로 유지.
+ *     · 대기/진행(pending/running) → 미체크 `- [ ]`
+ *     · 최근 완료(completed)       → 체크 `- [x]` (검수 후 직접 해제/삭제)
+ *   - 상세 내용은 전부 GitHub 링크(클릭). 완료=PR URL, 대기=태스크 파일 blob(미추적이면 폴더).
+ *   - **이 파일은 온라인에서도 사용자가 수시로 수정하므로, 수정 전 반드시 최신본을 반영한다.**
+ *
+ * 안전 설계 (공유 작업트리에서 다른 세션/봇 작업을 절대 유실시키지 않음):
+ *   - 자동 섹션은 마커(<!-- SLACKBOT-TASKS:START/END -->) 사이만 교체 → 사용자의 수동 내용은 보존.
+ *   - 작업트리가 base 브랜치(master)에 있고 태스크가 점유(bot/task-*)하지 않을 때만 실행.
+ *     (태스크 실행 중에는 skip → 다음 완료 시점(항상 master 복귀)에서 갱신되어 결과적으로 일관.)
+ *   - **최신화는 stash 없이 `fetch` + `merge --ff-only` 로만.** tracked 미커밋 변경이 있으면
+ *     사전 가드(hasTrackedChanges)로 즉시 skip → 다른 세션의 작업을 stash 로 쓸어담지 않는다.
+ *     (`--autostash` 는 유실은 아니어도 남의 tracked 변경을 잠시 stash 로 옮기므로 쓰지 않음.)
+ *   - tasklist.json(런타임, gitignore)을 소스로 하고, 커밋 대상은 대시보드 파일 1개뿐.
+ *   - 예외를 절대 밖으로 던지지 않는다(봇 흐름을 막지 않음).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const tm = require('./task-manager');
+
+const BASE_DIR = path.join(__dirname, '..');
+const DASH_REL = 'LOWY_ACTION_DASHBOARD.md';
+const DASH_FILE = path.join(BASE_DIR, DASH_REL);
+const TASKS_DIR = path.join(BASE_DIR, '.agent', 'tasks');
+
+const MARK_START = '<!-- SLACKBOT-TASKS:START -->';
+const MARK_END = '<!-- SLACKBOT-TASKS:END -->';
+
+const MAX_COMPLETED = 12; // 최근 완료 표시 개수
+
+// 겹치는 갱신 호출을 직렬화(sync spawn 이라 실제 병렬은 없지만 중복 no-op 방지)
+let running = false;
+
+function git(args, opts = {}) {
+  return spawnSync('git', args, { cwd: BASE_DIR, encoding: 'utf8', windowsHide: true, ...opts });
+}
+
+function currentBranch() {
+  const r = git(['rev-parse', '--abbrev-ref', 'HEAD']);
+  return (r.stdout || '').trim() || 'master';
+}
+
+// tracked 미커밋 변경(스테이지/워킹)이 하나라도 있으면 true. untracked(??)는 무시.
+// 다른 세션/봇의 진행 중 작업을 stash 로 건드리지 않기 위한 사전 가드에 쓴다.
+function hasTrackedChanges() {
+  const r = git(['status', '--porcelain', '--untracked-files=no']);
+  return (r.stdout || '').trim().length > 0;
+}
+
+// origin/base 최신을 로컬 base 로 **fast-forward 로만** 반영한다.
+//  - stash/pop 을 절대 쓰지 않는다 → 다른 세션의 tracked 미커밋 작업을 sweep 하지 않음.
+//  - 로컬이 앞서(diverged) 있거나, ff 가 로컬 미커밋을 덮어쓸 상황이면 git 이 스스로 거부 → skip.
+//    (덮어쓰기 대신 "안 함"을 택함 = 데이터 안전 최우선.)
+// 반환: { ok:true } | { ok:false, reason }
+function fastForwardBase(base) {
+  const f = git(['fetch', 'origin', base]);
+  if (f.status !== 0) return { ok: false, reason: 'fetch-failed' };
+  // 이미 최신이면 no-op 성공. 로컬 미커밋이 걸리거나 non-ff 면 status!=0 로 거부됨.
+  const m = git(['merge', '--ff-only', `origin/${base}`]);
+  if (m.status !== 0) return { ok: false, reason: 'not-fast-forwardable' };
+  return { ok: true };
+}
+
+// origin remote → https://github.com/Owner/Repo
+function repoWebBase() {
+  const r = git(['remote', 'get-url', 'origin']);
+  const remote = (r.stdout || '').trim();
+  return remote
+    .replace(/^git@github\.com:/, 'https://github.com/')
+    .replace(/^git@ssh\.github\.com:/, 'https://github.com/')
+    .replace(/\.git$/, '');
+}
+
+function isTracked(relPath) {
+  const r = git(['ls-files', '--error-unmatch', relPath]);
+  return r.status === 0;
+}
+
+// 태스크 파일 GitHub 링크. 추적 중이면 blob URL, 아니면(아직 master 미반영) 태스크 폴더 링크.
+function taskLink(taskId, branch, web) {
+  const candidates = [
+    path.join(TASKS_DIR, `${taskId}.md`),
+    path.join(TASKS_DIR, 'done', `${taskId}.md`),
+    path.join(TASKS_DIR, 'cancel', `${taskId}.md`),
+  ];
+  const found = candidates.find(f => fs.existsSync(f));
+  if (found) {
+    const rel = path.relative(BASE_DIR, found).replace(/\\/g, '/');
+    if (isTracked(rel)) return `${web}/blob/${branch}/${rel}`;
+  }
+  // 미추적이거나 파일 없음 → 태스크 폴더로 폴백(항상 유효)
+  return `${web}/tree/${branch}/.agent/tasks`;
+}
+
+function esc(s) {
+  // 마크다운/링크 라벨 깨짐 방지: 개행 제거, 링크문자 완화, 길이 제한
+  return String(s || '')
+    .replace(/[\r\n]+/g, ' ')
+    .replace(/\|/g, '\\|')
+    .replace(/\[/g, '(')
+    .replace(/\]/g, ')')
+    .trim()
+    .slice(0, 80);
+}
+
+function fmtDate(iso) {
+  if (!iso) return '';
+  const d = String(iso).slice(0, 10);
+  return d;
+}
+
+const EMOJI = { pending: '🕐', running: '⚙️' };
+
+// tasklist 배열 → 자동 섹션 마크다운 문자열(마커 포함)
+function buildSection(list, { branch, web, now }) {
+  const active = list
+    .filter(t => t.status === 'pending' || t.status === 'running')
+    .sort((a, b) => String(b.createdAt || '').localeCompare(String(a.createdAt || '')));
+
+  const completed = list
+    .filter(t => t.status === 'completed')
+    .sort((a, b) => String(b.completedAt || '').localeCompare(String(a.completedAt || '')))
+    .slice(0, MAX_COMPLETED);
+
+  const lines = [];
+  lines.push(MARK_START);
+  lines.push('## 🤖 slack-bot 요청 처리 현황');
+  lines.push('');
+  lines.push(`> 봇 자동 갱신: ${now} · 이 블록은 봇이 관리하므로 직접 수정하지 마세요(마커 밖은 자유).`);
+  lines.push('> 상세는 각 항목의 GitHub 링크(클릭). 완료 항목은 검수 후 체크를 해제하거나 삭제하세요.');
+  lines.push('');
+
+  lines.push('### ✅ 확인 필요 — 대기/진행 중');
+  if (active.length === 0) {
+    lines.push('- _(대기/진행 중인 요청 없음)_');
+  } else {
+    for (const t of active) {
+      const emoji = EMOJI[t.status] || '🕐';
+      const title = esc(t.title || t.summary || t.taskId);
+      const link = taskLink(t.taskId, branch, web);
+      lines.push(`- [ ] ${emoji} \`${t.taskId}\` ${title} — [상세](${link})`);
+    }
+  }
+  lines.push('');
+
+  lines.push(`### 🗂️ 최근 완료 — 검수 후 체크 (최대 ${MAX_COMPLETED}건)`);
+  if (completed.length === 0) {
+    lines.push('- _(완료된 요청 없음)_');
+  } else {
+    for (const t of completed) {
+      const title = esc(t.title || t.summary || t.taskId);
+      const link = t.resultUrl || taskLink(t.taskId, branch, web);
+      const date = fmtDate(t.completedAt);
+      const dateStr = date ? ` _(${date})_` : '';
+      lines.push(`- [x] \`${t.taskId}\` ${title}${dateStr} — [결과](${link})`);
+    }
+  }
+  lines.push('');
+  lines.push(`전체 태스크 이력: [\`.agent/tasks/\`](${web}/tree/${branch}/.agent/tasks)`);
+  lines.push(MARK_END);
+  return lines.join('\n');
+}
+
+// 파일 내용에 섹션을 삽입/교체한다. 마커가 있으면 그 사이만, 없으면 상단 첫 `---` 뒤에 삽입.
+function applySection(content, section) {
+  const s = content.indexOf(MARK_START);
+  const e = content.indexOf(MARK_END);
+  if (s >= 0 && e > s) {
+    const before = content.slice(0, s);
+    const after = content.slice(e + MARK_END.length);
+    return before + section + after;
+  }
+  // 마커 없음 → 최초 삽입: 상단 인트로(첫 '---') 뒤에 넣는다.
+  const hr = content.indexOf('\n---\n');
+  if (hr >= 0) {
+    const cut = hr + '\n---\n'.length;
+    return content.slice(0, cut) + '\n' + section + '\n' + content.slice(cut);
+  }
+  // '---' 도 없으면 상단에 프리펜드
+  return section + '\n\n' + content;
+}
+
+// tasklist 를 읽어 대시보드 파일을 갱신(디스크에만 write). git 은 건드리지 않는다.
+// 반환: { changed, path }
+function writeDashboardFile({ branch, web, now } = {}) {
+  branch = branch || currentBranch();
+  web = web || repoWebBase();
+  now = now || new Date().toISOString();
+
+  const list = tm.getTasklistByStatus(null) || [];
+  const section = buildSection(list, { branch, web, now });
+
+  let content = '';
+  try { content = fs.readFileSync(DASH_FILE, 'utf8'); } catch { content = '# Lowy 확인 필요 안건 대시보드\n\n---\n'; }
+
+  const next = applySection(content, section);
+  if (next === content) return { changed: false, path: DASH_FILE };
+  fs.writeFileSync(DASH_FILE, next);
+  return { changed: true, path: DASH_FILE };
+}
+
+// ── 메인: pull → 섹션 갱신 → 커밋 → push. base 브랜치에서만, 예외를 삼킨다. ──────
+// opts.push=false 면 디스크 갱신만(테스트/시드용).
+function refreshDashboard(reason = '', opts = {}) {
+  const doPush = opts.push !== false;
+  if (running) return { skipped: 'already-running' };
+  running = true;
+  try {
+    // 1) 작업트리가 base 브랜치인지 확인(태스크가 bot/task-* 로 점유 중이면 skip)
+    const base = tm.getBaseBranch(BASE_DIR);
+    const cur = currentBranch();
+    if (doPush && cur !== base) {
+      return { skipped: `not-on-base(${cur})` };
+    }
+
+    // 2) **수정 전 반드시 pull** — 온라인에서 사용자가 수정한 최신본을 먼저 반영
+    if (doPush) {
+      // 사전 가드: tracked 미커밋 변경이 있으면(다른 세션/봇이 작업 중일 수 있음) 이번 회차 skip.
+      //   → 어차피 뒤의 ff-only 도 거부되지만, 여기서 먼저 빠져 남의 작업 근처에서 아무 git 도 안 만짐.
+      if (hasTrackedChanges()) {
+        return { skipped: 'tree-dirty(tracked)' };
+      }
+      // **수정 전 반드시 최신 반영** — 단, stash 없이 fast-forward 로만(남의 작업 안전).
+      const sync = fastForwardBase(base);
+      if (!sync.ok) {
+        console.error(`[Dashboard] base 최신화 skip(${sync.reason}) — 다음 이벤트에서 재시도`);
+        return { skipped: sync.reason };
+      }
+    }
+
+    // 3) 섹션 재생성(디스크)
+    const web = repoWebBase();
+    const { changed } = writeDashboardFile({ branch: base, web });
+    if (!changed) return { skipped: 'no-change' };
+    if (!doPush) return { ok: true, pushed: false };
+
+    // 4) 대시보드 파일만 커밋
+    git(['add', DASH_REL]);
+    const msg = `docs(dashboard): slack-bot 요청 처리 현황 자동 갱신${reason ? ` (${reason})` : ''}\n\nAuto-updated by giipclaude Bot`;
+    const commit = git(['commit', '-m', msg]);
+    if (commit.status !== 0 && !/nothing to commit/.test(commit.stdout || '')) {
+      console.error('[Dashboard] git commit 실패:', (commit.stderr || '').trim().slice(0, 200));
+      return { error: 'commit-failed' };
+    }
+
+    // 5) push (원격이 앞서 거부되면 우리 대시보드 단일 커밋만 rebase 로 얹어 1회 재시도)
+    //   - autostash 미사용. 이 시점 작업트리는 위 사전 가드로 clean 이 보장되므로
+    //     rebase 가 남의 미커밋을 건드릴 일이 없다(더러웠다면 애초에 여기 도달 못 함).
+    let push = git(['push', 'origin', base]);
+    if (push.status !== 0) {
+      git(['fetch', 'origin', base]);
+      const rb = git(['rebase', `origin/${base}`]);
+      if (rb.status !== 0) {
+        git(['rebase', '--abort']); // 충돌 시 우리 커밋은 로컬 보존(유실 없음)
+        console.error('[Dashboard] push 재시도 rebase 실패 → 이번 회차 skip(커밋은 로컬 보존)');
+        return { skipped: 'push-retry-rebase-failed' };
+      }
+      push = git(['push', 'origin', base]);
+    }
+    if (push.status !== 0) {
+      console.error('[Dashboard] git push 실패:', (push.stderr || '').trim().slice(0, 200));
+      return { error: 'push-failed' };
+    }
+    console.log(`[Dashboard] 갱신 완료${reason ? ` (${reason})` : ''} → origin/${base}`);
+    return { ok: true, pushed: true };
+  } catch (e) {
+    console.error('[Dashboard] refreshDashboard 예외:', e.message);
+    return { error: e.message };
+  } finally {
+    running = false;
+  }
+}
+
+module.exports = { refreshDashboard, writeDashboardFile, buildSection, applySection };
+
+// CLI: `node dashboard.js`         → pull+갱신+push (base 브랜치에서)
+//      `node dashboard.js --local` → 디스크만 갱신(테스트/시드용, git 미조작)
+if (require.main === module) {
+  const local = process.argv.includes('--local');
+  const res = refreshDashboard('manual', { push: !local });
+  console.log('[Dashboard]', JSON.stringify(res));
+}

--- a/slack-bot-minimax/docs/DESIGN_slackbot_giip_issue_integration.md
+++ b/slack-bot-minimax/docs/DESIGN_slackbot_giip_issue_integration.md
@@ -1,0 +1,167 @@
+# DESIGN — slack-bot / 이 PC 작업을 giip issue API 로 통일
+
+> **상태**: 설계 확정용 초안 (2026-07-11). 구현 전 합의 문서.
+> **목적**: 이 PC 및 slack-bot 에서 주고받는 **모든 작업**을 로컬 파일이 아니라 **giip issue** 로 관리하고, Slack 에서 **모든 giip API** 를 호출할 수 있게 한다.
+> **관계 정리**: **태스크 번호(slack-bot 타임스탬프)** 와 **이슈 번호(giip issue, isn)** 는 지금까지 별개였다 → 본 설계로 **isn 으로 통일**한다. (giip issue 는 giip issue 관리 화면에서 관리.)
+
+---
+
+## 0. 용어
+- **AK** (Access Token): 웹 UI 로그인 시 발급되는 **동적 세션 토큰**. `tUserLogin.AccToken`(24h 유효, `ulLogout IS NULL`). 로그인마다 바뀜.
+- **SK** (Secret Key): 에이전트용 **정적 키**. `tCorpUser.uSecretKey`. 잘 안 바뀜.
+- **isn**: giip issue 번호(PK). giip issue 관리의 기본 식별자.
+- **byAK API**: `x-api-key`(=AK 또는 SK) 로 인증하는 giipfaw 함수. 내부적으로 `dbo.lwGetUSNbyat(@token)` 로 usn 도출.
+
+---
+
+## 1. 현행 (As-Is)
+- slack-bot(`task-manager.js`)은 요청을 **로컬 파일**로 관리:
+  - 태스크 ID = `getTimestampId()` = `YYYYMMDDHHMMSS`
+  - 저장: `Lowyworkenv/.agent/tasks/{id}.md`(+`done/`,`cancel/`), 결과 `.agent/results/{id}.md`, 인덱스 `slack-bot/tasklist.json`
+  - 생명주기: analyze → createTaskFile → startExecution(claude CLI) → completeTaskFile → gitPushResult(GitHub URL)
+- **giip API 미호출, giip 자격증명 없음**(SLACK/GITHUB 토큰만).
+- giip issue API 는 **이미 완비**되어 있으나 봇과 연결되어 있지 않음.
+
+## 2. 기존 giip issue API (재사용, 신규개발 불필요)
+`giipfaw/giipIssues` — `https://giipfaw.azurewebsites.net/api/giipIssues`
+| 메서드 | 동작 | SP | 비고 |
+| :-- | :-- | :-- | :-- |
+| POST | 생성(isn=0) → **새 isn 반환** | `pApiGiipIssuePutbyAK` | title,content,status,csn,target_lssn,agent_workflow |
+| PUT | 수정(isn=N) | `pApiGiipIssuePutbyAK` | ⚠️ **전체 덮어쓰기** (아래 §6) |
+| GET | `?isn=` 단건 / `?status=&csn=` 목록 | `pApiGiipIssue{Get,List}byAK` | |
+| DELETE | `?isn=` | `pApiGiipIssueDeletebyAK` | |
+- 코멘트: `giipfaw/giipIssueComments` (결과 보고를 코멘트로).
+- 범용 호출: `giipfaw/giipApi` — `text=<Verb>` → `exec pApi<Verb>byAK` (임의 SP 호출의 토대).
+
+---
+
+## 3. 인증 설계 (확정: .env = 로그인ID + SK)
+로그인마다 AK 가 바뀌므로 **.env 에는 로그인ID와 SK만** 둔다. 봇은 이 둘로 **최신 AK 를 DB에서 받아** giip API 를 호출한다.
+
+### 3-1. 신규 관리자 API — `AdminGetAK` (login + SK → 최신 AK)
+신규 SP `pApiAdminGetAKbyLoginSK`(byAK 규약, giipApi 디스패처로 자동 노출: `text=AdminGetAK`):
+```
+입력: @at = SK, @jsondata = { "uloginid": "<login>" }
+1) SK 로 usn 도출: SELECT usn FROM tCorpUser WHERE uSecretKey=@sk AND uloginid=@uloginid  -- 로그인ID+SK 동시 일치(2요소)
+   → 불일치면 401.
+2) 최신 활성 AK 조회:
+   SELECT TOP 1 AccToken FROM tUserLogin
+   WHERE usn=@usn AND ulLogout IS NULL AND AccTokenRegdt > DATEADD(HOUR,-24,GETDATE())
+   ORDER BY AccTokenRegdt DESC
+3) (권장) 활성 AK 가 없으면 **새 AccToken 발급**:
+   INSERT tUserLogin(usn, AccToken=NEWID(), AccTokenRegdt=GETDATE(), ...) → 그 토큰 반환
+   → 이렇게 하면 최근 웹 로그인 없이도 .env(로그인+SK)만으로 자립.
+반환: { ak, usn, csn }  (csn = 사용자 대표 프로젝트, 세션 스코프용)
+```
+- **왜 SK 직접 사용 안 하나(대안 비교)**: `lwGetUSNbyat` 는 SK 도 토큰으로 받으므로 *기술적으로는 SK 를 그대로 x-api-key 로 써도 byAK API 가 동작*한다(가장 단순, .env=SK 만). 그러나 (a) 동적 세션/CSN 컨텍스트가 없고 (b) SK 상시 노출·회수 어려움. → **로그인+SK→AK 방식 채택**(AK 자동 회전, 세션 스코프 확보). SK-직접은 폴백으로만.
+
+### 3-2. 봇 설정 — Slack 채널별 계정 매핑 (확정)
+채널마다 다른 프로젝트/계정을 쓸 수 있게 **채널 → {로그인ID, SK, csn}** 로 매핑한다. SK 는 비밀이므로 **비커밋 파일**에 둔다.
+- 파일(비커밋, gitignore): `slack-bot/.secrets/giip-accounts.json` (샘플 `giip-accounts.sample.json` 만 커밋).
+```jsonc
+{
+  "GIIP_API_BASE": "https://giipfaw.azurewebsites.net/api",
+  "default": { "login_id": "<uloginid>", "sk": "<uSecretKey>", "csn": 47 },
+  "channels": {
+    "C0ABC123":  { "login_id": "<uloginid>", "sk": "<uSecretKey>", "csn": 47 },
+    "C0XYZ789":  { "login_id": "<other>",    "sk": "<other_sk>",   "csn": 70 }
+  }
+}
+```
+- 해석 순서: 요청 채널 매핑 → 없으면 `default`.
+- **AK 는 저장하지 않는다** (로그인마다 바뀜). 런타임에 각 계정의 (login_id+sk) 로 `AdminGetAK` 취득·캐시(만료/401 시 재취득). — [[rule 39]], workflow `giip-get-ak`.
+- **.env 최소화**: 비밀은 위 파일에. (원하면 `default` 만 .env 로 둬도 됨.) **채널 계정 없이 default 만 쓰면 "로그인ID+SK만 있으면 됨" 그대로 성립.**
+
+### 3-3. 대화로 계정 변경 → 설정 영속화 (확정)
+Slack 대화에서 로그인ID/SK 를 바꾸면 위 매핑 파일을 **갱신·유지**한다.
+- 커맨드(예): `giip account set <login_id> <sk> [csn]` — 실행 채널에 대한 매핑을 갱신. `giip account set-default ...` — default 갱신.
+- 동작: `giip-accounts.json` 의 해당 채널(또는 default) 항목을 write → 다음부터 그 계정 사용. AK 캐시 무효화.
+- **보안**: SK 가 평문 노출되므로 **DM 또는 비공개 채널 권장**. 설정 후 원문 메시지 삭제 안내. 파일은 gitignore(비커밋) — [[reference_giipdb_secrets_standard]].
+
+### 3-3. AK 캐시/갱신
+- 봇 메모리에 `{ak, fetchedAt}` 캐시. 매 호출 전 만료(예: 20h) 또는 401 수신 시 `AdminGetAK` 재호출.
+
+### 3-4. 채널 → 기본 프로젝트 고정 (Channel Pin, task giip-724)
+"이 채널의 대화는 모두 `<project>` 로 처리" 를 위한 **채널 → 프로젝트명** 고정 매핑. §3-2 의 계정(SK/csn) 매핑과는
+**독립**이다(SK 비밀 없음 → **커밋**). csn 은 프로젝트명 → `project-csn.json` 으로 이미 해석되므로 여기서는 프로젝트명만 고정한다.
+- 파일(커밋): `slack-bot/channel-project.json` `map`(`channelId → 프로젝트명`). 편집: Slack `giip channel set|list|del`(재시작 불필요).
+- 적용: `processMessage` 에서 `config.applyChannelPin(channelId, parseProjectPrefix(text))`.
+- **우선순위**: 명시적 프로젝트 접두어([[rule 32]]) > 채널 고정. 접두어가 없을 때만 채널 기본 프로젝트가 workDir/projectName(→csn)을 채운다.
+- 기본값: `C0B5TV2T43S → ecokaku-aidc`(csn 70417). ⚠️ 봇 유저(uSn 29)가 그 csn 멤버여야 실제 라우팅됨(`giip project set` 이 자동 부여).
+
+---
+
+## 4. 태스크 ↔ giip issue 매핑 (통일)
+| slack-bot(As-Is) | giip issue(To-Be) |
+| :-- | :-- |
+| taskId `YYYYMMDDHHMMSS` | **isn** (POST 생성 시 반환) |
+| task 파일 request/제목 | issue **title** |
+| 분석 계획 planContent | issue **content** (본문) |
+| status: pending/running/completed/cancelled | issue **status** (giip issue 표준 그대로 사용): `PENDING`→`READY`→`IN_PROGRESS`→`REVIEW`→`DONE` |
+| .agent/results/{id}.md 결과보고 | issue **코멘트**(giipIssueComments) |
+| tasklist.json | giip issue **목록 API**(GET ?status=) — 로컬 인덱스 폐기 대상 |
+| workflow 지정 | issue **agent_workflow** 필드 |
+| 대상 서버 | **target_lssn** |
+
+### giip issue 표준 status (확정: 이 집합만 사용, 커스텀 상태 신설 금지)
+`PENDING`(에이전트 큐) → `READY`(머신 디스패치 준비) → `IN_PROGRESS`(실행중) → `REVIEW`(사람 확인 대기) → `DONE`(완료).
+- 실측 정본: giipv3 `admin/giip-issues/[isn]/edit` status 드롭다운. (머신 디스패치는 별도 필드 `dispatch_status`.)
+- **취소/실패 전용 상태는 없다** → 취소/실패는 **코멘트로 사유 기록 + status=`REVIEW`(사람 판단 대기)** 또는 `DONE`(종료)로 처리. 커스텀 상태를 만들지 않는다(사용자 결정 2026-07-11).
+
+### 태스크 생성 우선순위 (확정, 2026-07-11)
+대화에서 "태스크를 만들어야 한다"고 판단될 때:
+1. **giip issue API 연결 가능** (계정 매핑 존재 + AK 취득 성공) → **giip issue 로 우선 등록**(POST /giipIssues → isn). 로컬 파일 생성 안 함(또는 미러만).
+2. **미연결**(계정 없음/네트워크/AK 실패) → **기존 로컬 타임스탬프 태스크**(`getTimestampId` + `.agent/tasks/{id}.md`) 로 폴백(무중단).
+- 즉 giip issue 를 SSOT 로 하되, 끊겨도 봇은 계속 동작(graceful degradation).
+
+### 생명주기 (To-Be)
+1. Slack 요청 수신 → 분석(planContent) → **POST /giipIssues**{title,content,status:`IN_PROGRESS`(즉시 실행) 또는 `PENDING`(큐),csn,agent_workflow} → **isn** 확보.
+2. Slack 스레드에 `isn` 회신(태스크 번호 = isn 으로 통일). — 규칙: [[feedback_task_number_in_slack]]
+3. subagent(claude CLI) 실행 → 완료 시 결과를 **코멘트**로 POST, **PUT status=`REVIEW`(사람 확인 필요) 또는 `DONE`(완료)**.
+4. 재작업 요청(같은 isn 지정) → 해당 issue 에 코멘트 추가 + status 를 `IN_PROGRESS`로 재오픈(로컬 updateTaskFile 대체). — [[feedback_task_number_reuse]]
+
+---
+
+## 5. Slack 에서 모든 giip API 호출 (범용 게이트웨이)
+- 신규 Slack 커맨드: `giip api <Verb> [jsondata]`
+  - 예: `giip api DomainList {"csn":47}` → `giipApi` 디스패처(`text=DomainList`, jsondata) 호출, 결과 JSON 요약 회신.
+  - 인증: §3 의 AK 자동첨부.
+- issue 전용 단축 커맨드(선택): `giip issue new "<title>"`, `giip issue done <isn>`, `giip issue list [status]`.
+
+---
+
+## 6. 위험 / 가드
+- ⚠️ **PUT 전체 덮어쓰기**([[reference_giip_issue_put_hazard]]): status 만 바꿀 때 title/content 유실 방지 → 봇은 **read(GET)→merge→PUT** 로 항상 전체 필드 채워 전송. (또는 status 전용 SP 신설 검토.)
+- **SK 보안**: `.env`/`.secrets` 비커밋, gitignore 확인([[reference_giipdb_secrets_standard]]).
+- **AK 발급 남용**: `AdminGetAK` 의 신규토큰 발급은 SK+로그인ID 2요소 일치일 때만. 로깅.
+- **한글 인코딩**: giipfaw 함수/SP UTF-8([[reference_giipdb_sql_utf8_mojibake]]).
+- **PUT/POST body 파싱**: giipDomainWhois#6 사례처럼 Hashtable/PSCustomObject 양쪽 처리 확인(giipIssues 는 이미 처리됨 L49).
+
+## 7. 신규 개발물 (구현 단계에서)
+1. **giipdb**: SP `pApiAdminGetAKbyLoginSK.sql` (§3-1). byAK 규약 → giipApi 로 자동 노출(함수 무수정).
+2. **slack-bot**: `giip-accounts.js` — 채널별 계정 매핑 로드/저장(`.secrets/giip-accounts.json`), `resolve(channelId)→{login_id,sk,csn}`, `setAccount(channelId, ...)` 영속화. 샘플 `giip-accounts.sample.json` 커밋.
+3. **slack-bot**: `giip-api.js` — { getAK(account), issueCreate, issueGet, issueUpdate, issueList, issueComment, apiCall(verb,jsondata) }. 계정별 AK 캐시 포함.
+4. **slack-bot**: `task-manager.js` 리팩터 — 로컬파일 생명주기를 giip issue 호출로 대체(또는 §8 듀얼). csn 은 채널 매핑에서.
+5. **slack-bot**: `index.js` — `giip api ...` / `giip issue ...` / `giip account set ...` 커맨드 라우팅, 회신에 isn 포함.
+6. **gitignore**: `slack-bot/.secrets/giip-accounts.json` 비커밋 확인.
+
+## 8. 마이그레이션 (단계)
+- **P0 (본 문서)**: 설계 확정. ✅
+- **P1**: ✅ **완료** — SP `pApiAdminGetAKbyAK`(라이브) + `giip-accounts.js`/`giip-api.js`/`giip-commands.js` + index.js 훅. `giip api`/`giip issue`/`giip account` 커맨드.
+- **P2**: ✅ **완료** — `giip-task.js` + task-manager 등록/완료/에러 훅. 태스크 생성 시 연결이면 issue(IN_PROGRESS) 우선 등록·isn 회신, 완료/에러 시 코멘트+REVIEW. 미연결 시 로컬 폴백(rule 40). (수정요청(reuseTaskId) 재오픈은 P2.1 후속.)
+- **P3**: **잔여 로컬 태스크 이관** — `.agent/tasks/`(및 `done/` 밖의 pending) 에 남은 태스크가 있으면 **giip issue 로 등록(POST) 후 로컬 파일은 done 처리**(`.agent/tasks/done/` 이동). 이관 완료 후 `tasklist.json`/`.agent/tasks` 는 미러 캐시로 강등(또는 폐기). 문서·규칙 갱신.
+  - ⚠️ 이 이관은 P1(API 클라이언트 + 계정 자격증명) 이 갖춰진 뒤 실행 가능. 자격증명 없이는 등록 불가.
+
+## 9. 결정 로그 (2026-07-11 사용자 확정)
+1. ✅ **status 집합**: giip issue 표준 그대로 `PENDING/READY/IN_PROGRESS/REVIEW/DONE`. 커스텀(취소·실패) 상태 신설 안 함 → 코멘트+REVIEW/DONE 로 처리. (§4)
+2. ✅ **AK 신규발급 허용**: 활성 AK 없으면 `AdminGetAK` 가 기존 로그인 처리처럼 **새 토큰 발급**해도 됨. (§3-1)
+3. ✅ **csn/계정 = Slack 채널별 매핑**: 채널→{login_id, sk, csn}. SK 도 매핑. 대화로 변경 시 설정 파일 영속화. (§3-2·§3-3)
+4. ✅ **로컬 `.agent/tasks` 처리 + 생성 우선순위**: 잔여 로컬 태스크는 **giip issue 등록 후 로컬 done** 처리(P3). 런타임 정책 = **giip issue 연결 시 우선 등록, 미연결 시 기존 타임스탬프 폴백**. (§4 "태스크 생성 우선순위", §8 P3)
+
+**→ 설계(P0) 전 항목 확정 완료. 다음은 P1 구현.**
+
+---
+### 부록 A — 근거(실측 소스)
+- 인증: `giipdb/Functions/lwGetUSNbyat.sql`(AK=tUserLogin.AccToken 24h / SK=tCorpUser.uSecretKey / fallback uaccesstoken), `SP/pApiUserLoginbyAK.sql`(→pUserLoginCheckGiip03).
+- issue API: `giipfaw/giipIssues/run.ps1`, SP `pApiGiipIssue{Put,Get,List,Delete}byAK`.
+- 봇 연동점: `slack-bot/task-manager.js`(getTimestampId/createTaskFile/startExecution/gitPushResult), `slack-bot/index.js`(L1510-1520).

--- a/slack-bot-minimax/docs/POSTMORTEM_task_queue_freeze.md
+++ b/slack-bot-minimax/docs/POSTMORTEM_task_queue_freeze.md
@@ -1,0 +1,76 @@
+# Postmortem — Task 큐 "멈춤"(READY 정체 / IN_PROGRESS 미표시)
+
+- 발생 인지: 2026-07-24
+- 대상: `Lowyworkenv/slack-bot` (라이브 운용본, pm2 `slack-bot`)
+- 증상 보고(요지): "🚀 明示的な依頼のため自動実行します（`go` 不要）。中断: `cancel giip-738`" 이 뜨는데
+  진행되는 게 없이 `READY` 로 멈춰 보인다. **언제부터 "처리 중(IN_PROGRESS)"이 안 보이나?**
+
+---
+
+## 1. 조사 시점의 라이브 실측
+
+`.task-state.json` (조사 시점):
+
+- `running`: **giip-738** `@2026-07-24T11:37:21.101Z` — 요청(11:37:15) 6초 뒤 실행 시작. 현재(11:41) `claude.exe` 서브에이전트 다수 생존 → **실제로 실행 중이었음**(멈춘 게 아님).
+- `pending`: **12건** (giip-611·634·643·645·649·652·657·661·674·728·730 + 구 `20260708…`).
+  전부 `queuedBehind`/`queuedAt` 마커 **없음**(0건).
+
+즉 giip-738 자체는 정상 실행 중이었고, "멈춤"으로 보인 실체는 **pending 에 쌓인 orphan 12건 + 표시상 오해** 였다.
+
+## 2. 근본 원인
+
+### (A) "언제부터 IN_PROGRESS 가 안 보이나" — 의도된 설계 변경(2026-07-14)
+
+- `77430958` (07-14) — *명시적 명령형은 분석 후 자동 실행 + giip `IN_PROGRESS` 전이를 실행 시점으로 이관*
+- `8d6b0a0a` (07-14) — *신규 issue 는 `PENDING` 로 생성*
+
+이전엔 **요청/분석 즉시** 이슈를 `IN_PROGRESS` 로 찍어서 "아무것도 안 도는데 IN_PROGRESS·`go` 요구" 모순이 있었다.
+이를 고쳐 `IN_PROGRESS` 전이를 **실제 서브에이전트 실행 시작**(`handlers.js` `startTaskExecution`) 시점으로 미뤘다.
+결과적으로 분석중·큐 대기·실행 미개시 구간은 전부 `PENDING/READY` 로 보이고,
+`IN_PROGRESS` 는 서브에이전트가 실제로 도는 짧은 구간에만 보인다. **회귀가 아니라 설계상 결과.**
+
+부수적으로 봇이 붙여준 "복원 이력"의 `#738 [READY]` 는 **분석 시점 스냅샷**(IN_PROGRESS 전이 6초 전)이지 라이브 상태가 아니다.
+또한 로컬 `.agent/tasks/<id>.md` frontmatter 의 `status:` 는 생성 시 1회만 기록되고 running 으로 갱신되지 않아, 파일만 보면 항상 pending 처럼 보인다.
+
+### (B) 진짜 "멈춤" 위험 ① — ghost-occupier freeze (핵심 결함)
+
+직렬 실행이라, 다른 태스크가 작업트리를 점유 중일 때 들어온 태스크는 `pending` 에
+`queuedBehind` 마커와 함께 적재되고, **점유 태스크의 `onComplete`/`onError` 가 `drainNextQueued` 를 호출**해야 자동 기동된다.
+그런데 **점유 태스크 실행 도중 봇이 재시작**되면 그 서브프로세스가 죽어 `onComplete` 가 영영 발화하지 않는다.
+→ `queuedBehind` 대기 태스크는 누구도 기동하지 않아 **영구 동결**. 기동 시 `reconcileTaskState()` 는 `running` 만 청소할 뿐 이 복구를 하지 않았다.
+
+### (C) 진짜 "멈춤" 위험 ② — orphan pending 무한 누적
+
+`reconcileTaskState()` 는 `running` 만 reconcile 하고 **`pending` 은 전혀 손대지 않았다.**
+세션·수동·타 클론 등 다른 경로로 이미 처리된 태스크의 pending 항목이 정리되지 않고 무한 누적 → 조사 시점 12건.
+이것이 대시보드/체감상 "READY 로 방치된 것들"의 실체다.
+
+## 3. 조치 (이 PR)
+
+`index.js` `reconcileTaskState()` + 신규 `recoverQueuedOnStartup()`, `handlers.js` export:
+
+1. **pending 스윕** — `reconcileTaskState()` 가 `done/`·`cancel/` 로 이미 해소된 pending 항목을 제거.
+   진짜 미착수 backlog(파일이 `tasks/` 직하)는 건드리지 않는다(마커 없는 pending = 수동 `go` 대기 설계 존중).
+2. **ghost-occupier 해동** — `recoverQueuedOnStartup()` 를 **기동 직후 + 주기 reconcile(10분)** 에 호출.
+   `running` 이 비었는데 `queuedBehind` 대기 태스크가 있으면 = 동결 상태이므로 `drainNextQueued()` 를 한 번 叩いて 직렬 큐를 되살린다.
+   실행 중인 태스크가 있으면 통상 경로에 맡긴다(직렬 보장 유지).
+
+두 조치 모두 **재실행 위험을 회피**한다: 스윕은 이미 해소된 것만 제거하고, 해동은 원래 자동 실행 대상(`queuedBehind`)만 다룬다.
+마커 없는 orphan backlog 를 임의로 자동 실행하지는 않는다.
+
+### 검증(반영 절차)
+
+라이브 반영은 **워킹카피 sync + `pm2 restart slack-bot`** 필요(자동 아님). 재시작 시:
+- 조사 시점 pending 12건 중 `done/`·`cancel/` 로 해소된 것은 자동 제거된다.
+- (해당 시) 동결 큐가 자동 해동된다.
+- 로그: `[Bot] reconcile: stale pending … 제거`, `[Bot] startup-recovery: 凍結された待機タスク …`.
+
+## 4. giip-fde-agent(템플릿) 점검 결과
+
+`giip-fde-agent/slack-bot`(사용자 직접 관리 템플릿)은 **더 이전 버전**:
+- `reconcileTaskState()` 가 인자 없이 `running` 만 청소 — **staleMinutes 개념/주기 reconcile 없음**, **pending 스윕 없음**.
+- `drainNextQueued`/`queuedBehind` **큐·직렬 드레인 메커니즘 자체가 부재** → ghost-occupier freeze 형태는 없으나,
+  애초에 직렬 대기열 자동 기동이 없고 stale-running 정리도 라이브본보다 약하다.
+
+→ 동일 부류의 취약(재시작 시 pending 미정리)은 존재. 라이브본과 동등화하려면 위 조치 + 큐 메커니즘 포팅이 필요.
+(메모리 규칙상 템플릿은 명시 요청 시에만 포팅하므로, 이 PR 에는 포함하지 않고 별도 승인 대기.)

--- a/slack-bot-minimax/docs/RCA_result_url_missing.md
+++ b/slack-bot-minimax/docs/RCA_result_url_missing.md
@@ -1,0 +1,41 @@
+# RCA: 완료보고 GitHub URL이 사라진 문제
+
+- 발생 인지: 2026-07-03
+- 영향: `giipclaude` Slack 봇의 작업 완료보고에서 **어제까지 붙던 GitHub 결과 URL이 오늘부터 누락**
+- 상태: 수정·검증 완료 (Lowyworkenv `5d2656d5`, giip-dev-agent `f047b43`), task(20260703143321)
+
+## 증상
+완료보고가 어제(예: task `20260702145007`)는 정상이었다:
+```
+✅ 작업 완료: 20260702145007
+📋 태스크 결과 보고서: https://github.com/LowyShin/Lowyworkenv/blob/master/.agent/tasks/done/20260702145007.md
+```
+오늘부터는 URL 없이 파일 경로만 나오는 폴백 메시지로 바뀌었다.
+
+## 근본 원인 (메모리 문제 아님 — 코드 버그)
+완료보고의 URL은 `task-manager.js`의 `gitPushResult()`가 **git push 성공 시에만** 반환한다.
+호출부 `index.js`는 `if (githubUrl)` 이 거짓이면 URL 없는 폴백 메시지를 보낸다.
+
+`gitPushResult()`가 null을 반환한 연쇄:
+1. slack-bot 런타임 상태 파일(`.bot-threads.json`, `.task-state.json`, `tasklist.json`)이 **git 추적 대상**이었다(Lowyworkenv). 봇이 돌 때마다 수정 → **작업트리 상시 dirty**.
+2. `gitPushResult`가 `git pull --rebase origin <branch>` 실행 — 그러나 **dirty 트리에선 rebase가 "cannot pull with rebase: You have unstaged changes"로 거부**된다. 게다가 코드는 **pull 결과를 확인하지 않았다.**
+3. 그 상태에서 origin이 로컬보다 앞서 있으면 이어지는 `git push`가 **non-fast-forward로 거부** → status≠0 → **null 반환**.
+4. → 완료보고가 URL 없는 폴백으로.
+
+### 왜 어제는 되고 오늘은 안 됐나
+- 어제: origin이 봇보다 앞서지 않아 **fast-forward push 성공** → URL 정상.
+- 오늘: origin이 앞서감(예: 다른 세션/사람이 같은 브랜치에 push) → 봇 로컬이 뒤처짐 → dirty라 rebase 불가 → push 거부 → URL 증발. **한 번 뒤처지면 스스로 못 따라잡아 계속 실패**한다.
+
+## 수정
+1. **`gitPushResult` 견고화** (양쪽 repo): `git pull --rebase --autostash` 로 dirty여도 rebase 가능하게 하고, push 거부 시 `fetch` 후 rebase+push **1회 재시도**. rebase 실패 시 `rebase --abort`로 중간상태 방지.
+2. **런타임 상태 untrack** (Lowyworkenv): `.gitignore`에 3파일 추가 + `git rm --cached`. (giip는 이미 미추적 — `.gitignore` 패턴만 보강.)
+3. **폴백 메시지 개선** (양쪽): push 실패 시 "원격 미반영이라 URL 미생성" 사유 명시로 조용한 손실 방지.
+
+## 검증
+- dirty 트리(7파일)에서 `git pull --rebase --autostash origin master` → **exit 0**(구버그의 거부 지점 통과), 편집 보존.
+- 수정 파일 `node --check` 전부 통과.
+- 봇 pm2 재시작(PID 34796) 후 Socket Mode 정상 접속.
+
+## 재발 방지
+- 규칙: `Lowyworkenv/.agent/rules/38_slackbot_push_reliability.md`.
+- 핵심: **런타임 상태는 절대 git 추적하지 않는다** + **push는 autostash·재시도로 견고하게**. 완료보고 URL은 push 성공에 의존하므로 push 신뢰성이 곧 보고 신뢰성이다.

--- a/slack-bot-minimax/giip-accounts.js
+++ b/slack-bot-minimax/giip-accounts.js
@@ -1,0 +1,80 @@
+/**
+ * giip-accounts.js — Slack 채널별 giip 계정 매핑(로그인ID + SK + csn) 로드/저장.
+ * 설계: docs/DESIGN_slackbot_giip_issue_integration.md §3-2·§3-3. 규칙: .agent/rules/39,40.
+ *
+ * 비밀(SK)은 .secrets/giip-accounts.json(비커밋)에만. 샘플은 giip-accounts.sample.json.
+ * AK 는 저장하지 않는다(로그인마다 바뀜) — 런타임에 giip-api.getAK 로 도출.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const SECRETS_DIR = path.join(__dirname, '.secrets');
+const ACCOUNTS_FILE = path.join(SECRETS_DIR, 'giip-accounts.json');
+const DEFAULT_API_BASE = 'https://giipfaw.azurewebsites.net/api';
+
+function load() {
+  try {
+    return JSON.parse(fs.readFileSync(ACCOUNTS_FILE, 'utf8'));
+  } catch {
+    return { GIIP_API_BASE: DEFAULT_API_BASE, default: null, channels: {} };
+  }
+}
+
+function save(cfg) {
+  fs.mkdirSync(SECRETS_DIR, { recursive: true });
+  fs.writeFileSync(ACCOUNTS_FILE, JSON.stringify(cfg, null, 2));
+}
+
+function apiBase() {
+  return load().GIIP_API_BASE || process.env.GIIP_API_BASE || DEFAULT_API_BASE;
+}
+
+/**
+ * 채널 → 계정 {login_id, sk, csn, apiBase} 해석.
+ * 순서: 채널 매핑 → default → env(GIIP_LOGIN_ID/GIIP_SK/GIIP_CSN). 없으면 null(=미연결).
+ */
+function resolve(channelId) {
+  const cfg = load();
+  const base = cfg.GIIP_API_BASE || process.env.GIIP_API_BASE || DEFAULT_API_BASE;
+  const acct =
+    (channelId && cfg.channels && cfg.channels[channelId]) ||
+    cfg.default ||
+    null;
+  if (acct && acct.login_id && acct.sk) {
+    return { login_id: acct.login_id, sk: acct.sk, csn: acct.csn ?? null, apiBase: base };
+  }
+  if (process.env.GIIP_LOGIN_ID && process.env.GIIP_SK) {
+    return {
+      login_id: process.env.GIIP_LOGIN_ID,
+      sk: process.env.GIIP_SK,
+      csn: process.env.GIIP_CSN ? Number(process.env.GIIP_CSN) : null,
+      apiBase: base,
+    };
+  }
+  return null;
+}
+
+/** giip issue 연결 가능 여부(계정 존재). */
+function isConnected(channelId) {
+  return !!resolve(channelId);
+}
+
+/**
+ * 대화로 계정 설정/변경 → 파일 영속화. channelId 없거나 asDefault=true 면 default 갱신.
+ */
+function setAccount(channelId, { login_id, sk, csn } = {}, asDefault = false) {
+  const cfg = load();
+  cfg.GIIP_API_BASE = cfg.GIIP_API_BASE || DEFAULT_API_BASE;
+  const acct = { login_id, sk };
+  if (csn != null && csn !== '') acct.csn = Number(csn);
+  if (asDefault || !channelId) {
+    cfg.default = acct;
+  } else {
+    cfg.channels = cfg.channels || {};
+    cfg.channels[channelId] = acct;
+  }
+  save(cfg);
+  return acct;
+}
+
+module.exports = { load, save, resolve, isConnected, setAccount, apiBase, ACCOUNTS_FILE };

--- a/slack-bot-minimax/giip-accounts.sample.json
+++ b/slack-bot-minimax/giip-accounts.sample.json
@@ -1,0 +1,9 @@
+{
+  "GIIP_API_BASE": "https://giipfaw.azurewebsites.net/api",
+  "_comment": "실제 파일은 .secrets/giip-accounts.json (비커밋). SK 는 tCorpUser.uSecretKey. AK 는 저장하지 않는다(런타임 도출). 대화에서 'giip account set <login> <sk> [csn]' 로 갱신 가능.",
+  "default": { "login_id": "you@example.com", "sk": "<your-secret-key>", "csn": 47 },
+  "channels": {
+    "C0EXAMPLE1": { "login_id": "you@example.com", "sk": "<your-secret-key>", "csn": 47 },
+    "C0EXAMPLE2": { "login_id": "team@example.com", "sk": "<other-secret-key>", "csn": 70 }
+  }
+}

--- a/slack-bot-minimax/giip-api.js
+++ b/slack-bot-minimax/giip-api.js
@@ -1,0 +1,198 @@
+/**
+ * giip-api.js — giip API 클라이언트(의존성 없음, 내장 https).
+ * 설계: docs/DESIGN_slackbot_giip_issue_integration.md. 규칙: .agent/rules/39(AK 도출),40(생성 우선).
+ *
+ * 인증: 전용 이슈 엔드포인트는 SK 를 그대로 x-api-key 로 쓴다(익명, 실측 REPORT_giip_issue_api_test_20260708).
+ * AK 도출(AdminGetAK) 안 함 — SK 를 AT(token) 자리에 넣으면 401(SK≠AT 혼동 금지, rule 39).
+ */
+const https = require('https');
+const { URL } = require('url');
+const accounts = require('./giip-accounts');
+
+const AK_TTL_MS = 20 * 60 * 60 * 1000; // 20h
+const akCache = new Map(); // login_id → { ak, csn, usn, fetchedAt }
+
+function request(method, urlStr, { headers = {}, body = null, timeoutMs = 30000 } = {}) {
+  return new Promise((resolve, reject) => {
+    const u = new URL(urlStr);
+    const data = body == null ? null : typeof body === 'string' ? body : JSON.stringify(body);
+    const opts = {
+      method,
+      hostname: u.hostname,
+      port: u.port || 443,
+      path: u.pathname + u.search,
+      headers: { ...headers },
+    };
+    if (data) opts.headers['Content-Length'] = Buffer.byteLength(data);
+    const req = https.request(opts, (res) => {
+      let chunks = '';
+      res.on('data', (d) => (chunks += d));
+      res.on('end', () => {
+        let parsed = chunks;
+        try { parsed = JSON.parse(chunks); } catch { /* keep string */ }
+        resolve({ status: res.statusCode, body: parsed, raw: chunks });
+      });
+    });
+    req.on('error', reject);
+    req.setTimeout(timeoutMs, () => req.destroy(new Error('giip-api request timeout')));
+    if (data) req.write(data);
+    req.end();
+  });
+}
+
+function form(params) {
+  return Object.entries(params)
+    .filter(([, v]) => v != null)
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join('&');
+}
+
+/**
+ * 인증 토큰 취득. rule 39 + 실측(REPORT_giip_issue_api_test_20260708):
+ * 전용 이슈 엔드포인트(/api/giipIssues 등)는 **SK 를 그대로 x-api-key 로** 인증한다(익명).
+ * AK 도출(AdminGetAK)은 불필요하며, SK 를 AdminGetAK 의 token(=AT 자리)으로 넣으면 401 이 난다
+ * (SK≠AT 혼동 금지). 따라서 네트워크 호출 없이 SK 를 그대로 반환한다.
+ */
+async function getAK(account) {
+  return { ak: account.sk, csn: account.csn ?? null, usn: null, fetchedAt: Date.now() };
+}
+
+/** giipIssues(전용함수) 호출. x-api-key=AK, 401 시 1회 강제 갱신 재시도. */
+async function issueApi(account, method, { query = '', body = null } = {}) {
+  const base = account.apiBase || accounts.apiBase();
+  let ak = (await getAK(account)).ak;
+  const url = `${base}/giipIssues${query}`;
+  let res = await request(method, url, {
+    headers: { 'x-api-key': ak, 'Content-Type': 'application/json' },
+    body,
+  });
+  if (res.status === 401) {
+    ak = (await getAK(account, { force: true })).ak;
+    res = await request(method, url, {
+      headers: { 'x-api-key': ak, 'Content-Type': 'application/json' },
+      body,
+    });
+  }
+  return res;
+}
+
+async function issueGet(account, isn) {
+  const res = await issueApi(account, 'GET', { query: `?isn=${encodeURIComponent(isn)}` });
+  if (res.status !== 200) throw new Error(`issueGet 실패: ${res.body?.error || res.status}`);
+  return res.body?.issue || {};
+}
+
+async function issueList(account, { status = '', csn = '' } = {}) {
+  const q = [];
+  if (status) q.push(`status=${encodeURIComponent(status)}`);
+  if (csn) q.push(`csn=${encodeURIComponent(csn)}`);
+  const res = await issueApi(account, 'GET', { query: q.length ? `?${q.join('&')}` : '' });
+  if (res.status !== 200) throw new Error(`issueList 실패: ${res.body?.error || res.status}`);
+  return res.body?.issues || [];
+}
+
+// 생성 기본값은 PENDING(대기열). '생성'은 착수가 아니라 등록이므로, 무인 처리기(:20/:40, PENDING/READY만 픽업)가
+// 집을 수 있는 상태로 둔다. 착수(IN_PROGRESS)가 필요한 호출자(task 자동연동 등)는 status 를 명시적으로 넘긴다.
+async function issueCreate(account, { title, content, status = 'PENDING', csn, target_lssn = null, agent_workflow = null }) {
+  const res = await issueApi(account, 'POST', {
+    body: { title, content, status, csn: csn ?? account.csn, target_lssn, agent_workflow },
+  });
+  if (res.status !== 200 || !res.body?.isn) throw new Error(`issueCreate 실패: ${res.body?.error || res.status}`);
+  return res.body; // { success, isn, message }
+}
+
+/** PUT 은 전체 덮어쓰기 → read-modify-write 로 미지정 필드 보존(설계 §6). */
+async function issueUpdate(account, fields) {
+  const cur = await issueGet(account, fields.isn);
+  const merged = {
+    isn: fields.isn,
+    title: fields.title ?? cur.title,
+    content: fields.content ?? cur.content,
+    status: fields.status ?? cur.status,
+    csn: fields.csn ?? cur.CSn ?? cur.csn ?? account.csn,
+    target_lssn: fields.target_lssn ?? cur.target_lssn ?? null,
+    agent_workflow: fields.agent_workflow ?? cur.agent_workflow ?? null,
+  };
+  const res = await issueApi(account, 'PUT', { body: merged });
+  if (res.status !== 200) throw new Error(`issueUpdate 실패: ${res.body?.error || res.status}`);
+  return res.body;
+}
+
+async function issueComment(account, isn, content) {
+  const base = account.apiBase || accounts.apiBase();
+  let ak = (await getAK(account)).ak;
+  const doPost = (token) =>
+    request('POST', `${base}/giipIssueComments`, {
+      headers: { 'x-api-key': token, 'Content-Type': 'application/json' },
+      body: { isn: Number(isn), content },
+    });
+  let res = await doPost(ak);
+  if (res.status === 401) { ak = (await getAK(account, { force: true })).ak; res = await doPost(ak); }
+  if (res.status !== 200) throw new Error(`issueComment 실패: ${res.body?.error || res.status}`);
+  return res.body;
+}
+
+/**
+ * GET /giipIssueComments?isn= — 이슈의 모든 코멘트를 시간순(regdate ASC)으로 반환한다.
+ * giip issue 재처리 시 로컬 태스크 파일이 done/ 이동·타 클론 처리 등으로 없더라도
+ * DB(SSOT)에서 전체 코멘트 이력을 복원해 처리 맥락으로 쓰기 위한 조회 경로.
+ * 반환: [{ cSn, isn, content, author, issuetype, regdate }, ...]
+ */
+async function issueComments(account, isn) {
+  const base = account.apiBase || accounts.apiBase();
+  let ak = (await getAK(account)).ak;
+  const doGet = (token) =>
+    request('GET', `${base}/giipIssueComments?isn=${encodeURIComponent(isn)}`, {
+      headers: { 'x-api-key': token, 'Content-Type': 'application/json' },
+    });
+  let res = await doGet(ak);
+  if (res.status === 401) { ak = (await getAK(account, { force: true })).ak; res = await doGet(ak); }
+  if (res.status !== 200) throw new Error(`issueComments 실패: ${res.body?.error || res.status}`);
+  return res.body?.comments || [];
+}
+
+/**
+ * 봇 유저(SK→usn)를 @csn 의 멤버로 giip DB(tUserPerCorp)에 멱등 등록한다.
+ * → `giip project set <p> <csn>` 이 로컬 map 저장뿐 아니라 DB 멤버십까지 완결하게 해,
+ *   pApiGiipIssuePutbyAK 의 멤버십 게이트가 홈 CSN(47)으로 클램프하는 문제를 자동 해소한다.
+ * SP: pApiUserPerCorpGrantBotbySk (권한 게이트: 봇 계정 또는 기존 tCorpUserRel 멤버만, 대상=자기 자신).
+ * 호출: giipApiSk2  text="UserPerCorpGrantBot"  jsondata={"csn":<n>}  (ISN-161 auto-append 로 전달).
+ * @returns {{ ok:boolean, rstVal:number|null, already:boolean, msg:string, raw:any }}
+ */
+async function grantBotCsn(account, csn) {
+  const n = Number(csn);
+  if (!Number.isInteger(n)) throw new Error('csn 은 정수여야 합니다.');
+  const raw = await apiCall(account, 'UserPerCorpGrantBot', { csn: n });
+  // giipApiSk2 응답: { data: [ { RstVal, Proc_MSG, usn, csn, already } ], debug } 또는 { error }
+  const row = raw && Array.isArray(raw.data) ? raw.data[0] : null;
+  const rstVal = row && row.RstVal != null ? Number(row.RstVal) : null;
+  const already = !!(row && (row.already === true || row.already === 1));
+  const msg = (row && row.Proc_MSG) || (raw && raw.error) || (raw && raw.message) || '';
+  return { ok: rstVal === 200, rstVal, already, msg, raw };
+}
+
+/** 범용: 임의 giip API 를 giipApi 디스패처로 호출(text=Verb). */
+async function apiCall(account, verb, jsondata = null) {
+  const base = account.apiBase || accounts.apiBase();
+  // SK 기반 디스패처(giipApiSk2). SK 를 x-api-key + token 으로 직접 인증(AK 도출 안 함).
+  const params = { text: verb, token: account.sk, usertoken: account.sk };
+  if (jsondata) params.jsondata = typeof jsondata === 'string' ? jsondata : JSON.stringify(jsondata);
+  const res = await request('POST', `${base}/giipApiSk2`, {
+    headers: { 'x-api-key': account.sk, 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: form(params),
+  });
+  return res.body;
+}
+
+module.exports = {
+  getAK,
+  issueGet,
+  issueList,
+  issueCreate,
+  issueUpdate,
+  issueComment,
+  issueComments,
+  apiCall,
+  grantBotCsn,
+  _akCache: akCache,
+};

--- a/slack-bot-minimax/giip-commands.js
+++ b/slack-bot-minimax/giip-commands.js
@@ -1,0 +1,233 @@
+/**
+ * giip-commands.js — Slack `giip ...` 커맨드 핸들러 (자립 모듈).
+ * index.js 는 한 줄 훅으로 연결:
+ *   const gc = await handleGiipCommand(text, channelId); if (gc.handled) { await reply(gc.text); return; }
+ * 설계: docs/DESIGN_slackbot_giip_issue_integration.md §5. 규칙 39/40.
+ */
+const accounts = require('./giip-accounts');
+const giip = require('./giip-api');
+const config = require('./config');
+
+function code(obj, max = 1800) {
+  return '```\n' + JSON.stringify(obj, null, 2).slice(0, max) + '\n```';
+}
+
+/**
+ * @returns {Promise<{handled:boolean, text?:string}>}
+ */
+async function handleGiipCommand(rawText, channelId) {
+  const text = (rawText || '').trim();
+  const m = text.match(/^giip\s+(\S+)\s*([\s\S]*)$/i);
+  if (!m) return { handled: false };
+  const sub = m[1].toLowerCase();
+  const rest = (m[2] || '').trim();
+
+  // ── giip account ... — 채널 계정 매핑(대화로 변경 → .secrets 영속화) ──
+  if (sub === 'account') {
+    const setM = rest.match(/^set(-default)?\s+(\S+)\s+(\S+)\s*(\d+)?/i);
+    if (setM) {
+      const asDefault = !!setM[1];
+      const login_id = setM[2];
+      const sk = setM[3];
+      const csn = setM[4] || null;
+      accounts.setAccount(asDefault ? null : channelId, { login_id, sk, csn }, asDefault);
+      return {
+        handled: true,
+        text: `✅ giip 계정 저장(${asDefault ? 'default' : channelId}) — login=${login_id}${csn ? `, csn=${csn}` : ''}.\n⚠️ 보안: SK 가 포함된 이 메시지는 삭제하세요.`,
+      };
+    }
+    if (/^(show|status)/i.test(rest)) {
+      const acct = accounts.resolve(channelId);
+      return {
+        handled: true,
+        text: acct ? `login=${acct.login_id}, csn=${acct.csn ?? '-'} (SK 숨김)` : '계정 미설정',
+      };
+    }
+    return {
+      handled: true,
+      text: '사용법: `giip account set <login_id> <sk> [csn]` | `set-default <login_id> <sk> [csn]` | `show`',
+    };
+  }
+
+  // ── giip project ... — 프로젝트명 ↔ csn 매핑 관리(project-csn.json, 재시작 불필요) ──
+  //   giip 계정과 무관하므로 account 확인 게이트보다 먼저 처리한다.
+  //   `<프로젝트명> issue 등록 <내용>` 이 어떤 csn 으로 등록되는지를 여기서 관리.
+  if (sub === 'project' || sub === 'proj' || sub === 'csn') {
+    const pm = rest.match(/^(set|add|del|delete|rm|remove|list|ls|show)?\s*([\s\S]*)$/i);
+    const action = (pm && pm[1] ? pm[1].toLowerCase() : 'list');
+    const pargs = pm ? (pm[2] || '').trim() : '';
+    const USAGE = '사용법: `giip project set <프로젝트명> <csn>` | `giip project list` | `giip project del <프로젝트명>`';
+    try {
+      if (action === 'set' || action === 'add') {
+        const sm = pargs.match(/^(\S+)\s+(-?\d+)$/);
+        if (!sm) return { handled: true, text: USAGE };
+        const { name, csn } = config.setProjectCsn(sm[1], sm[2]);
+        // ── DB 멤버십 자동 부여 ──
+        // map 저장만으로는 pApiGiipIssuePutbyAK 의 멤버십 게이트가 홈 CSN(47)으로 클램프한다.
+        // 봇 SK 로 pApiUserPerCorpGrantBotbySk 를 호출해 tUserPerCorp 에 (봇usn, csn) 을 멱등 부여하면
+        // 그 즉시 그 csn 으로 라우팅된다(수동 시드/재배포 불필요). 계정 미설정·실패는 비치명(map 은 저장됨).
+        let grantLine = '';
+        const acctForGrant = accounts.resolve(channelId);
+        if (Number(csn) === 47) {
+          grantLine = '\n(홈 CSN 47 은 항상 허용되므로 멤버십 부여 불필요)';
+        } else if (!acctForGrant) {
+          grantLine = '\n⚠️ giip 계정 미설정이라 DB 멤버십은 부여하지 못했습니다. `giip account set ...` 후 다시 `set` 하세요.';
+        } else {
+          try {
+            const g = await giip.grantBotCsn(acctForGrant, csn);
+            if (g.ok) grantLine = g.already
+              ? `\n🟢 DB 멤버십 이미 존재 (tUserPerCorp usn↔csn ${csn}).`
+              : `\n🟢 DB 멤버십 부여 완료 (tUserPerCorp += csn ${csn}). 다음 등록부터 바로 반영.`;
+            else grantLine = `\n⚠️ DB 멤버십 부여 실패(RstVal=${g.rstVal ?? '?'}): ${g.msg || '알 수 없음'}. map 은 저장됨.`;
+          } catch (e) {
+            grantLine = `\n⚠️ DB 멤버십 부여 호출 오류: ${e.message}. map 은 저장됨.`;
+          }
+        }
+        return {
+          handled: true,
+          text: `✅ 프로젝트 CSN 매핑 저장: \`${name}\` → csn ${csn}\n이제 \`${name} issue 등록 <내용>\` 은 csn ${csn} 로 등록됩니다(봇 재시작 불필요).${grantLine}`,
+        };
+      }
+      if (action === 'del' || action === 'delete' || action === 'rm' || action === 'remove') {
+        const name = pargs.split(/\s+/)[0];
+        if (!name) return { handled: true, text: USAGE };
+        const ok = config.deleteProjectCsn(name);
+        return { handled: true, text: ok ? `✅ 매핑 삭제: \`${name.toLowerCase()}\`` : `⚠️ \`${name.toLowerCase()}\` 매핑이 없습니다.` };
+      }
+      // list / ls / show / (인자 없음)
+      const map = config.listProjectCsn();
+      const keys = Object.keys(map);
+      const body = keys.length ? keys.map((k) => `• \`${k}\` → csn ${map[k]}`).join('\n') : '(등록된 매핑 없음)';
+      return { handled: true, text: `📋 프로젝트 → CSN 매핑 (project-csn.json)\n${body}\n\n${USAGE}` };
+    } catch (e) {
+      return { handled: true, text: `❌ ${e.message}\n${USAGE}` };
+    }
+  }
+
+  // ── giip channel ... — 채널 → 기본 프로젝트 고정 매핑(channel-project.json, 재시작 불필요) ──
+  //   「이 채널의 발화는 모두 <project> 로 처리」. giip 계정과 무관하므로 account 게이트보다 먼저 처리.
+  //   채널ID 생략 시 현재 채널에 적용. Rule 32 우선순위: 명시적 접두어 > 채널 고정.
+  if (sub === 'channel' || sub === 'ch') {
+    const cm = rest.match(/^(set|del|delete|rm|remove|list|ls|show)?\s*([\s\S]*)$/i);
+    const action = (cm && cm[1] ? cm[1].toLowerCase() : 'list');
+    const cargs = cm ? (cm[2] || '').trim() : '';
+    const USAGE = '사용법: `giip channel set <프로젝트명> [채널ID]` | `giip channel list` | `giip channel del [채널ID]`';
+    try {
+      if (action === 'set') {
+        // `set <프로젝트명> [채널ID]` — 채널ID 생략 시 현재 채널.
+        const sm = cargs.match(/^(\S+)(?:\s+(\S+))?$/);
+        if (!sm) return { handled: true, text: USAGE };
+        const project = sm[1];
+        const target = sm[2] || channelId;
+        if (!target) return { handled: true, text: '채널ID를 확인할 수 없습니다. `giip channel set <프로젝트명> <채널ID>` 로 명시하세요.' };
+        const { channelId: cid, project: pj } = config.setChannelProject(target, project);
+        const csn = config.resolveProjectCsn(pj);
+        return {
+          handled: true,
+          text: `✅ 채널 고정 매핑 저장: \`${cid}\` → \`${pj}\`${csn != null ? ` (csn ${csn})` : ' (project-csn.json 미등록 → account 기본 csn)'}\n이제 이 채널의 접두어 없는 메시지는 모두 \`${pj}\` 로 처리됩니다(봇 재시작 불필요). 명시적 프로젝트 접두어는 계속 우선합니다.`,
+        };
+      }
+      if (action === 'del' || action === 'delete' || action === 'rm' || action === 'remove') {
+        const target = cargs.split(/\s+/)[0] || channelId;
+        if (!target) return { handled: true, text: USAGE };
+        const ok = config.deleteChannelProject(target);
+        return { handled: true, text: ok ? `✅ 채널 매핑 삭제: \`${target}\`` : `⚠️ \`${target}\` 매핑이 없습니다.` };
+      }
+      // list / ls / show / (인자 없음)
+      const map = config.listChannelProject();
+      const keys = Object.keys(map);
+      const body = keys.length
+        ? keys.map((k) => {
+            const csn = config.resolveProjectCsn(map[k]);
+            return `• \`${k}\` → \`${map[k]}\`${csn != null ? ` (csn ${csn})` : ''}${k === channelId ? ' ← 현재 채널' : ''}`;
+          }).join('\n')
+        : '(등록된 매핑 없음)';
+      return { handled: true, text: `📌 채널 → 기본 프로젝트 매핑 (channel-project.json)\n${body}\n\n${USAGE}` };
+    } catch (e) {
+      return { handled: true, text: `❌ ${e.message}\n${USAGE}` };
+    }
+  }
+
+  const acct = accounts.resolve(channelId);
+  if (!acct) {
+    return {
+      handled: true,
+      text: '⚠️ giip 계정 미설정. `giip account set <login_id> <sk> [csn]` 로 등록하세요(DM 권장).',
+    };
+  }
+
+  // ── giip issue ... ──
+  if (sub === 'issue') {
+    // 자연어 의뢰 감지: `giip issue #604 <자연어 작업 지시>` 형식(에이전트 보고문을 그대로 복붙).
+    //   - 번호만 → get(상세 조회)
+    //   - 번호 뒤에 지시문이 붙으면 → 커맨드로 소비하지 않고(handled:false) 태스크 라우팅으로 넘겨
+    //     에이전트가 "이슈 내용 확인 → 작업 → 코멘트"까지 수행하게 한다.
+    //   (기존엔 '#604 …' 가 알 수 없는 action → list 로 떨어져 rest 전체가 status 필터가 되고,
+    //    존재하지 않는 status 라 목록 0건 → '(이슈 없음)' 오답을 냈다. rule 39/40.)
+    const leadNum = rest.match(/^#?(\d+)\b\s*([\s\S]*)$/);
+    if (leadNum) {
+      const after = (leadNum[2] || '').trim();
+      if (after) return { handled: false }; // 자연어 지시 → 태스크 경로(handleChannelMention 이 이어서 처리)
+      try { const i = await giip.issueGet(acct, Number(leadNum[1])); return { handled: true, text: code(i, 1500) }; }
+      catch (e) { return { handled: true, text: `❌ ${e.message}` }; }
+    }
+    // `giip issue 등록 <내용>` → giipprj 등록 경로와 '동일하게' 위임(handled:false).
+    //   등록/登録/register 는 list status 필터가 아니라 '등록 동사'다. 여기서 소비하면
+    //   im 의 (\w+) 가 한글 '등록'을 못 잡아 action=list, arg='등록 …' 이 되고 status 0건 →
+    //   '(이슈 없음)' 오답을 냈다(rule 39/40). handleChannelMention 의 issueTrigger 가 이어받아
+    //   분석→작업지시서→READY 등록한다. 구분자(공백/콜론/말미) 필수로 '등록됐어?' 질문 오폭 방지
+    //   (JS \b 는 ASCII 전용이라 한글 경계 미검출 → 명시 구분자 요구).
+    if (/^(?:등록|登録|register)(?:\s+|\s*[:：]\s*|$)/i.test(rest)) return { handled: false };
+    const im = rest.match(/^(\w+)?\s*([\s\S]*)$/);
+    const action = (im && im[1] ? im[1] : 'list').toLowerCase();
+    const arg = im ? (im[2] || '').trim() : '';
+    try {
+      if (action === 'new' || action === 'create') {
+        const title = arg.replace(/^["']|["']$/g, '').trim() || '(무제)';
+        const r = await giip.issueCreate(acct, { title, content: title, status: 'IN_PROGRESS' });
+        return { handled: true, text: `✅ 이슈 생성 #${r.isn} — ${title}` };
+      }
+      if (action === 'done') { await giip.issueUpdate(acct, { isn: Number(arg), status: 'DONE' }); return { handled: true, text: `✅ #${arg} → DONE` }; }
+      if (action === 'review') { await giip.issueUpdate(acct, { isn: Number(arg), status: 'REVIEW' }); return { handled: true, text: `✅ #${arg} → REVIEW` }; }
+      if (action === 'progress' || action === 'start') { await giip.issueUpdate(acct, { isn: Number(arg), status: 'IN_PROGRESS' }); return { handled: true, text: `✅ #${arg} → IN_PROGRESS` }; }
+      if (action === 'get' || action === 'show') { const i = await giip.issueGet(acct, Number(arg)); return { handled: true, text: code(i, 1500) }; }
+      if (action === 'comment') {
+        const cm = arg.match(/^(\d+)\s+([\s\S]+)$/);
+        if (cm) { await giip.issueComment(acct, Number(cm[1]), cm[2]); return { handled: true, text: `✅ #${cm[1]} 코멘트 추가` }; }
+        return { handled: true, text: '사용법: `giip issue comment <isn> <내용>`' };
+      }
+      if (action === 'list') {
+        const list = await giip.issueList(acct, { status: arg || '', csn: acct.csn || '' });
+        return {
+          handled: true,
+          text: list.length ? list.slice(0, 20).map((i) => `#${i.isn} [${i.status}] ${i.title}`).join('\n') : '(이슈 없음)',
+        };
+      }
+      return { handled: true, text: '사용법: `giip issue new "<title>"` | `list [status]` | `get <isn>` | `done|review|progress <isn>` | `comment <isn> <text>`' };
+    } catch (e) {
+      return { handled: true, text: `❌ ${e.message}` };
+    }
+  }
+
+  // ── giip api <Verb> [jsondata] — 범용 giip API 호출 ──
+  if (sub === 'api') {
+    const am = rest.match(/^(\S+)\s*([\s\S]*)$/);
+    if (!am) return { handled: true, text: '사용법: `giip api <Verb> [jsondata]`' };
+    const verb = am[1];
+    let jsondata = null;
+    const jsonPart = (am[2] || '').trim();
+    if (jsonPart) {
+      try { jsondata = JSON.parse(jsonPart); } catch { return { handled: true, text: 'jsondata JSON 파싱 실패' }; }
+    }
+    try {
+      const r = await giip.apiCall(acct, verb, jsondata);
+      return { handled: true, text: code(r) };
+    } catch (e) {
+      return { handled: true, text: `❌ ${e.message}` };
+    }
+  }
+
+  return { handled: false };
+}
+
+module.exports = { handleGiipCommand };

--- a/slack-bot-minimax/giip-task.js
+++ b/slack-bot-minimax/giip-task.js
@@ -1,0 +1,129 @@
+/**
+ * giip-task.js — task-manager 생명주기 ↔ giip issue 연동(얇은 훅, best-effort).
+ * rule 40: 연결 시 giip issue 우선 등록, 미연결/실패 시 null → 로컬 타임스탬프 폴백.
+ * 설계: docs/DESIGN_slackbot_giip_issue_integration.md §4.
+ * 모든 함수는 절대 throw 하지 않는다(봇 무중단). 실패는 로그 + null/no-op.
+ */
+const accounts = require('./giip-accounts');
+const giip = require('./giip-api');
+
+/** 타임아웃/네트워크 등 일시적 오류인지 판단(1회 재시도 대상). 권한/데이터 오류는 재시도해도 무의미하므로 제외. */
+function isRetryableIssueError(e) {
+  const msg = String((e && e.message) || e || '');
+  const code = e && e.code;
+  if (['ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'EAI_AGAIN', 'ENOTFOUND'].includes(code)) return true;
+  return /timeout|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN|ENOTFOUND|socket hang up/i.test(msg);
+}
+
+/**
+ * 태스크 생성(=분석) 시: 연결되어 있으면 issue 생성(PENDING) → isn. 아니면 null(로컬 폴백).
+ * 상태는 PENDING 으로 만든다 — 분석만 끝났을 뿐 아직 실행 전(go 대기)이므로. IN_PROGRESS 전이는
+ * 실제 실행 시작(handlers.startTaskExecution → maybeFinish(...,'IN_PROGRESS')) 시점에만 한다.
+ *   (과거: 여기서 IN_PROGRESS 로 만들어 "아무것도 안 움직이는데 IN_PROGRESS·go 요구" 모순 발생)
+ * csn: 프로젝트명 기준 csn(config.resolveProjectCsn). null 이면 issueCreate 가 account.csn 으로 폴백.
+ * 반환: { isn, error }. acct 미연동(csn/계정 미설정)은 정상 경로라 error:null 로 조용히 로컬 폴백.
+ * API 호출이 실제로 실패한 경우만 error 에 사유를 담아 호출측이 "미설정"과 "일시적 오류"를 구분해
+ * 사용자에게 알릴 수 있게 한다(타임아웃 등 일시적 오류로 오인된 채 미설정처럼 보이던 문제 대응).
+ * 일시적 오류(타임아웃/네트워크)는 1회만 재시도 후 그래도 실패하면 포기(무인 봇이 무한 대기하지 않도록).
+ */
+async function maybeCreateIssue(channelId, title, content, csn = null) {
+  const acct = accounts.resolve(channelId);
+  if (!acct) return { isn: null, error: null };
+  const body = {
+    title: (title || '(무제)').slice(0, 200),
+    content: (content || title || '').slice(0, 8000),
+    status: 'PENDING',
+    csn,
+  };
+  let lastErr = null;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const r = await giip.issueCreate(acct, body);
+      return { isn: r && r.isn ? Number(r.isn) : null, error: null };
+    } catch (e) {
+      lastErr = e;
+      if (attempt === 0 && isRetryableIssueError(e)) {
+        console.error(`[giip-task] issue 생성 실패(재시도 1회): ${e.message}`);
+        await new Promise((resolve) => setTimeout(resolve, 1500));
+        continue;
+      }
+      break;
+    }
+  }
+  console.error('[giip-task] issue 생성 실패(로컬 폴백):', lastErr.message);
+  return { isn: null, error: lastErr.message };
+}
+
+/** 완료/에러 시: 코멘트 + 상태전이(best-effort, 실패해도 무시). */
+async function maybeFinish(channelId, isn, status, comment) {
+  if (!isn) return;
+  const acct = accounts.resolve(channelId);
+  if (!acct) return;
+  try { if (comment) await giip.issueComment(acct, isn, comment); }
+  catch (e) { console.error('[giip-task] comment 실패:', e.message); }
+  try { if (status) await giip.issueUpdate(acct, { isn, status }); }
+  catch (e) { console.error('[giip-task] status 실패:', e.message); }
+}
+
+/**
+ * 코멘트만 남긴다(상태 전이 없음, best-effort). 작업트리 점유 대기 관계 등
+ * "상태는 그대로 두고 사실만 기록"하는 용도. 실패해도 봇 흐름을 막지 않는다.
+ */
+async function maybeComment(channelId, isn, comment) {
+  if (!isn || !comment) return;
+  const acct = accounts.resolve(channelId);
+  if (!acct) return;
+  try { await giip.issueComment(acct, isn, comment); }
+  catch (e) { console.error('[giip-task] comment(note) 실패:', e.message); }
+}
+
+/** 길이 제한(태스크 파일·프롬프트 폭주 방지). */
+function clip(s, max) {
+  const str = String(s == null ? '' : s);
+  return str.length > max ? `${str.slice(0, max)}\n…(${str.length - max}자 생략)` : str;
+}
+
+/** 이슈 본문 + 코멘트 배열을 사람이·서브에이전트가 읽는 히스토리 다이제스트(마크다운)로 만든다. */
+function formatIssueHistory(isn, issue, comments) {
+  const title  = (issue && (issue.title  || issue.Title))  || '(제목 없음)';
+  const status = (issue && (issue.status || issue.Status)) || '';
+  const body   = (issue && (issue.content || issue.Content)) || '';
+  const lines = [`### giip issue #${isn}${status ? ` [${status}]` : ''}: ${title}`];
+  if (body) lines.push('', '**본문:**', clip(body, 4000));
+  const list = Array.isArray(comments) ? comments : [];
+  if (list.length) {
+    lines.push('', `**코멘트 이력 (${list.length}건, 시간순):**`);
+    list.forEach((c, i) => {
+      const when = c.regdate  || c.Regdate  || '';
+      const who  = c.author   || c.Author   || '?';
+      const type = c.issuetype || c.Issuetype || '';
+      lines.push('', `[${i + 1}] ${when} · ${who}${type ? ` · ${type}` : ''}`,
+        clip(c.content || c.Content || '', 1500));
+    });
+  } else {
+    lines.push('', '(코멘트 없음)');
+  }
+  return clip(lines.join('\n'), 12000); // 전체 상한(대량 코멘트 이슈 대비)
+}
+
+/**
+ * giip issue 의 본문 + 모든 코멘트를 DB(SSOT)에서 가져와 히스토리 다이제스트를 만든다.
+ * 로컬 태스크 파일이 done/ 으로 이동됐거나 타 클론에서 처리돼 없어도, 재처리 요청은
+ * 코멘트 이력을 모두 읽고 맥락을 이어가야 하므로 DB 에서 전체를 복원한다.
+ * best-effort: 계정 미연결/API 실패 시 null(호출자는 기존 폴백 유지).
+ * 반환: { issue, comments, digest } | null
+ */
+async function fetchIssueHistory(channelId, isn) {
+  if (!isn) return null;
+  const acct = accounts.resolve(channelId);
+  if (!acct) return null;
+  let issue = null, comments = [];
+  try { issue = await giip.issueGet(acct, isn); }
+  catch (e) { console.error('[giip-task] issueGet(history) 실패:', e.message); }
+  try { comments = await giip.issueComments(acct, isn); }
+  catch (e) { console.error('[giip-task] issueComments(history) 실패:', e.message); }
+  if (!issue && (!comments || comments.length === 0)) return null;
+  return { issue, comments, digest: formatIssueHistory(isn, issue, comments) };
+}
+
+module.exports = { maybeCreateIssue, maybeFinish, maybeComment, fetchIssueHistory, formatIssueHistory };

--- a/slack-bot-minimax/github-issues.js
+++ b/slack-bot-minimax/github-issues.js
@@ -1,0 +1,79 @@
+const https = require('https');
+const fs = require('fs');
+const path = require('path');
+
+const CACHE_FILE = path.join(__dirname, '.issues-cache.json');
+const CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
+
+async function fetchFromGitHub() {
+  const token = process.env.GITHUB_TOKEN;
+  const repo = process.env.GITHUB_REPO; // e.g. 'LowyShin/smartorder-works'
+
+  if (!token || !repo) return null;
+
+  return new Promise((resolve) => {
+    const req = https.get({
+      hostname: 'api.github.com',
+      path: `/repos/${repo}/issues?state=open&per_page=30&sort=updated`,
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'User-Agent': 'smartorder-slack-bot/1.0',
+        'Accept': 'application/vnd.github.v3+json',
+      },
+    }, (res) => {
+      let data = '';
+      res.on('data', chunk => { data += chunk; });
+      res.on('end', () => {
+        try {
+          const raw = JSON.parse(data);
+          if (!Array.isArray(raw)) { resolve(null); return; }
+          resolve(raw.map(i => ({
+            number: i.number,
+            title: i.title,
+            state: i.state,
+            labels: (i.labels || []).map(l => l.name),
+            url: i.html_url,
+            updated_at: i.updated_at,
+          })));
+        } catch { resolve(null); }
+      });
+    });
+    req.on('error', () => resolve(null));
+    req.setTimeout(8000, () => { req.destroy(); resolve(null); });
+  });
+}
+
+async function refreshIssues() {
+  const issues = await fetchFromGitHub();
+  if (issues !== null) {
+    try {
+      fs.writeFileSync(CACHE_FILE, JSON.stringify({ timestamp: Date.now(), issues }));
+    } catch {}
+  }
+  return issues || [];
+}
+
+async function getIssues() {
+  try {
+    if (fs.existsSync(CACHE_FILE)) {
+      const cache = JSON.parse(fs.readFileSync(CACHE_FILE, 'utf8'));
+      if (Date.now() - cache.timestamp < CACHE_TTL_MS) {
+        return cache.issues || [];
+      }
+    }
+  } catch {}
+  return refreshIssues();
+}
+
+function getCacheAge() {
+  try {
+    const cache = JSON.parse(fs.readFileSync(CACHE_FILE, 'utf8'));
+    const ageMs = Date.now() - cache.timestamp;
+    const ageMins = Math.floor(ageMs / 60000);
+    return `${ageMins}분 전 캐시`;
+  } catch {
+    return '캐시 없음';
+  }
+}
+
+module.exports = { getIssues, refreshIssues, getCacheAge };

--- a/slack-bot-minimax/handlers.js
+++ b/slack-bot-minimax/handlers.js
@@ -1,0 +1,1476 @@
+// handlers.js — メッセージ/DM/チャンネル mention/タスク実行ハンドラ群
+// index.js から behavior-preserving で切り出し（ロジック変更なし）。
+// 内部の giip フック (./giip-commands, ./giip-task) は元コード通りインライン require のまま。
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const config = require('./config');
+const { BASE_DIR, AGENT_DIR, TASK_STATE_FILE, HISTORY_FILE, getAgentDir, parseProjectPrefix } = config;
+const { loadJSON, saveJSON } = require('./state');
+const { postMessage, postLong, fetchThreadTranscript } = require('./slack-api');
+const { checkAllRepoStatus, isPushFailureNotice } = require('./repo-status');
+const { callClaude } = require('./claude-cli');
+const { isGoCmd, isCancelCmd, isForceTaskCmd, isPureGitOp, classifyRequest } = require('./intent');
+const {
+  extractExistingTaskIds, extractGiipIssueRef, findSimilarPendingTasks, findDuplicatePendingClusters, applyTaskMerge,
+} = require('./task-dedup');
+const tm = require('./task-manager');
+const dashboard = require('./dashboard');
+const { searchKLayer } = require('./k-layer');
+const { getIssues, refreshIssues, getCacheAge } = require('./github-issues');
+
+// LOWY_ACTION_DASHBOARD.md 자동 갱신 훅. tasklist 변화 후 호출한다.
+//  - 예외/블로킹 없이(비동기 defer) 봇 흐름을 막지 않는다.
+//  - base 브랜치가 아니거나(태스크 실행 중) pull 실패면 dashboard 모듈이 알아서 skip.
+function refreshDashboardSafe(reason) {
+  setImmediate(() => {
+    try { dashboard.refreshDashboard(reason); }
+    catch (e) { console.error('[Bot] dashboard refresh 훅 오류:', e.message); }
+  });
+}
+
+async function handleSimpleGitOp({ channelId, replyTs, text, workDir = BASE_DIR }) {
+  if (!isPureGitOp(text)) return false;
+  const t = text.trim();
+  if (/git\s+push/i.test(t)) {
+    spawnSync('git', ['pull', '--rebase', 'origin'], { cwd: workDir, encoding: 'utf8', windowsHide: true });
+    const res = spawnSync('git', ['push'], { cwd: workDir, encoding: 'utf8', windowsHide: true });
+    const ok = res.status === 0;
+    await postMessage(channelId, ok ? '✅ git push 完了' : `❌ git push 失敗\n\`\`\`${(res.stderr || '').slice(0, 500)}\`\`\``, replyTs);
+    return true;
+  }
+  if (/git\s+pull/i.test(t)) {
+    const res = spawnSync('git', ['pull', '--rebase', 'origin'], { cwd: workDir, encoding: 'utf8', windowsHide: true });
+    const ok = res.status === 0;
+    await postMessage(channelId, ok ? '✅ git pull 完了' : `❌ git pull 失敗\n\`\`\`${(res.stderr || '').slice(0, 500)}\`\`\``, replyTs);
+    return true;
+  }
+  return false;
+}
+
+async function answerInChannel({ channelId, replyTs, text, workDir = BASE_DIR, threadTs = null }) {
+  if (await handleSimpleGitOp({ channelId, replyTs, text, workDir })) return;
+
+  // 即時受付通知: callClaude は最大20分ブロックし、その間ユーザには何も返らないため
+  // 「먹통」に見える。実処理の前に受付メッセージを出して無応答体感を無くす。
+  await postMessage(channelId, '💬 질문을 확인했습니다. 답변을 준비 중입니다…', replyTs);
+
+  // スレッド内での質問なら、スレッド全体を取得して文脈として渡す。
+  // Bot は mention された1件しか受け取らないため、これをやらないと
+  // 「스레드를 정리해줘」に対して「대화 기록이 없습니다」と誤答してしまう。
+  let threadTranscript = '';
+  try {
+    threadTranscript = await fetchThreadTranscript(channelId, threadTs);
+  } catch (e) {
+    console.error('[Bot] fetchThreadTranscript error:', e.message);
+  }
+
+  const claims = searchKLayer(text);
+  let issues = [];
+  if (['issue', 'bug', 'イシュー', 'バグ', 'task', 'github', '#'].some(k => text.toLowerCase().includes(k))) {
+    issues = await getIssues();
+  }
+
+  const projectName = path.basename(workDir);
+  const agentDir = getAgentDir(workDir);
+  let prompt = `You are giipclaude, an AI assistant. Always respond in Korean.
+
+Working project: ${projectName}
+Working directory: ${workDir}
+Agent context directory: ${agentDir}
+  - roles/    : project role definitions
+  - rules/    : coding and workflow rules
+  - skills/   : available skills
+  - workflows/: workflow definitions
+Read relevant files from the agent context directory as needed to apply the correct role and rules.
+
+IMPORTANT: Answer based on your knowledge of the project directory and K-Layer context below. If you do not know the answer, say "모르겠습니다" clearly.
+
+되묻지 말고 실측: 경로·설정·사양 등 조회로 확정 가능한 값은 사용자에게 묻지 말고 직접 찾아라. giip 서비스 설정(SMTP·메일·인증 등)의 정본은 giipdb 사양서(\`giipprj/giipdb/docs/30_Specs/\`)와 DB 다. 예: SMTP 는 \`tEmailServerConfig\` 테이블 + giip API \`EmailServerConfigGetActive\`. 사람에게 묻기 전에 반드시 그곳부터 grep/조회하고, 정말 사람만 아는 값(외부 자격증명 실물)만 질문한다.
+
+MANDATORY RULE — Task Number: If the user's message contains a 14-digit task number (e.g. 20260630170105), you MUST start your response with "[태스크 \`<task_number>\`]" on the very first line. Never omit the task number from your response.`;
+  if (claims.length) prompt += '\n\nK-Layer:\n' + claims.map(c => `• ${c}`).join('\n');
+  if (issues.length) prompt += '\n\nOpen Issues:\n' + issues.map(i => `• #${i.number} ${i.title}`).join('\n');
+  if (threadTranscript) {
+    prompt += `\n\n── 현재 Slack 스레드 전체 내용 (시간순, "화자: 발언") ──\n${threadTranscript}\n── 스레드 끝 ──\n\n위 스레드가 사용자가 말하는 "현재 스레드 / 이 대화 / 이 슬랙 메시지"입니다. 스레드 정리·요약·누가 무슨 말을 했는지·전후 확인 요청은 반드시 이 내용을 근거로 답하세요. "대화 기록이 없다"고 답하지 마세요.`;
+  }
+  prompt += `\n\nQuestion: ${text}\nAnswer:`;
+
+  // ── 安全網: question 経路でも「ファイル変更 = 必ずブランチ+PR」規則を強制する ──
+  // task/question 分類は flaky(LLM)なため、誤って question に落ちた作業依頼でも
+  // callClaude がファイルを書けば作業ツリーに未コミットで取り残される事故が起きる
+  // (giip-629 追加依頼: 未追跡ファイルのまま PR 未生成)。task 経路と同一の
+  // commitAndPRChangedRepos 機械を再利用し、実行「前」に clean だったリポの
+  // タスク由来変更だけを安全に commit·push·PR する(pre-dirty は触らず skip)。
+  let qnaSnapshots = [];
+  try { qnaSnapshots = tm.snapshotCandidateRepos(workDir); }
+  catch (e) { console.error('[Bot] answer snapshot error:', e.message); }
+
+  try {
+    const reply = await callClaude(prompt, workDir);
+    // 코드레벨 강제: 사용자 메시지의 태스크 ID가 응답에 없으면 첫 줄에 삽입
+    const missingIds = extractExistingTaskIds(text).filter(id => !reply.includes(id));
+    const finalReply = missingIds.length > 0
+      ? `[태스크 \`${missingIds.join('`, `')}\`]\n\n${reply}`
+      : reply;
+    await postLong(channelId, finalReply, replyTs);
+  } catch (err) {
+    const isTimeout = err.code === 'ETIMEDOUT' || (err.message && err.message.includes('ETIMEDOUT'));
+    const msg2 = isTimeout
+      ? '⏱️ 処理がタイムアウトしました（20分超過）。もう少し短い要求に分けて送ってください。'
+      : `回答エラー: ${err.message}`;
+    await postMessage(channelId, msg2, replyTs);
+  }
+
+  // callClaude が(成功/タイムアウト問わず)ファイルを変更していたら、未コミットで
+  // 放置せず自動 PR にする。変更ゼロなら静かに何もしない。
+  try {
+    const stamp = new Date().toISOString().replace(/[^0-9]/g, '').slice(0, 14);
+    const qtitle = String(text).replace(/\s+/g, ' ').trim().slice(0, 60);
+    const multi = tm.commitAndPRChangedRepos(`qna-${stamp}`, qtitle, qnaSnapshots);
+    const prLines = (multi.prs || []).map(p => `🔀 PR (${path.basename(p.repo)}): ${p.url}`);
+    const skipLines = (multi.skipped || []).map(s => `⚠️ 수동 필요: ${path.basename(s.repo)} (${s.reason})`);
+    const blockedLines = (multi.blocked || []).map(b =>
+      `🚧 보류: ${path.basename(b.repo)} — 미머지 PR ${(b.prs || []).map(p => '#' + p.number).join(', ')} 과 같은 파일. 브랜치 \`${b.branch}\` push 됨(선행 PR 머지 후 수동 PR/rebase 필요).`);
+    if (prLines.length || skipLines.length || blockedLines.length) {
+      await postMessage(channelId, [
+        '📝 *답변 중 파일 변경 감지 → 자동 브랜치/PR* (질문 경로 안전망)',
+        ...prLines,
+        ...blockedLines,
+        ...skipLines,
+      ].join('\n'), replyTs);
+    }
+  } catch (e) { console.error('[Bot] answer auto-PR error:', e.message); }
+}
+
+// ── DM 처리 (일반 Q&A) ───────────────────────────────────────────────────────
+async function handleDM({ channelId, ts, threadTs, text, conversations, workDir = BASE_DIR }) {
+  const convKey = channelId;
+  const replyTs = threadTs || undefined;
+  const cmd = text.trim().toLowerCase();
+
+  // ── giip 커맨드 (giip api|issue|account) — DM 은 특히 account set(SK) 에 안전 ──
+  try {
+    const { handleGiipCommand } = require('./giip-commands');
+    const gc = await handleGiipCommand(text.trim(), channelId);
+    if (gc.handled) { await postMessage(channelId, gc.text, replyTs); return; }
+  } catch (e) { console.error('[Bot] giip command error:', e.message); }
+
+  if (cmd === '!help') {
+    await postMessage(channelId, [
+      '*giipclaude AI — DM コマンド一覧*',
+      '• `!issues` — GitHub Issue 一覧',
+      '• `!issues refresh` — Issue 強制更新',
+      '• `!klayer <キーワード>` — K-Layer 知識検索',
+      '• `!reset` — 会話履歴リセット',
+      '',
+      '*giip issue 連携:*',
+      '• `giip account set <login_id> <sk> [csn]` — チャンネル連携（DM推奨・SK含むので channel では避ける）',
+      '• `giip account show` — 現在の連携アカウント表示',
+      '• `giip issue list [status]` — イシュー一覧',
+      '• `giip issue get <isn>` — イシュー詳細',
+      '• `giip issue new "<title>"` — イシュー新規作成',
+      '• `giip issue done|review|progress <isn>` — ステータス変更',
+      '• `giip issue comment <isn> <text>` — コメント追加',
+      '• `giip project set <프로젝트명> <csn>` — プロジェクト名→CSN マッピング登録（`<프로젝트> issue 등록` 用）',
+      '• `giip project list` / `giip project del <프로젝트명>` — マッピング一覧 / 削除',
+      '• `giip api <Verb> [jsondata]` — 汎用 giip API 呼び出し',
+      '',
+      'チャンネルで `@ボット名 要求内容` と書くと Task ワークフローが始まります。',
+    ].join('\n'), replyTs);
+    return;
+  }
+  if (cmd === '!reset') {
+    conversations[convKey] = [];
+    await postMessage(channelId, '会話履歴をリセットしました。', replyTs);
+    return;
+  }
+  if (cmd === '!issues' || cmd === '!issues refresh') {
+    const issues = cmd.includes('refresh') ? await refreshIssues() : await getIssues();
+    if (!issues.length) { await postMessage(channelId, 'GITHUB_TOKEN / GITHUB_REPO の設定を確認してください。', replyTs); return; }
+    const lines = issues.map(i => `• #${i.number} ${i.title}`);
+    await postMessage(channelId, `Issues (${issues.length}件) — ${getCacheAge()}\n${lines.join('\n')}`, replyTs);
+    return;
+  }
+  if (cmd.startsWith('!klayer ')) {
+    const kw = cmd.slice(8).trim();
+    const claims = searchKLayer(kw);
+    await postMessage(channelId, claims.length ? `K-Layer "${kw}":\n${claims.map(c=>`• ${c}`).join('\n')}` : `"${kw}" に関連する claim はありません`, replyTs);
+    return;
+  }
+
+  // ── タスク番号による状況照会（DM）────────────────────────────────────────
+  const dmTaskMatch = text.trim().match(/^(?:status\s+)?(\d{14}|giip-\d{1,6})$/);
+  if (dmTaskMatch) {
+    const targetId = dmTaskMatch[1];
+    const taskFile = path.join(AGENT_DIR, 'tasks', `${targetId}.md`);
+    if (fs.existsSync(taskFile)) {
+      const fc = fs.readFileSync(taskFile, 'utf8');
+      const statusM = fc.match(/^status:\s*(.+)$/m);
+      const requestM = fc.match(/^request:\s*"?([^\n"]{1,120})/m);
+      const status = statusM ? statusM[1].trim() : '不明';
+      const request = requestM ? requestM[1].trim() : '（内容なし）';
+      const logMatch = fc.match(/## 進捗ログ([\s\S]*)/);
+      const logLines = logMatch ? logMatch[1].trim().split('\n').filter(l => l.startsWith('|')).slice(-5).join('\n') : null;
+      let reply = `*タスク \`${targetId}\` — 状況報告*\n• ステータス: ${status}\n• 内容: ${request}`;
+      if (logLines) reply += `\n\n*進捗ログ（直近）:*\n${logLines}`;
+      await postMessage(channelId, reply, replyTs);
+    } else {
+      await postMessage(channelId, `⚠️ タスク \`${targetId}\` が見つかりません。`, replyTs);
+    }
+    return;
+  }
+
+  // 일반 대화
+  const history = conversations[convKey] || [];
+  const claims = searchKLayer(text);
+  let issues = [];
+  if (['issue','bug','이슈','버그','task','github','#'].some(k => text.toLowerCase().includes(k))) {
+    issues = await getIssues();
+  }
+
+  const projectName = path.basename(workDir);
+  const agentDirDM = getAgentDir(workDir);
+  let prompt = `You are giipclaude, an AI assistant. Always respond in Korean regardless of the language the user writes in.\n\nWorking project: ${projectName}\nWorking directory: ${workDir}\nAgent context directory: ${agentDirDM} (roles/, rules/, skills/, workflows/)\nRead relevant files from the agent context directory to apply the correct role and rules.\n\nIMPORTANT: Answer based on your knowledge of the project and K-Layer context. If you do not know the answer, say "모르겠습니다" clearly.\n\n되묻지 말고 실측: 설정·사양은 직접 조회하라. giip 서비스 설정(SMTP 등)의 정본=giipdb \`docs/30_Specs/\` + DB(예: SMTP=\`tEmailServerConfig\`, API \`EmailServerConfigGetActive\`). 사람만 아는 값만 질문한다.\n\nMANDATORY RULE — Task Number: If the user's message contains a 14-digit task number (e.g. 20260630170105), you MUST start your response with "[태스크 \`<task_number>\`]" on the very first line. Never omit the task number from your response.`;
+  if (claims.length) prompt += '\n\nK-Layer:\n' + claims.map(c=>`• ${c}`).join('\n');
+  if (issues.length) prompt += '\n\nOpen Issues:\n' + issues.map(i=>`• #${i.number} ${i.title}`).join('\n');
+  if (history.length) {
+    prompt += '\n\nHistory:';
+    history.slice(-10).forEach(m => { prompt += `\n${m.role==='user'?'User':'Assistant'}: ${m.content}`; });
+  }
+  prompt += `\n\nUser: ${text}\nAssistant:`;
+
+  try {
+    const reply = await callClaude(prompt, workDir);
+    if (!conversations[convKey]) conversations[convKey] = [];
+    conversations[convKey].push({ role: 'user', content: text });
+    conversations[convKey].push({ role: 'assistant', content: reply });
+    if (conversations[convKey].length > 20) conversations[convKey] = conversations[convKey].slice(-20);
+    // 코드레벨 강제: 사용자 메시지의 태스크 ID가 응답에 없으면 첫 줄에 삽입
+    const missingIdsDM = extractExistingTaskIds(text).filter(id => !reply.includes(id));
+    const finalReplyDM = missingIdsDM.length > 0
+      ? `[태스크 \`${missingIdsDM.join('`, `')}\`]\n\n${reply}`
+      : reply;
+    await postLong(channelId, finalReplyDM, replyTs);
+  } catch (err) {
+    await postMessage(channelId, `오류: ${err.message}`, replyTs);
+  }
+}
+
+// ── 작업트리 점유가 풀렸을 때, 대기열의 다음 태스크를 자동 기동한다 ──────────────
+//   busy 로 되돌려진 태스크는 pending 에 `queuedBehind` 마커와 함께 남는다.
+//   태스크 완료(onComplete/onError)로 락이 풀린 직후 이 함수를 호출하면, 마커가 있는
+//   대기 태스크를 FIFO(queuedAt 오름차순) 로 하나 꺼내 실행한다.
+//   ※ 마커 없는 pending(=수동 `go` 대기 중인 분석 완료 태스크)은 자동 실행하지 않는다.
+//   ※ 한 번에 하나만 기동(직렬). 다음 태스크는 그 태스크의 완료 시 다시 드레인된다.
+async function drainNextQueued(reason = 'task-completed') {
+  try {
+    const ts = loadJSON(TASK_STATE_FILE, { pending: {}, running: {} });
+    // 이미 다른 태스크가 실행 중(작업트리 점유)이면 드레인하지 않는다(직렬 보장).
+    if (ts.running && Object.keys(ts.running).length > 0) return;
+    const queued = Object.entries(ts.pending || {})
+      .filter(([, t]) => t && t.queuedBehind)
+      .sort((a, b) => String(a[1].queuedAt || '').localeCompare(String(b[1].queuedAt || '')));
+    if (!queued.length) return;
+    const [key, entry] = queued[0];
+    const ch = entry.channelId;
+    const rt = entry.replyTs || undefined;
+    if (!ch) { console.error('[Bot] drainNextQueued: channelId 없음 → 스킵:', key); return; }
+    console.log(`[Bot] drainNextQueued(${reason}): 대기 태스크 ${entry.taskId} 자동 기동`);
+    await postMessage(ch,
+      `▶️ 작업트리가 비었습니다 — 대기 중이던 \`${entry.taskId}\` 을(를) 자동 기동합니다.`,
+      rt);
+    await startTaskExecution(key, entry, ch, rt, ts, entry.workDir || BASE_DIR);
+  } catch (e) {
+    console.error('[Bot] drainNextQueued error:', e.message);
+  }
+}
+
+// ── Task 実行共通処理 ─────────────────────────────────────────────────────────
+async function startTaskExecution(pendingKey, pendingTask, channelId, replyTs, taskState, workDir = BASE_DIR) {
+  // 保存された workDir を優先（go <id> はプレフィックス無しで来るため handlers 側の
+  // parseProjectPrefix が BASE_DIR に潰してしまう。タスク作成時の workDir を必ず使う）。
+  const effWorkDir = (pendingTask && pendingTask.workDir) || workDir;
+
+  delete taskState.pending[pendingKey];
+  const startedAt = new Date().toISOString();
+  taskState.running[pendingKey] = {
+    taskId: pendingTask.taskId,
+    taskTitle: pendingTask.taskTitle,
+    isn: pendingTask.isn || null, // 점유 중 대기 태스크가 이 이슈에 대기 코멘트를 남길 수 있게 보존
+    startedAt,
+  };
+  saveJSON(TASK_STATE_FILE, taskState);
+  tm.updateTasklistEntry(pendingTask.taskId, { status: 'running', startedAt });
+
+  // ── 作業「前」: 候補 nested repo の base を origin 最新へ ff 同期 ──
+  // giipv3 等の nested repo は誰も base を pull せず stale なまま編集され、後段 auto-PR が
+  // 最新 origin/base から切ったブランチへ replay する時に既 merge 済み変更と衝突していた
+  // (= ユーザ指摘「giipv3 は毎回 conflict」の根治)。clean かつ base 上の repo だけ ff 同期。
+  try { tm.syncCandidateReposBase(effWorkDir); }
+  catch (e) { console.error('[Bot] syncCandidateReposBase error:', e.message); }
+
+  // ── 実行「前」: 候補 nested repo を「このタスク専用ブランチ」へ切り替える(スト孤児化の根本予防) ──
+  // prepareTaskBranch が BASE_DIR だけを bot/task-<id> にしていたため、nested repo(giipv3/giipdb)は
+  //   直前タスクのブランチに停留したまま編集され、後段 auto-PR が foreign branch として skip →
+  //   コードが PR されず「REVIEW인데 배포 0」になっていた。ここで clean·on-base の nested repo を
+  //   先に bot/task-<id> へ切り替え、編集が正しい専用ブランチに載るようにする(dirty/foreign は不触)。
+  //   snapshot はこの「後」に撮る(専用ブランチ上の clean 状態を基準にするため順序が重要)。
+  let nestedPrepared = [];
+  try { nestedPrepared = tm.prepareNestedBranches(effWorkDir, pendingTask.taskId, [BASE_DIR]); }
+  catch (e) { console.error('[Bot] prepareNestedBranches error:', e.message); }
+
+  // ── 実行「前」に、タスクが変更しうる候補リポの dirty 状態をスナップショット ──
+  // (effWorkDir を含むリポ + その配下の nested git repo。onComplete/onError で
+  //  「タスクが実際に変更したリポだけ」を安全に判定・PR するための基準。)
+  let repoSnapshots = [];
+  try { repoSnapshots = tm.snapshotCandidateRepos(effWorkDir); }
+  catch (e) { console.error('[Bot] snapshotCandidateRepos error:', e.message); }
+
+  // ── 作業前: 最新 base(origin) から専用ブランチを用意（結果レポート = BASE_DIR）──
+  // 旧: 現在ブランチを git pull --rebase（stale base だと conflict 誘発）→ 廃止。
+  // 新: `git fetch origin <base>` 直後に origin/<base> を起点にブランチを作る。
+  //     常に最新 base 基準なので「ブランチを作るたび merge conflict」を根本回避する。
+  // 注意: 結果レポート/タスクファイルは常に BASE_DIR(lowyworkenv) 配下に生成されるため、
+  //     この既存経路は BASE_DIR を対象にする。effWorkDir 本体や nested repo の
+  //     コード変更は onComplete の commitAndPRChangedRepos が別途担当する。
+  const branchCtx = tm.prepareTaskBranch(pendingTask.taskId, BASE_DIR);
+  if (!branchCtx.ok && !branchCtx.notRepo) {
+    // busy(他タスクが作業ツリー占有) or ブランチ生成失敗 → pending へ戻して中断
+    const ts0 = loadJSON(TASK_STATE_FILE, { pending: {}, running: {} });
+    delete ts0.running[pendingKey];
+
+    if (branchCtx.busy) {
+      // 다른 태스크가 작업트리(git)를 점유 중 → 대기열에 등록만 하고, 점유 태스크가
+      // 끝나면 onComplete/onError 의 drainNextQueued 가 이 태스크를 자동 기동한다.
+      // (직렬 실행은 유지: 사용자가 다시 `go` 하지 않아도 순서대로 실행됨.)
+      const occupying = Object.values(ts0.running || {})[0] || null;
+      const occId = (occupying && occupying.taskId) || '(불명)';
+      ts0.pending[pendingKey] = {
+        ...pendingTask,
+        queuedBehind: occId,                 // 어떤 태스크가 점유 중이었는지(진단·표시용)
+        queuedAt: new Date().toISOString(),  // FIFO 드레인 정렬 키
+        channelId,                           // 자동 기동 시 회신 채널
+        replyTs: replyTs || null,            // 자동 기동 시 회신 스레드
+      };
+      saveJSON(TASK_STATE_FILE, ts0);
+      tm.updateTasklistEntry(pendingTask.taskId, { status: 'pending', startedAt: null });
+      await postMessage(channelId,
+        `⏸️ 지금은 \`${occId}\` 이(가) 작업트리(git)를 점유 중입니다.\n` +
+        `\`${pendingTask.taskId}\` 을(를) *대기열에 등록*했습니다 — 점유 작업이 끝나면 *자동으로 기동*합니다 (다시 \`go\` 하지 않아도 됩니다).`,
+        replyTs
+      );
+      // 점유 중인 giip 이슈에 대기 관계를 코멘트로 남긴다(best-effort, SSOT-안전한 코멘트 채널).
+      try {
+        if (occupying && occupying.isn) {
+          await require('./giip-task').maybeComment(channelId, occupying.isn,
+            `⏳ 대기 중: \`${pendingTask.taskId}\`${pendingTask.isn ? ` (giip #${pendingTask.isn})` : ''} 이(가) 작업트리 점유 해제를 기다립니다 — 이 작업(#${occupying.isn}) 완료 시 자동 기동됩니다.`);
+        }
+      } catch (e) { console.error('[Bot] 대기 코멘트 훅 오류:', e.message); }
+      return;
+    }
+
+    // busy 이외의 브랜치 생성 실패 → 종전대로 수동 재실행 안내.
+    ts0.pending[pendingKey] = pendingTask;
+    saveJSON(TASK_STATE_FILE, ts0);
+    tm.updateTasklistEntry(pendingTask.taskId, { status: 'pending', startedAt: null });
+    await postMessage(channelId,
+      `⏸️ *実行できません*: ${branchCtx.error}\n\`go ${pendingTask.taskId}\` で後ほど再実行してください。`,
+      replyTs
+    );
+    return;
+  }
+  const execCtx = branchCtx.ok ? branchCtx : null; // notRepo 時は ctx=null (PR 不可、従来通り実行)
+  if (execCtx) {
+    await postMessage(channelId,
+      `🌿 作業ブランチ作成: \`${execCtx.branch}\`\n• base: \`${execCtx.base}\`${execCtx.fetchedBase ? ' (origin 最新 fetch 済)' : ' (⚠️ fetch 失敗 — ローカル base 基準)'}`,
+      replyTs
+    );
+  }
+
+  await postMessage(channelId,
+    `⚙️ *Task 実行開始*: \`${pendingTask.taskId}\`\n• ${pendingTask.taskTitle}\n\n_サブエージェントが作業中です。完了したら PR URL をお知らせします。_`,
+    replyTs
+  );
+
+  // giip issue 연동: 실제 실행이 시작되는 이 시점에 IN_PROGRESS 로 전이한다.
+  //   분석 단계에서 미리 IN_PROGRESS 를 찍지 않으므로 「issue 는 IN_PROGRESS 인데
+  //   실제로는 아무것도 안 도는」 모순 상태가 생기지 않는다(사용자 지적 대응).
+  if (pendingTask && pendingTask.isn) {
+    try { await require('./giip-task').maybeFinish(channelId, pendingTask.isn, 'IN_PROGRESS', null); }
+    catch (e) { console.error('[Bot] giip IN_PROGRESS 전이 오류:', e.message); }
+  }
+
+  // effWorkDir/nested repo の PR を Slack へ整形するヘルパ（onComplete/onError 共用）
+  const renderRepoLines = (reportUrl, multi) => {
+    const prLines = [];
+    if (reportUrl) prLines.push(`🔀 PR: ${reportUrl}`);
+    for (const p of (multi.prs || [])) prLines.push(`🔀 PR (${path.basename(p.repo)}): ${p.url}`);
+    const skipLines = (multi.skipped || []).map(s => {
+      const files = (s.files || []).slice(0, 6).map(f => path.basename(f)).join(', ');
+      const more = (s.files || []).length > 6 ? ' 외' : '';
+      return `⚠️ 수동 필요: ${path.basename(s.repo)}${files ? ` [${files}${more}]` : ''} — ${s.reason}`;
+    });
+    // PR 충돌 게이트로 보류된 저장소: 어떤 미머지 PR 과 어느 파일이 겹쳤는지 알린다.
+    const blockedLines = [];
+    for (const b of (multi.blocked || [])) {
+      const prTxt = (b.prs || []).map(p => `#${p.number}`).join(', ');
+      const fileTxt = (b.files || []).slice(0, 5).map(f => path.basename(f)).join(', ') + ((b.files || []).length > 5 ? ' 외' : '');
+      blockedLines.push(`🚧 보류: ${path.basename(b.repo)} — 파일 [${fileTxt}] 이(가) 미머지 PR ${prTxt} 대상이라 새 PR 을 만들지 않았습니다(브랜치 \`${b.branch}\` 는 push 됨).`);
+      for (const p of (b.prs || [])) blockedLines.push(`   ↳ ${p.url}`);
+    }
+    return { prLines, skipLines, blockedLines };
+  };
+
+  // ── 자가 치유: giip issue 태스크인데 로컬 태스크 파일이 없으면 DB 이력으로 재생성 ──
+  //   giip issue 재처리 요청은 done/ 이동·타 클론 처리·워킹트리 churn 으로 로컬
+  //   .agent/tasks/{giip-isn}.md 가 사라졌을 수 있다(#660 "タスクファイルが見つかりません"의 원인).
+  //   이 경우 DB(SSOT)에서 이슈 본문 + 전체 코멘트를 가져와 태스크 파일을 복원해, 서브에이전트가
+  //   코멘트 이력을 모두 읽고 이어서 처리하도록 한다. isn 이 있는 태스크에만 적용(best-effort).
+  if (pendingTask.isn && (!pendingTask.taskFile || !fs.existsSync(pendingTask.taskFile))) {
+    try {
+      const hist = await require('./giip-task').fetchIssueHistory(channelId, pendingTask.isn);
+      const rebuilt = tm.rebuildTaskFileFromIssue(
+        pendingTask.taskId, pendingTask.isn, pendingTask.requestText || '', hist && hist.digest);
+      pendingTask.taskFile = rebuilt;
+      await postMessage(channelId,
+        `🗄️ 로컬 태스크 파일이 없어 giip issue #${pendingTask.isn} 의 DB 이력(본문+코멘트${hist && hist.comments ? ` ${hist.comments.length}건` : ''})으로 복원해 처리합니다.`,
+        replyTs);
+    } catch (e) {
+      console.error('[Bot] giip 태스크 파일 DB 복원 실패:', e.message);
+    }
+  }
+
+  tm.startExecution(pendingTask.taskId, pendingTask.taskFile, {
+    isn: pendingTask.isn || null, // giip 연동 시 서브에이전트가 진행 코멘트를 남기도록 isn 전달
+    onComplete: async (resultFile) => {
+      // 결과 내용을 태스크 파일에 추가하고 done/ 폴더로 이동
+      let doneTaskFile = null;
+      try {
+        const resultContent = fs.existsSync(resultFile) ? fs.readFileSync(resultFile, 'utf8') : '';
+        doneTaskFile = tm.completeTaskFile(pendingTask.taskId, resultContent);
+      } catch (e) {
+        console.error('[Bot] completeTaskFile error:', e.message);
+      }
+
+      // ① 결과 보고서/기본 리포(BASE_DIR): 기존 경로 유지 (report + BASE_DIR 코드 변경).
+      // ⚠️ gitPushResultAndPR 내부에서 restoreTaskBranch 를 호출해 gitTreeBusy 락을 해제한다.
+      //   running 상태 삭제는 반드시 이 호출 *이후* 에 해야 한다 — 먼저 지우면 gitTreeBusy=true 인데
+      //   running 은 이미 비어 있는 창(레이스 윈도우)이 생겨, 그 사이 새 태스크가 busy 로 걸리면
+      //   점유자를 찾지 못해 '(불명)' 으로 표시된다(실제로는 이 태스크가 push/PR 처리 중이었음).
+      const reportUrl = tm.gitPushResultAndPR(pendingTask.taskId, pendingTask.taskTitle, resultFile, doneTaskFile, execCtx, BASE_DIR);
+      const ts2 = loadJSON(TASK_STATE_FILE, {});
+      delete ts2.running[pendingKey];
+      saveJSON(TASK_STATE_FILE, ts2);
+      // ② 그 외 실제로 바뀐 저장소(effWorkDir 본체 + nested repo) 각각 커밋·push·PR.
+      let multi = { prs: [], skipped: [] };
+      try {
+        multi = tm.commitAndPRChangedRepos(pendingTask.taskId, pendingTask.taskTitle, repoSnapshots, { excludeRoots: [BASE_DIR] });
+      } catch (e) { console.error('[Bot] commitAndPRChangedRepos error:', e.message); }
+      // prepareNestedBranches 로 전환한 nested repo 를 base 로 복원(드리프트 누적 차단).
+      try { tm.restoreNestedBranches(nestedPrepared); }
+      catch (e) { console.error('[Bot] restoreNestedBranches error:', e.message); }
+
+      const allUrls = [reportUrl, ...multi.prs.map(p => p.url)].filter(Boolean);
+      const blocked = multi.blocked || [];
+      // unlanded = このタスクが変更したのに PR にできなかった repo(兄弟 giipv3 が別ブランチに停留 等)。
+      //   これがあるのに素直に「완료」と言うと、コードが未反映のまま完了扱いになる(giip-720 の再発)。
+      const unlanded = multi.skipped || [];
+      tm.updateTasklistEntry(pendingTask.taskId, {
+        // 일부 저장소가 미머지 PR 과 충돌해 PR 보류되면 'blocked' — "머지완료 <taskid>" 로 재개.
+        // unlanded(이 태스크가 바꿨는데 PR 못한 repo)도 '완료'가 아니다 → 'blocked' 로 묶어
+        //   대시보드/집계에서 '완료'로 세지 않게 한다(= 거짓 완료 방지).
+        status: (blocked.length || unlanded.length) ? 'blocked' : 'completed',
+        completedAt: new Date().toISOString(),
+        resultUrl: allUrls[0] || null,
+        blocked: blocked.length ? blocked : undefined,
+        unlanded: unlanded.length ? unlanded.map(s => ({ repo: s.repo, files: s.files || [], reason: s.reason })) : undefined,
+      });
+      refreshDashboardSafe('task-completed'); // 완료 후 작업트리는 master 복귀 상태 → 갱신 가능
+      // giip issue 통일: 완료 → 코멘트 + REVIEW.
+      // ⚠️ 근본수정: REVIEW 는 「이 태스크가 바꾼 코드가 전부 PR 로 반영됐을 때만」 찍는다.
+      //   blocked(선행 PR 충돌 보류) 뿐 아니라 unlanded(foreign branch 등으로 PR 못한 변경)가
+      //   하나라도 있으면 REVIEW 로 넘기지 않는다 → IN_PROGRESS 유지 + 미반영 사유 명시.
+      //   (과거: unlanded 여도 REVIEW 로 전이해 「REVIEW인데 배포 0」 거짓 완료가 양산됐다.)
+      try {
+        if (pendingTask.isn) {
+          const gt = require('./giip-task');
+          if (blocked.length) {
+            const prTxt = blocked.map(b => (b.prs || []).map(p => '#' + p.number).join(',')).join(' ');
+            await gt.maybeFinish(channelId, pendingTask.isn, 'IN_PROGRESS',
+              `⏸️ 작업 산출물은 브랜치에 push 됐으나, 선행 미머지 PR(${prTxt})과 같은 파일이라 PR 을 보류했습니다. 선행 PR 머지 후 재개합니다.`);
+          } else if (unlanded.length) {
+            const unlandedTxt = unlanded.map(s => {
+              const files = (s.files || []).slice(0, 6).map(f => path.basename(f)).join(', ');
+              return `${path.basename(s.repo)}${files ? ` [${files}]` : ''} — ${s.reason}`;
+            }).join(' / ');
+            const prTxt = allUrls.length ? `\n부분 PR: ${allUrls.join(' , ')}` : '';
+            await gt.maybeFinish(channelId, pendingTask.isn, 'IN_PROGRESS',
+              `⚠️ 아직 완료 아님(REVIEW 보류). 이 태스크가 바꾼 다음 저장소 변경분이 PR 로 반영되지 않았습니다(수동 PR 필요): ${unlandedTxt}${prTxt}`);
+          } else {
+            const cmt = allUrls.length
+              ? `✅ 작업 완료. PR: ${allUrls.join(' , ')}`
+              : `✅ 작업 완료(push/PR 실패). 결과: .agent/tasks/done/${pendingTask.taskId}.md`;
+            await gt.maybeFinish(channelId, pendingTask.isn, 'REVIEW', cmt);
+          }
+        }
+      } catch (e) { console.error('[Bot] giip finish 훅 오류:', e.message); }
+
+      const { prLines, skipLines, blockedLines } = renderRepoLines(reportUrl, multi);
+      const resumeGuide = blocked.length
+        ? ['', `⏸️ 선행 PR 머지 후 \`머지완료 ${pendingTask.taskId}\` 라고 알려주면 base 를 pull→rebase 후 PR 을 만듭니다.`]
+        : [];
+      // 헤드라인: 보류(blocked) > 미반영(unlanded) > 완료 の優先で正直に表示する。
+      const headline = blocked.length
+        ? '⏸️ *작업 완료 (일부 PR 보류)*'
+        : (unlanded.length ? '⚠️ *작업 완료 — 일부 저장소 PR 미생성(수동 필요)*' : '✅ *작업 완료*');
+      if (prLines.length || blockedLines.length) {
+        await postMessage(channelId, [
+          `${headline}: \`${pendingTask.taskId}\`${pendingTask.isn ? ` / giip #${pendingTask.isn}${(blocked.length || unlanded.length) ? '' : '→REVIEW'}` : ''}`,
+          `• ${pendingTask.taskTitle}`,
+          '',
+          ...prLines,
+          ...(blockedLines.length ? ['', ...blockedLines] : []),
+          ...(skipLines.length ? ['', ...skipLines] : []),
+          ...resumeGuide,
+        ].join('\n'), replyTs);
+      } else {
+        await postMessage(channelId, [
+          `${unlanded.length ? '⚠️ *작업 완료 — 일부 저장소 PR 미생성(수동 필요)*' : '✅ *작업 완료*'} (⚠️ 원격 반영된 PR 없음)`,
+          `• \`${pendingTask.taskId}\`: ${pendingTask.taskTitle}`,
+          `결과 파일: \`.agent/tasks/done/${pendingTask.taskId}.md\``,
+          ...(skipLines.length
+            ? ['', ...skipLines]
+            : ['변경된 저장소가 없거나 push/PR 생성에 실패했습니다. 봇 로그의 git/gh 오류를 확인하세요.']),
+        ].join('\n'), replyTs);
+        if (!skipLines.length) await postLong(channelId, checkAllRepoStatus(), replyTs);
+      }
+
+      // 작업트리 락이 해제된 시점 → 대기열에 쌓인 다음 태스크를 자동 기동.
+      await drainNextQueued('task-completed');
+    },
+    onError: async (err, resultFile) => {
+      // エラー時も部分成果を push+PR し、必ず作業ツリーを原状復帰(ブランチ復元)する。
+      // ⚠️ onComplete 와 동일한 이유로 running 삭제는 gitPushResultAndPR(restoreTaskBranch 포함) 이후.
+      const reportUrl = tm.gitPushResultAndPR(pendingTask.taskId, pendingTask.taskTitle + ' (error)', resultFile, null, execCtx, BASE_DIR);
+      const ts2 = loadJSON(TASK_STATE_FILE, {});
+      delete ts2.running[pendingKey];
+      saveJSON(TASK_STATE_FILE, ts2);
+      let multi = { prs: [], skipped: [] };
+      try {
+        multi = tm.commitAndPRChangedRepos(pendingTask.taskId, pendingTask.taskTitle + ' (error)', repoSnapshots, { excludeRoots: [BASE_DIR] });
+      } catch (e) { console.error('[Bot] commitAndPRChangedRepos(error) 오류:', e.message); }
+      try { tm.restoreNestedBranches(nestedPrepared); }
+      catch (e) { console.error('[Bot] restoreNestedBranches(error) error:', e.message); }
+
+      const allUrls = [reportUrl, ...multi.prs.map(p => p.url)].filter(Boolean);
+      tm.updateTasklistEntry(pendingTask.taskId, {
+        status: 'cancelled',
+        completedAt: new Date().toISOString(),
+        resultUrl: allUrls[0] || null,
+      });
+      refreshDashboardSafe('task-error'); // 에러 후에도 작업트리는 master 복귀 상태
+      // giip issue 통일: 에러 → 코멘트 + REVIEW(사람 판단 대기)
+      try {
+        if (pendingTask.isn) {
+          const gt = require('./giip-task');
+          await gt.maybeFinish(channelId, pendingTask.isn, 'REVIEW', `❌ 작업 에러: ${err.message}${allUrls.length ? `\nPR(부분): ${allUrls.join(' , ')}` : ''}`);
+        }
+      } catch (e) { console.error('[Bot] giip finish(error) 훅 오류:', e.message); }
+
+      const { prLines, skipLines, blockedLines } = renderRepoLines(reportUrl, multi);
+      await postMessage(channelId, [
+        `❌ *작업 에러* (\`${pendingTask.taskId}\`)${pendingTask.isn ? ` / giip #${pendingTask.isn}→REVIEW` : ''}: ${err.message}`,
+        ...(prLines.length ? ['', '🔀 부분 결과:', ...prLines] : []),
+        ...(blockedLines.length ? ['', ...blockedLines] : []),
+        ...(skipLines.length ? ['', ...skipLines] : []),
+      ].join('\n'), replyTs);
+
+      // 에러여도 작업트리 락은 해제됨 → 대기열의 다음 태스크를 자동 기동.
+      await drainNextQueued('task-error');
+    },
+  }, effWorkDir, execCtx);
+}
+
+// ── チャンネル Mention 処理 (Task ワークフロー) ───────────────────────────────
+async function handleChannelMention({ channelId, ts, threadTs, text, workDir = BASE_DIR, projectName = null }) {
+  const convKey = `${channelId}:${threadTs || ts}`;
+  const replyTs = threadTs || ts;
+  const taskState = loadJSON(TASK_STATE_FILE, { pending: {}, running: {} });
+
+  // バッククォート・全角スペース等を除去してからコマンド判定
+  const cmd = text.trim().replace(/`/g, '').replace(/\s+/g, ' ').toLowerCase();
+  console.log(`[Bot] handleChannelMention cmd="${cmd}" convKey="${convKey}"`);
+
+  // ── giip 커맨드 (giip api|issue|account) — giip issue 통일 (rule 39/40) ──
+  try {
+    const { handleGiipCommand } = require('./giip-commands');
+    const gc = await handleGiipCommand(text.trim(), channelId);
+    if (gc.handled) { await postMessage(channelId, gc.text, replyTs); return; }
+  } catch (e) { console.error('[Bot] giip command error:', e.message); }
+
+  // ── "issue 등록 <내용>" — 分類器を通さず明示的に giip issue として登録 ──────
+  //   利用形: `<プロジェクト名> issue 등록 <内容>` / `이슈 등록 <内容>`
+  //   （プロジェクト名は parseProjectPrefix で workDir に解決済み → text は接頭辞除去済み）
+  //   既存の task 自動連携(giip-task.maybeCreateIssue)は変更せず、明示登録の即時経路のみ追加。
+  //   区切り(空白 / コロン / 文字列末)を必須にして「issue 등록됐어?」等の質問誤爆を防ぐ
+  //   （JS の \b は ASCII 専用でハングル境界を検出できないため明示的に区切りを要求）。
+  //   선두 `giip ` 도 허용: `giip issue 등록 …` == `giipprj issue 등록 …` (사용자 요청).
+  //   'giip' 는 projects/ 실폴더가 아니라 parseProjectPrefix 가 못 벗겨 workDir=BASE_DIR 로 남으므로
+  //   아래에서 이 형태만 workDir 을 giipprj 로 고정해 분석(작업지시서) 경로를 동일하게 탄다.
+  const issueTrigger = /^(?:giip\s+)?(?:issue|이슈|イシュー)\s*(?:등록|登録|register)(?:\s+|\s*[:：]\s*|$)/i;
+  if (issueTrigger.test(text.trim())) {
+    const body = text.trim().replace(issueTrigger, '').trim();
+    // `giip issue 등록 …`(선두 giip) → giipprj 프로젝트 등록과 동일 처리하도록 workDir 고정.
+    const effWorkDir = /^giip\s+/i.test(text.trim())
+      ? path.join(config.PROJECTS_ROOT, 'giipprj')
+      : workDir;
+    if (!body) {
+      await postMessage(channelId, '사용법: `<프로젝트> issue 등록 <내용>` — 내용을 그대로 giip issue 로 등록합니다.', replyTs);
+      return;
+    }
+    const title = body.split(/\r?\n/)[0].slice(0, 200).trim() || '(무제)';
+    try {
+      const giipAccounts = require('./giip-accounts');
+      const giip = require('./giip-api');
+      const acct = giipAccounts.resolve(channelId);
+      if (!acct) {
+        await postMessage(channelId,
+          '⚠️ giip 계정 미설정입니다. `giip account set <login_id> <sk> [csn]` 로 먼저 등록하세요(SK 포함이라 DM 권장).',
+          replyTs);
+        return;
+      }
+      // giipprj(giipprj 폴더) 는 의뢰를 그대로 넣지 않고, 분석해 '작업지시서' 수준으로 등록한다.
+      //   무인 처리기(run-gissue-claude)의 refine([B]) 를 등록 시점에 앞당겨 수행하는 셈:
+      //   raw 본문은 content 로, 분석된 작업지시서는 코멘트로 붙이고 status=READY 로 두면
+      //   처리기 [C](READY + 지시서 코멘트)가 다음 :20/:40 에 바로 착수한다.
+      const isGiipprj = /(^|[\\/])giipprj$/i.test(String(effWorkDir).replace(/[\\/]+$/, ''));
+      if (isGiipprj) {
+        await postMessage(channelId, '🔍 의뢰 내용을 분석해 작업지시서로 정리 중입니다... (수십 초 소요)', replyTs);
+        let planContent = null;
+        try { ({ planContent } = tm.analyzeRequest(body, null, effWorkDir)); }
+        catch (e) { console.error('[Bot] issue 등록 분석 실패:', e.message); }
+
+        const specTitle = ((planContent && tm.extractTitle(planContent)) || title).slice(0, 200);
+        // create 는 항상 PENDING 으로(유실 방지). 분석 성공 시에만 작업지시서 코멘트 + READY 로 승격.
+        const r = await giip.issueCreate(acct, { title: specTitle, content: body.slice(0, 8000), status: 'PENDING', csn: config.resolveProjectCsn(projectName || effWorkDir) });
+        const isn = r && r.isn ? Number(r.isn) : null;
+        let promoted = false;
+        if (isn && planContent) {
+          try {
+            await giip.issueComment(acct, isn, `📋 작업지시서 (봇 자동 분석)\n\n${planContent}`.slice(0, 8000));
+            await giip.issueUpdate(acct, { isn, status: 'READY' }); // read-modify-write(제목·본문 보존)
+            promoted = true;
+          } catch (e) { console.error('[Bot] issue 작업지시서 첨부 실패:', e.message); }
+        }
+        await postMessage(channelId,
+          isn
+            ? [
+                `✅ giip issue #${isn} 등록 완료 (${promoted ? 'READY · 작업지시서 첨부 → 자동 처리 대기' : 'PENDING · 무인 refine 대기'})`,
+                `• 제목: ${specTitle}`,
+                ...(promoted ? ['', '```', planContent.slice(0, 1200), '```'] : []),
+              ].join('\n')
+            : '⚠️ issue 등록 응답에 isn 이 없습니다. 계정/CSN 설정을 확인하세요.',
+          replyTs);
+        return;
+      }
+      // 그 외 프로젝트: 의뢰를 그대로 PENDING 으로 등록(무인 처리기가 refine 부터 수행).
+      //   IN_PROGRESS 로 만들면 PENDING/READY 만 집는 처리기의 사각지대에 빠져 '먹통'이 된다.
+      const r = await giip.issueCreate(acct, { title, content: body.slice(0, 8000), status: 'PENDING', csn: config.resolveProjectCsn(projectName || effWorkDir) });
+      const isn = r && r.isn ? Number(r.isn) : null;
+      await postMessage(channelId,
+        isn
+          ? `✅ giip issue #${isn} 등록 완료 (PENDING · 대기열 등록 → 자동 처리 대기)\n• 제목: ${title}`
+          : '⚠️ issue 등록 응답에 isn 이 없습니다. 계정/CSN 설정을 확인하세요.',
+        replyTs);
+    } catch (e) {
+      console.error('[Bot] issue 등록 실패:', e.message);
+      await postMessage(channelId, `❌ issue 등록 실패: ${e.message}`, replyTs);
+    }
+    return;
+  }
+
+  // ── 내장 명령어 ─────────────────────────────────────────────────────────────
+  if (cmd === '!help') {
+    await postMessage(channelId, [
+      '*giipclaude AI — 使い方*',
+      '`@ボット名 <質問>` → その場で回答（曖昧な内容も質問扱い）',
+      '`@ボット名 <作業依頼>` → Task 分析 → 確認 → 実行 → GitHub 結果 URL',
+      '`@ボット名 タスク登録: <内容>` → 強制的に Task として登録',
+      '`@ボット名 <プロジェクト名> task <内容>` / `<プロジェクト名> 태스크등록 <内容>` → 先頭が task/태스크등록 なら強制 Task 登録',
+      '',
+      '*Task 管理:*',
+      '• `tasklist` — 待機中 Task 一覧',
+      '• `tasklist all` — 全 Task 一覧 (完了・キャンセル含む)',
+      '• `task7days` — 直近7日間の全 Task (完了・キャンセル含む／未処理・異常検知用)',
+      '• `go` — 待機中 Task の一覧を表示',
+      '• `go <Task番号>` — 指定した Task を実行',
+      '• `cancel` — 待機中 Task の一覧を表示',
+      '• `cancel <Task番号>` — 指定した Task をキャンセル',
+      '• `머지완료 <Task番号>` — 선행 PR 머지 후, 보류(⏸️)된 Task 를 rebase→PR 로 재개',
+      '• `taskmerge` — 未完了の重複タスクを検出（プレビュー） *別名: 중복 정리 / dedup / マージ*',
+      '• `taskmerge go` — 重複タスクを統合（代表1件に集約し残りを取消）',
+      '',
+      '*ワークフロー:*',
+      '• `<プロジェクト名> wflist` — そのプロジェクトの .agent/workflows 一覧',
+      '• `<プロジェクト名> wflist <絞り込み語>` — 名前で絞り込み',
+      '• `<プロジェクト名> wflist all` — 参考ドキュメントも表示',
+      '• *ワークフロー実行* — 次のどの形でもOK（実行サブエージェント経路で走るので DB/スクリプトが権限に阻まれない）:',
+      '    ‣ `<プロジェクト> workflow <名>` / `wf <名>` / `wfrun <名>` / `워크플로우 <名>`  （「워크플로우」が長い時は workflow / wf でOK）',
+      '    ‣ `<プロジェクト> <名> 실행` / `<プロジェクト> /<名>` / `<プロジェクト> <名>`',
+      '    例) `giipprj wf errorproc` = `giipprj errorproc 실행` = `giipprj /errorproc` = `giipprj workflow errorproc`',
+      '    ※ 「<名> 실행」「<名>」の形は実在ワークフロー名と完全一致した時のみ実行（誤爆防止）',
+      '',
+      '*giip issue 連携:*',
+      '• `giip account set <login_id> <sk> [csn]` — チャンネル連携（SK含むので DM 推奨）',
+      '• `giip account show` — 現在の連携アカウント表示',
+      '• `giip issue list [status]` — イシュー一覧',
+      '• `giip issue get <isn>` — イシュー詳細',
+      '• `giip issue new "<title>"` — イシュー新規作成',
+      '• `giip issue done|review|progress <isn>` — ステータス変更',
+      '• `giip issue comment <isn> <text>` — コメント追加',
+      '• `giip project set <프로젝트명> <csn>` — プロジェクト名→CSN マッピング登録（`<프로젝트> issue 등록` 用）',
+      '• `giip project list` / `giip project del <프로젝트명>` — マッピング一覧 / 削除',
+      '• `giip api <Verb> [jsondata]` — 汎用 giip API 呼び出し',
+      '',
+      '*情報:*',
+      '• `!issues` — GitHub Issue 一覧',
+      '• `!klayer <キーワード>` — K-Layer 検索',
+      '• `!help` — ヘルプ',
+    ].join('\n'), replyTs);
+    return;
+  }
+  if (cmd === '!issues' || cmd === '!issues refresh') {
+    const issues = cmd.includes('refresh') ? await refreshIssues() : await getIssues();
+    if (!issues.length) { await postMessage(channelId, 'GITHUB_TOKEN / GITHUB_REPO の設定を確認してください。', replyTs); return; }
+    const lines = issues.map(i => `• #${i.number} ${i.title}`);
+    await postMessage(channelId, `Issues (${issues.length}件) — ${getCacheAge()}\n${lines.join('\n')}`, replyTs);
+    return;
+  }
+  if (cmd.startsWith('!klayer ')) {
+    const kw = cmd.slice(8).trim();
+    const claims = searchKLayer(kw);
+    await postMessage(channelId, claims.length ? `K-Layer "${kw}":\n${claims.map(c=>`• ${c}`).join('\n')}` : `"${kw}" に関連する claim はありません`, replyTs);
+    return;
+  }
+
+  // ── wflist — 指定プロジェクトの .agent/workflows 一覧 ──────────────────────
+  //   使い方: `<プロジェクト名> wflist [絞り込み語|all]`
+  //   プロジェクト名は parseProjectPrefix で workDir に解決済み。
+  //   例: `giipprj wflist` → giipprj/.agent/workflows を一覧表示。
+  //   `all` を付けると README 等の参考ドキュメントも表示。
+  if (cmd === 'wflist' || cmd.startsWith('wflist ')) {
+    const filter = cmd === 'wflist' ? '' : cmd.slice('wflist '.length).trim();
+    const showAll = filter === 'all';
+    const agentDir = getAgentDir(workDir);
+    const wfDir = path.join(agentDir, 'workflows');
+    const projName = path.basename(workDir);
+    const usingFallback = !fs.existsSync(path.join(workDir, '.agent'));
+    let files = [];
+    try { files = fs.readdirSync(wfDir).filter(f => f.toLowerCase().endsWith('.md')); } catch { files = []; }
+    if (!files.length) {
+      await postMessage(channelId,
+        `📂 \`${projName}\` の .agent/workflows にワークフローがありません。\n探索パス: \`${wfDir}\``,
+        replyTs);
+      return;
+    }
+    const isDoc = f => /^(readme|common_|scheduling|_)/i.test(f);
+    const nameOf = f => f.replace(/\.md$/i, '');
+    let wf = files.filter(f => !isDoc(f)).sort();
+    const docs = files.filter(isDoc).sort();
+    if (filter && !showAll) wf = wf.filter(f => f.toLowerCase().includes(filter));
+    const header = usingFallback
+      ? `📋 *\`${projName}\` に .agent が無いため既定(${path.basename(BASE_DIR)}/.agent)を表示* (${wf.length}件)`
+      : `📋 *\`${projName}\` ワークフロー一覧* (${wf.length}件${filter && !showAll ? ` / 絞り込み: "${filter}"` : ''})`;
+    const lines = wf.length ? wf.map(f => `• \`${nameOf(f)}\``) : ['(該当なし)'];
+    if (showAll && docs.length) lines.push('', '_参考ドキュメント:_ ' + docs.map(f => `\`${nameOf(f)}\``).join(', '));
+    await postMessage(channelId, `${header}\n${lines.join('\n')}`, replyTs);
+    return;
+  }
+
+  // ── ワークフロー実行 — 指定ワークフローをサブエージェントで実行 ────────────────
+  //   受け付ける言い回し（すべて実行サブエージェント経路 = --dangerously-skip-permissions）:
+  //     明示形（keyword-first / slash）— 部分一致も許可:
+  //       `<プロジェクト> 워크플로우 <名>` / `workflow <名>` / `wfrun <名>` / `wf <名>` / `/<名>`
+  //       （「워크플로우」は長いので英語別名 workflow / wf / wfrun いずれも可）
+  //     ゆるい形（name-first / 単語のみ）— 一般質問の誤爆を防ぐため .agent/workflows に
+  //     完全一致する時だけ実行:
+  //       `<プロジェクト> <名> 실행[해/해줘]` / `<名> 워크플로우 실행` / `<名> run|start` / `<名>`
+  //   例: `giipprj errorproc 실행` / `giipprj /errorproc` → giipprj/.agent/workflows/errorproc.md を実行。
+  //   なぜ必須か: DB照会等の .ps1 を含むワークフローは、この実行経路（権限スキップ）
+  //   でしか非対話 Slack セッションの権限ポリシーを越えられない。Q&A経路(callClaude)は
+  //   skip 権限が無いため必ずブロックされる。ワークフローは必ずここへ載せること。
+  {
+    let wfQuery = null, looseForm = false, mWf;
+    if ((mWf = cmd.match(/^(?:wfrun|workflow|wf\s+run|wf|워크플로우\s*실행|워크플로우|워크플로)\s+(.+)$/))) {
+      wfQuery = mWf[1];                                   // 明示: keyword-first (wfrun/workflow/wf/워크플로우)
+    } else if ((mWf = cmd.match(/^\/([\w가-힣-]+)$/))) {
+      wfQuery = mWf[1];                                   // 明示: slash-command "/name"
+    } else if ((mWf = cmd.match(/^(.+?)\s*(?:워크플로우\s*)?(?:실행(?:\s*해\s*주세요|\s*해\s*줘|\s*해|\s*하기)?|run|start)$/))) {
+      wfQuery = mWf[1]; looseForm = true;                 // ゆるい: "<name> 実行/실행/run"
+    } else if (/^[\w가-힣-]+$/.test(cmd)) {
+      wfQuery = cmd; looseForm = true;                    // ゆるい: 単語のみ "<name>"
+    }
+
+    if (wfQuery) {
+      const query = wfQuery.trim().replace(/\.md$/i, '');
+      const agentDir = getAgentDir(workDir);
+      const wfDir = path.join(agentDir, 'workflows');
+      const projName = path.basename(workDir);
+      let files = [];
+      try { files = fs.readdirSync(wfDir).filter(f => f.toLowerCase().endsWith('.md')); } catch { files = []; }
+      const isDoc = f => /^(readme|common_|scheduling|_)/i.test(f);
+      const candidates = files.filter(f => !isDoc(f));
+      const nameOf = f => f.replace(/\.md$/i, '');
+      const q = query.toLowerCase();
+      let match = candidates.find(f => nameOf(f).toLowerCase() === q);
+      // 明示形のみ部分一致を許可（ゆるい形は完全一致に限定して誤爆を防ぐ）
+      if (!match && !looseForm) {
+        const subs = candidates.filter(f => f.toLowerCase().includes(q));
+        if (subs.length === 1) match = subs[0];
+        else if (subs.length > 1) {
+          await postMessage(channelId,
+            `🔎 \`${query}\` に一致するワークフローが複数あります。1つに絞ってください:\n${subs.map(f => `• \`${nameOf(f)}\``).join('\n')}`,
+            replyTs);
+          return;
+        }
+      }
+      // ゆるい形で未一致 → ワークフロー指示ではない。通常ルーティングへフォールスルー。
+      if (!match && !looseForm) {
+        const list = candidates.length ? candidates.map(f => `• \`${nameOf(f)}\``).join('\n') : '(なし)';
+        await postMessage(channelId,
+          `❓ \`${projName}\` に \`${query}\` というワークフローが見つかりません。\n利用可能:\n${list}\n\n一覧: \`${projName} wflist\``,
+          replyTs);
+        return;
+      }
+      if (match) {
+      const wfPath = path.join(wfDir, match);
+      const wfName = nameOf(match);
+      let wfContent = '';
+      try { wfContent = fs.readFileSync(wfPath, 'utf8'); }
+      catch (e) { await postMessage(channelId, `⚠️ ワークフロー読み込み失敗: ${e.message}`, replyTs); return; }
+      const relWf = path.relative(workDir, wfPath).replace(/\\/g, '/');
+      const taskId = tm.getTimestampId();
+      const planContent = [
+        `# TASK: 워크플로우 실행 — ${wfName} (${projName})`,
+        '',
+        '## リクエスト内容',
+        `プロジェクト \`${projName}\` のワークフロー \`${wfName}\` を定義どおり実行`,
+        '',
+        '## 実行方針',
+        `- 対象ワークフロー定義: \`${relWf}\``,
+        '- 下記「ワークフロー定義」を上から順に、記載どおり忠実に実行する。',
+        '- 定義が他の roles/rules/skills/workflows を参照する場合、.agent 配下の該当ファイルを読んで従う。',
+        '- ファイルを変更したら実行プロンプトの共通規則に従い即コミット＆push する。',
+        '',
+        '## ワークフロー定義（この内容を実行）',
+        `===== BEGIN WORKFLOW: ${wfName} =====`,
+        wfContent.trim(),
+        `===== END WORKFLOW: ${wfName} =====`,
+      ].join('\n');
+      const taskFile = tm.createTaskFile(taskId, `[wfrun] ${projName}/${wfName}`, planContent, [wfPath]);
+      const taskTitle = tm.extractTitle(planContent);
+      const taskSummary = tm.extractSummary(planContent);
+      taskState.pending[convKey] = { taskId, taskTitle, taskFile, requestText: `wfrun ${wfName}`, workDir };
+      saveJSON(TASK_STATE_FILE, taskState);
+      tm.addToTasklist(taskId, taskTitle, taskSummary, `wfrun ${wfName}`);
+      await postMessage(channelId,
+        `🚀 *ワークフロー実行*: \`${wfName}\` (プロジェクト \`${projName}\`)\nTask \`${taskId}\` として開始します。`,
+        replyTs);
+      await startTaskExecution(convKey, taskState.pending[convKey], channelId, replyTs, taskState, workDir);
+      return;
+      }
+    }
+  }
+
+  // ── tasklist / tasklist all ────────────────────────────────────────────────
+  if (cmd === 'tasklist' || cmd === 'tasklist all') {
+    const showAll = cmd === 'tasklist all';
+    const tasks = tm.getTasklistByStatus(showAll ? null : 'pending');
+    if (tasks.length === 0) {
+      await postMessage(channelId,
+        showAll ? '記録された Task はありません。' : '待機中の Task はありません。\n全履歴は `tasklist all` で確認できます。',
+        replyTs
+      );
+      return;
+    }
+    const lines = tasks.map(t => {
+      const emoji = tm.statusEmoji(t.status);
+      const date = t.createdAt ? t.createdAt.slice(0, 10) : '';
+      const taskUrl = tm.getTaskFileUrl(t.taskId);
+      const taskLink = taskUrl ? `\n     📁 ${taskUrl}` : '';
+      const result = t.resultUrl ? `\n     📄 ${t.resultUrl}` : '';
+      return `${emoji} \`${t.taskId}\` [${t.status}] ${date}\n     *${t.title}*\n     ${t.summary}${taskLink}${result}`;
+    });
+    const header = showAll
+      ? `*全 Task 一覧 (${tasks.length}件)*`
+      : `*待機中 Task 一覧 (${tasks.length}件)*`;
+    await postLong(channelId, [header, '', ...lines].join('\n'), replyTs);
+    return;
+  }
+
+  // ── task7days — 直近7日間の全 Task (完了・キャンセル含む) ─────────────────
+  //   未処理・異常処理された Task を洗い出すため、期間内は全ステータスを列挙する
+  if (cmd === 'task7days' || cmd === 'task 7days' || cmd === 'task7d' || cmd === 'tasklist 7days') {
+    const DAY_MS = 24 * 60 * 60 * 1000;
+    const cutoff = Date.now() - 7 * DAY_MS;
+    const inWindow = (t) => {
+      // createdAt / startedAt / completedAt のいずれかが直近7日以内なら対象
+      const stamps = [t.createdAt, t.startedAt, t.completedAt]
+        .filter(Boolean)
+        .map(s => Date.parse(s))
+        .filter(n => !isNaN(n));
+      return stamps.some(n => n >= cutoff);
+    };
+    const tasks = tm.getTasklistByStatus(null)
+      .filter(inWindow)
+      .sort((a, b) => String(b.createdAt || '').localeCompare(String(a.createdAt || '')));
+    if (tasks.length === 0) {
+      await postMessage(channelId, '直近7日間に記録された Task はありません。', replyTs);
+      return;
+    }
+    // ステータス別に件数を集計（未処理／異常検知の手がかりに）
+    const counts = tasks.reduce((acc, t) => { acc[t.status] = (acc[t.status] || 0) + 1; return acc; }, {});
+    const summary = ['pending', 'running', 'completed', 'cancelled']
+      .filter(s => counts[s])
+      .map(s => `${tm.statusEmoji(s)} ${s} ${counts[s]}`)
+      .join('  ');
+    const lines = tasks.map(t => {
+      const emoji = tm.statusEmoji(t.status);
+      const date = t.createdAt ? t.createdAt.slice(0, 10) : '';
+      const taskUrl = tm.getTaskFileUrl(t.taskId);
+      const taskLink = taskUrl ? `\n     📁 ${taskUrl}` : '';
+      const result = t.resultUrl ? `\n     📄 ${t.resultUrl}` : '';
+      return `${emoji} \`${t.taskId}\` [${t.status}] ${date}\n     *${t.title}*\n     ${t.summary}${taskLink}${result}`;
+    });
+    const header = `*直近7日間の全 Task 一覧 (${tasks.length}件)*\n${summary}`;
+    await postLong(channelId, [header, '', ...lines].join('\n'), replyTs);
+    return;
+  }
+
+  // ── taskmerge — 未完了の重複タスクを検出・統合 ─────────────────────────────
+  //   `taskmerge`           → プレビュー（何を統合するか表示のみ、変更なし）
+  //   `taskmerge go/실행/apply` → 実際に統合（重複を survivor に集約し残りを取消）
+  const mergeCmd = cmd.match(/^(?:taskmerge|task\s*merge|merge\s*tasks|dedupe?|dupes|duplicates|consolidate|중복\s*통합|중복\s*정리|중복\s*제거|중복\s*태스크|태스크\s*정리|중복\s*찾기|타스크\s*통합|머지|タスク統合|重複統合|重複整理|マージ)(?:\s+(go|실행|실행해|확정|apply|yes|ok|はい|実行|실시))?$/);
+  if (mergeCmd) {
+    const doApply = !!mergeCmd[1];
+    const clusters = findDuplicatePendingClusters();
+    if (clusters.length === 0) {
+      await postMessage(channelId, '🔍 統合対象の重複した未完了タスクはありません。', replyTs);
+      return;
+    }
+
+    if (!doApply) {
+      // プレビュー（dry-run）
+      const blocks = clusters.map((cl, i) => {
+        const merged = cl.members.filter(m => m.taskId !== cl.survivor.taskId);
+        return [
+          `*グループ ${i + 1}* (${cl.members.length}件)`,
+          `  ✅ 維持: \`${cl.survivor.taskId}\` — ${cl.survivor.title}`,
+          ...merged.map(m => `  🚫 統合→取消: \`${m.taskId}\` — ${m.title}`),
+        ].join('\n');
+      });
+      await postLong(channelId, [
+        `*🔀 重複した未完了タスク ${clusters.length}グループを検出*`,
+        '',
+        ...blocks,
+        '',
+        '統合を実行するには: `taskmerge go`',
+        '（維持タスクに重複要請を統合記録し、残りは cancel フォルダへ移動します。取消済みは復元可能です。）',
+      ].join('\n'), replyTs);
+      return;
+    }
+
+    // 実行
+    const report = applyTaskMerge(clusters, taskState);
+    saveJSON(TASK_STATE_FILE, taskState);
+    await postLong(channelId, report, replyTs);
+    return;
+  }
+
+  // ── 머지완료 <Task番号> — 선행 PR 머지 알림 → 보류했던 저장소를 rebase 후 PR ──────
+  //   PR 충돌 게이트(commitAndPRChangedRepos)로 'blocked' 된 태스크를 재개한다.
+  const mergedDone = cmd.match(/^(?:머지완료|머지됨|merge완료|merged)\s+(\d{14}|giip-\d{1,6})$/);
+  if (mergedDone) {
+    const targetId = mergedDone[1];
+    const entry = tm.getTasklistByStatus(null).find(t => t.taskId === targetId);
+    if (!entry || !Array.isArray(entry.blocked) || entry.blocked.length === 0) {
+      await postMessage(channelId, `⚠️ \`${targetId}\` 는 보류(blocked) 상태가 아닙니다. \`tasklist all\` 로 상태를 확인하세요.`, replyTs);
+      return;
+    }
+    await postMessage(channelId, `🔄 \`${targetId}\` 재개: 선행 PR 머지 반영(base pull→rebase) 후 PR 생성 중...`, replyTs);
+    let res;
+    try { res = tm.resumeBlockedTask(targetId, entry.title || targetId, entry.blocked); }
+    catch (e) { await postMessage(channelId, `❌ 재개 실패: ${e.message}`, replyTs); return; }
+
+    const lines = [];
+    for (const p of (res.prs || [])) lines.push(`🔀 PR (${path.basename(p.repo)}): ${p.url}`);
+    for (const s of (res.stillBlocked || [])) lines.push(`🚧 여전히 보류: ${path.basename(s.repo)} — ${s.reason}`);
+    for (const f of (res.failed || [])) lines.push(`⚠️ 실패: ${path.basename(f.repo)} — ${f.reason}`);
+
+    // 아직 해소 안 된 저장소(재-conflict/실패)만 blocked 로 남긴다.
+    const unresolved = new Set([...(res.stillBlocked || []).map(s => s.repo), ...(res.failed || []).map(f => f.repo)]);
+    const remainingBlocked = entry.blocked.filter(b => unresolved.has(b.repo));
+    tm.updateTasklistEntry(targetId, {
+      status: remainingBlocked.length ? 'blocked' : 'completed',
+      completedAt: new Date().toISOString(),
+      blocked: remainingBlocked.length ? remainingBlocked : undefined,
+    });
+    refreshDashboardSafe('task-resumed');
+    await postMessage(channelId, [
+      remainingBlocked.length ? `⏸️ *\`${targetId}\` 일부 재개*` : `✅ *\`${targetId}\` 재개 완료*`,
+      ...(lines.length ? lines : ['(변경 없음)']),
+      ...(remainingBlocked.length ? ['', '여전히 conflict/실패인 저장소는 수동 해소가 필요합니다. 해소 후 다시 `머지완료 ' + targetId + '`.'] : []),
+    ].join('\n'), replyTs);
+    return;
+  }
+
+  // ── cancel <Task番号> — スレッド不問でどこからでもキャンセル ──────────────
+  const cancelWithId = cmd.match(/^(?:cancel|취소|キャンセル|中断)\s+(\d{14}|giip-\d{1,6})$/);
+  if (cancelWithId) {
+    const targetId = cancelWithId[1];
+    const entry = Object.entries(taskState.pending || {}).find(([, t]) => t.taskId === targetId);
+    if (entry) {
+      const [key, task] = entry;
+      delete taskState.pending[key];
+      saveJSON(TASK_STATE_FILE, taskState);
+      tm.updateTasklistEntry(targetId, { status: 'cancelled', completedAt: new Date().toISOString() });
+      try { tm.cancelTaskFile(targetId); } catch {}
+      refreshDashboardSafe('task-cancelled');
+      await postMessage(channelId, `🚫 Task \`${targetId}\` をキャンセルしました。\n• ${task.taskTitle}`, replyTs);
+    } else {
+      const runEntry = Object.entries(taskState.running || {}).find(([, t]) => t.taskId === targetId);
+      if (runEntry) {
+        await postMessage(channelId, `⚠️ \`${targetId}\` は実行中のためキャンセルできません。`, replyTs);
+      } else {
+        // taskState にないが .agent/tasks/ ファイルがあればキャンセル
+        const taskFilePath = path.join(AGENT_DIR, 'tasks', `${targetId}.md`);
+        if (fs.existsSync(taskFilePath)) {
+          try {
+            const dest = tm.cancelTaskFile(targetId);
+            tm.updateTasklistEntry(targetId, { status: 'cancelled', completedAt: new Date().toISOString() });
+            refreshDashboardSafe('task-cancelled');
+            await postMessage(channelId, `🚫 Task \`${targetId}\` をキャンセルしました。\n📁 移動先: \`${dest}\``, replyTs);
+          } catch (err) {
+            await postMessage(channelId, `⚠️ キャンセル失敗: ${err.message}`, replyTs);
+          }
+        } else {
+          await postMessage(channelId, `⚠️ Task \`${targetId}\` が見つかりません。\n\`tasklist\` で一覧を確認してください。`, replyTs);
+        }
+      }
+    }
+    return;
+  }
+
+  // ── bare cancel — 待機中 Task の一覧を表示 ───────────────────────────────
+  if (isCancelCmd(text)) {
+    const allPending = Object.entries(taskState.pending || {});
+    if (allPending.length === 0) {
+      await postMessage(channelId, '待機中の Task はありません。', replyTs);
+      return;
+    }
+    const lines = allPending.map(([, t]) => `• \`${t.taskId}\` — ${t.taskTitle}`);
+    await postMessage(channelId, [
+      `*待機中 Task 一覧 (${allPending.length}件)*`,
+      ...lines,
+      '',
+      'キャンセルするには: `cancel <Task番号>`',
+      '例: `cancel ' + allPending[0][1].taskId + '`',
+    ].join('\n'), replyTs);
+    return;
+  }
+
+  // ── go <Task番号> [追加指示] — スレッド不問で指定 Task を実行 ──────────────
+  //   末尾に $ を張らず、`go <番号>` の後ろに続くテキストを「追加指示」として許容する。
+  //   （旧: $ 固定 → コメント行を付けると bare go に落ちて Task 一覧が出るバグ）
+  const goWithId = cmd.match(/^(?:go|start|실행|시작|진행|実行|開始)\s+(\d{14}|giip-\d{1,6})\b/);
+  if (goWithId) {
+    const targetId = goWithId[1];
+    // go <番号> の後ろに続くテキスト = その Task への「追加指示」。原文 text から抽出し
+    //   (大小文字/改行/한글 保持)、Task ファイルへの追記は tm.appendTaskNote に委譲する。
+    const extraNote = text.trim()
+      .replace(/^(?:go|start|실행|시작|진행|実行|開始)\s+(?:\d{14}|giip-\d{1,6})[ \t]*/i, '')
+      .trim();
+    const entry = Object.entries(taskState.pending || {}).find(([, t]) => t.taskId === targetId);
+    if (!entry) {
+      const runEntry = Object.entries(taskState.running || {}).find(([, t]) => t.taskId === targetId);
+      if (runEntry) {
+        await postMessage(channelId, `⚙️ \`${targetId}\` はすでに実行中です。`, replyTs);
+        return;
+      }
+      // .task-state.json になくても .agent/tasks/{id}.md があれば実行
+      const taskFileFallback = path.join(AGENT_DIR, 'tasks', `${targetId}.md`);
+      if (fs.existsSync(taskFileFallback)) {
+        const fc = fs.readFileSync(taskFileFallback, 'utf8');
+        const titleMatch = fc.match(/^# TASK:\s*(.+)$/m);
+        const taskTitle = titleMatch ? titleMatch[1].trim() : `タスク ${targetId}`;
+        const pendingKeyNew = `${channelId}:${replyTs}`;
+        taskState.pending[pendingKeyNew] = { taskId: targetId, taskTitle, taskFile: taskFileFallback, requestText: '', workDir };
+        saveJSON(TASK_STATE_FILE, taskState);
+        if (extraNote && tm.appendTaskNote(targetId, extraNote)) {
+          await postMessage(channelId, `📎 追加指示 (${extraNote.length}字) を Task \`${targetId}\` に反映しました。`, replyTs);
+        }
+        await startTaskExecution(pendingKeyNew, taskState.pending[pendingKeyNew], channelId, replyTs, taskState, workDir);
+      } else {
+        const doneFile   = path.join(AGENT_DIR, 'tasks', 'done',   `${targetId}.md`);
+        const cancelFile = path.join(AGENT_DIR, 'tasks', 'cancel', `${targetId}.md`);
+        if (fs.existsSync(doneFile)) {
+          await postMessage(channelId, `✅ Task \`${targetId}\` はすでに完了しています。\nファイル: \`.agent/tasks/done/${targetId}.md\``, replyTs);
+        } else if (fs.existsSync(cancelFile)) {
+          await postMessage(channelId, `🚫 Task \`${targetId}\` はキャンセル済みです。`, replyTs);
+        } else {
+          await postMessage(channelId, `⚠️ Task \`${targetId}\` が見つかりません。\n\`tasklist\` で一覧を確認してください。`, replyTs);
+        }
+      }
+      return;
+    }
+    const [pendingKey, pendingTask] = entry;
+    if (extraNote && tm.appendTaskNote(targetId, extraNote)) {
+      await postMessage(channelId, `📎 追加指示 (${extraNote.length}字) を Task \`${targetId}\` に反映しました。`, replyTs);
+    }
+    await startTaskExecution(pendingKey, pendingTask, channelId, replyTs, taskState, workDir);
+    return;
+  }
+
+  // ── bare go — 待機中 Task の一覧を表示 ──────────────────────────────────
+  if (isGoCmd(text)) {
+    const allPending = Object.entries(taskState.pending || {});
+    if (allPending.length === 0) {
+      await postMessage(channelId, '待機中の Task はありません。新しいリクエストを入力してください。', replyTs);
+      return;
+    }
+    const lines = allPending.map(([, t]) => `• \`${t.taskId}\` — ${t.taskTitle}`);
+    await postMessage(channelId, [
+      `*待機中 Task 一覧 (${allPending.length}件)*`,
+      ...lines,
+      '',
+      '実行するには: `go <Task番号>`',
+      '例: `go ' + allPending[0][1].taskId + '`',
+    ].join('\n'), replyTs);
+    return;
+  }
+
+  // ── タスク番号による状況照会（14桁数字のみ or "status <14桁>"） ──────────
+  const taskStatusMatch = text.trim().replace(/`/g, '').match(/^(?:status\s+)?(\d{14}|giip-\d{1,6})$/);
+  if (taskStatusMatch) {
+    const targetId = taskStatusMatch[1];
+    const taskFile = path.join(AGENT_DIR, 'tasks', `${targetId}.md`);
+    if (fs.existsSync(taskFile)) {
+      const fc = fs.readFileSync(taskFile, 'utf8');
+      const statusM = fc.match(/^status:\s*(.+)$/m);
+      const requestM = fc.match(/^request:\s*"?([^\n"]{1,120})/m);
+      const status = statusM ? statusM[1].trim() : '不明';
+      const request = requestM ? requestM[1].trim() : '（内容なし）';
+      const logMatch = fc.match(/## 進捗ログ([\s\S]*)/);
+      const logLines = logMatch ? logMatch[1].trim().split('\n').filter(l => l.startsWith('|')).slice(-5).join('\n') : null;
+      let reply = `*タスク \`${targetId}\` — 状況報告*\n• ステータス: ${status}\n• 内容: ${request}`;
+      if (logLines) reply += `\n\n*進捗ログ（直近）:*\n${logLines}`;
+      reply += `\n\n実行: \`go ${targetId}\` | キャンセル: \`cancel ${targetId}\``;
+      await postMessage(channelId, reply, replyTs);
+    } else {
+      await postMessage(channelId, `⚠️ タスク \`${targetId}\` が見つかりません。`, replyTs);
+    }
+    return;
+  }
+
+  // ── push 失敗通知 → 全リポジトリ状況を自動チェック ──────────────────────
+  if (isPushFailureNotice(text)) {
+    await postLong(channelId, checkAllRepoStatus(), replyTs);
+    return;
+  }
+
+  // ── 既存タスクIDへの言及 → 3分岐: 質問=回答 / 修正依頼=再実行 / ID単独=状態表示 ──
+  //   注意: ここでの分類結果は下流の intent 判定でも再利用し、二重の classifyRequest 呼び出しを避ける。
+  let preIntent = null;        // この分岐で確定した意図（下流で再分類しないため）
+  let refTaskContext = '';     // 修正依頼時に本文へ付加する親タスク文脈
+  let reuseTaskId = null;      // 既存タスクID言及の修正依頼 → 新規発給せずこのIDを更新する
+  let linkedIsn = null;        // 既存 giip issue 番号への言及 → 新規 task/issue を作らず #NNN に紐付ける
+  const mentionedIds = extractExistingTaskIds(text);
+  if (mentionedIds.length > 0) {
+    const targetId = mentionedIds[0];
+    const activeFile = [
+      path.join(AGENT_DIR, 'tasks', `${targetId}.md`),
+      path.join(AGENT_DIR, 'tasks', 'done', `${targetId}.md`),
+      path.join(AGENT_DIR, 'tasks', 'cancel', `${targetId}.md`),
+    ].find(f => fs.existsSync(f));
+
+    // テキストがタスクID単独（些末な語のみ）か、指示を含むかを判定
+    const isOnlyId = text.trim().replace(/`/g, '').match(/^(\d{14}|\d{8}_[\w-]+|giip-\d{1,6})$/);
+    if (isOnlyId) {
+      // ① ID単独 → 状態表示のみ（新規タスクは作らない）
+      if (activeFile) {
+        const fc = fs.readFileSync(activeFile, 'utf8');
+        const statusM = fc.match(/^status:\s*(.+)$/m);
+        const requestM = fc.match(/^request:\s*"?([^\n"]{1,100})/m);
+        const status = statusM ? statusM[1].trim() : '不明';
+        const request = requestM ? requestM[1].trim() : '（内容なし）';
+        await postMessage(channelId,
+          `📌 タスク \`${targetId}\` 参照:\n• ステータス: ${status}\n• 内容: ${request}\n📁 ファイル: \`${activeFile}\`\n\n実行: \`go ${targetId}\` | キャンセル: \`cancel ${targetId}\``,
+          replyTs
+        );
+      } else {
+        await postMessage(channelId, `⚠️ タスク \`${targetId}\` が見つかりません。`, replyTs);
+      }
+      return;
+    }
+
+    // ID以外の指示を含む → 意図を判定（下流と共有するため preIntent に保持）
+    preIntent = isForceTaskCmd(text) ? 'task' : await classifyRequest(text, workDir);
+    if (preIntent === 'question') {
+      // ② 質問 → その場で回答（タスクファイルのパスをコンテキストとして付加）
+      const taskContext = activeFile
+        ? `\n\n[参考] タスク ${targetId} のファイルパス: ${activeFile}`
+        : '';
+      await answerInChannel({ channelId, replyTs, text: text + taskContext, workDir, threadTs });
+      return;
+    }
+
+    // ③ 修正・再実行依頼（task）→ 新規タスクは作らず、参照された既存タスクIDを更新する。
+    //    （ユーザ指摘: タスク番号を指定した返信は、その番号のファイルに追記すべきで、
+    //      別番号の新規ファイルを量産してはならない）
+    if (activeFile) {
+      reuseTaskId = targetId;
+      refTaskContext = `\n\n[修正対象] このリクエストは既存タスク ${targetId}（${activeFile}）に対する修正/再実行依頼です。元タスクの内容・成果物を踏まえて対応してください。`;
+      await postMessage(channelId,
+        `🔧 タスク \`${targetId}\` への修正依頼として受け付けました。新規タスクは作らず、このタスクを更新します。`,
+        replyTs
+      );
+    }
+    // ここで return せず、下流の「タスク確定 → 分析 → 更新/作成」フローへ落とす
+  }
+
+  // ── 既存 giip issue 番号への言及 → 新規 task 番号/新規 issue を作らず #NNN に紐付けて処理 ──
+  //   ユーザ指摘(D): issue 番号を指定して処理を頼んだのに新規 task 番号が発給され、さらに #610 のような
+  //   二重 issue まで作られた。既存 issue があるなら実行単位を giip-<isn> に固定(冪等)し、下流の
+  //   reuseTaskId 経路に載せて maybeCreateIssue(新規 issue 作成)をスキップ、#NNN へ紐付け・状態遷移する。
+  //   `admin/giip-issues/609 처리해줘` / `giip issue #609 …` 等の URL・自然文経路を拾う(番号のみ get は giip-commands 側)。
+  if (!reuseTaskId) {
+    const isn = extractGiipIssueRef(text);
+    if (isn) {
+      const forcedGiip = isForceTaskCmd(text);
+      const gIntent = forcedGiip ? 'task' : (preIntent || await classifyRequest(text, workDir));
+      preIntent = gIntent; // 下流の再分類を避けるため確定意図を共有
+      if (gIntent === 'task') {
+        linkedIsn = isn;
+        reuseTaskId = `giip-${isn}`;
+        // DB(SSOT)에서 이슈 본문 + 전체 코멘트 이력을 가져와 재처리 컨텍스트로 주입한다.
+        //   재처리 시점엔 로컬 태스크 파일이 done/ 이동·타 클론 처리로 없을 수 있으나, 코멘트 이력은
+        //   DB 에 남아 있으므로 전체를 읽어 맥락을 이어가야 한다(사용자 지적). best-effort.
+        let giipHistoryBlock = '';
+        try {
+          const hist = await require('./giip-task').fetchIssueHistory(channelId, isn);
+          if (hist && hist.digest) giipHistoryBlock =
+            `\n\n[DB에서 복원한 이슈 이력 — 아래 코멘트 히스토리를 시간순으로 모두 읽고 맥락을 반영해 처리하라]\n${hist.digest}`;
+        } catch (e) { console.error('[Bot] giip 이슈 이력 조회 실패(비치명):', e.message); }
+        refTaskContext = `\n\n[対象 giip issue] このリクエストは既存 giip issue #${isn} の処理依頼です。まず #${isn} の内容を確認し(giip issue get ${isn} 相当)、作業後は結果を #${isn} にコメントして状態遷移してください。新しい issue は作成しないこと。${giipHistoryBlock}`;
+        await postMessage(channelId,
+          forcedGiip
+            // 「처리해줘」等の明示的命令形 = go と等価 → 分析後そのまま自動実行（go 不要）。
+            ? `🔗 giip issue #${isn} の処理依頼として受け付けました。新規 issue/タスク番号は作らず、この issue に紐付けて *そのまま実行* します（\`go\` 不要）。`
+            : `🔗 giip issue #${isn} への処理依頼として受け付けました。新規 issue/タスク番号は作らず、この issue に紐付けて実行します(実行: \`go giip-${isn}\`)。`,
+          replyTs
+        );
+      }
+    }
+  }
+
+  // ── 実行中チェック ────────────────────────────────────────────────────────
+  const running = taskState.running[convKey];
+  if (running) {
+    await postMessage(channelId,
+      `⚙️ \`${running.taskId}\` の作業が進行中です。完了次第、結果をお知らせします。`,
+      replyTs
+    );
+    return;
+  }
+
+  // ── 意図を分類してルーティング ──────────────────────────────────────────────
+  // 明示的タスク作成キーワードがあれば分類器をバイパスして強制 task 化する。
+  // （質問形で始まる複合文の question 誤分類 → 番号未発給を防ぐ）
+  const forcedTask = isForceTaskCmd(text);
+  // preIntent（既存タスクID分岐で確定済み）があれば再分類せず流用する
+  const intent = forcedTask ? 'task' : (preIntent || await classifyRequest(text, workDir));
+  console.log(`[Bot] intent="${intent}"${forcedTask ? ' (forced)' : preIntent ? ' (reused)' : ''} text="${text.slice(0, 60)}"`);
+
+  if (intent === 'question') {
+    // 質問・曖昧 → その場で回答（スレッド内なら全文脈を渡す）
+    await answerInChannel({ channelId, replyTs, text, workDir, threadTs });
+    return;
+  }
+
+  // ── タスク確定 → 類似タスク自動クローズ → Task 分析 ──────────────────────
+  // 同一内容の旧タスクを自動検出してクローズ（既存タスクID更新時はクローズしない）
+  const similarTasks = reuseTaskId ? [] : findSimilarPendingTasks(text);
+  let closedNotice = '';
+  if (similarTasks.length > 0) {
+    const closedLines = [];
+    for (const old of similarTasks) {
+      try { tm.cancelTaskFile(old.taskId); } catch {}
+      Object.keys(taskState.pending).forEach(k => {
+        if ((taskState.pending[k] || {}).taskId === old.taskId) delete taskState.pending[k];
+      });
+      tm.updateTasklistEntry(old.taskId, { status: 'cancelled', completedAt: new Date().toISOString() });
+      closedLines.push(`• \`${old.taskId}\` — ${old.title.slice(0, 50)}`);
+    }
+    saveJSON(TASK_STATE_FILE, taskState);
+    closedNotice = `\n\n⚠️ 同一内容の旧タスクを自動クローズしました:\n${closedLines.join('\n')}`;
+  }
+
+  await postMessage(channelId, '🔍 作業内容を分析中です...', replyTs);
+
+  // 修正依頼（既存タスクID言及）の場合は親タスク文脈を本文に付加して分析・保存する
+  const taskRequestText = text + refTaskContext;
+
+  let planContent, filesRead;
+  try {
+    ({ planContent, filesRead } = tm.analyzeRequest(taskRequestText, null, workDir));
+  } catch (err) {
+    await postMessage(channelId, `分析エラー: ${err.message}`, replyTs);
+    return;
+  }
+
+  const taskTitle = tm.extractTitle(planContent);
+  const taskSummary = tm.extractSummary(planContent);
+
+  // ── giip issue 통일(rule 40): 연결돼 있으면 issue 를 "먼저" 등록(PENDING)하고 그 번호(giip-<isn>)를
+  //   태스크 ID 로 삼는다 → 한 작업 = ID 하나. 미연결/실패 시에만 로컬 타임스탬프로 폴백한다.
+  //   (과거: 타임스탬프를 항상 먼저 발급하고 issue 를 그 위에 덧붙여 ID 두 개[타임스탬프+isn]가 생겼다)
+  //   상태전이(IN_PROGRESS)는 분석이 아니라 실행 시작(startTaskExecution)에서만 한다.
+  let giipIsn = null;
+  let giipIssueError = null; // API 호출 자체가 실패한 경우의 사유(csn/계정 미설정과 구분해 사용자에게 알리기 위함)
+  if (linkedIsn) {
+    // 既存 issue 참조: 新規作成せず #linkedIsn を再利用(reuseTaskId は既に giip-<isn>)。
+    giipIsn = linkedIsn;
+  } else if (!reuseTaskId) {
+    try {
+      const gt = require('./giip-task');
+      // csn 은 처음 언급한 프로젝트명(projectName, 폴더 없어도 해석) 기준(project-csn.json). 없으면 account.csn 폴백.
+      const res = await gt.maybeCreateIssue(channelId, taskTitle, planContent, config.resolveProjectCsn(projectName || workDir));
+      giipIsn = res.isn;
+      giipIssueError = res.error;
+    } catch (e) { console.error('[Bot] giip issue 등록 훅 오류:', e.message); }
+  }
+
+  // ID 통일: 기존 태스크 갱신이면 그 ID, 신규+issue 등록 성공이면 giip-<isn>, 그 외엔 타임스탬프.
+  const taskId = reuseTaskId || (giipIsn ? `giip-${giipIsn}` : tm.getTimestampId());
+  const taskFile = reuseTaskId
+    ? tm.updateTaskFile(taskId, taskRequestText, planContent, filesRead)
+    : tm.createTaskFile(taskId, taskRequestText, planContent, filesRead);
+
+  taskState.pending[convKey] = { taskId, taskTitle, taskFile, requestText: taskRequestText, workDir };
+  if (giipIsn) taskState.pending[convKey].isn = giipIsn;
+  saveJSON(TASK_STATE_FILE, taskState);
+  if (reuseTaskId) {
+    tm.updateTasklistEntry(taskId, { title: taskTitle, summary: taskSummary, status: 'pending', updatedAt: new Date().toISOString() });
+  } else {
+    tm.addToTasklist(taskId, taskTitle, taskSummary, taskRequestText);
+  }
+  refreshDashboardSafe('task-created'); // 대기 항목이 바로 대시보드에 뜨도록
+  // giipIssueError 가 있으면 "csn/계정 미설정으로 조용히 로컬 폴백"이 아니라 API 호출이 실제로 실패한
+  //   것이므로 사유를 노출한다(과거: 둘 다 같은 타임스탬프 ID 로만 보여 원인을 구분할 수 없었다).
+  const isnLine = giipIsn
+    ? `\n🔗 giip issue #${giipIsn}`
+    : (giipIssueError ? `\n⚠️ giip issue 연동 실패(${giipIssueError}) — 로컬 태스크 번호로 진행합니다` : '');
+
+  // 明示的命令形(처리/수정/구현…해줘 = isForceTaskCmd)は「実行の意思確定」= go と等価。
+  //   分析後そのまま実行し、redundant な二度目の `go` を要求しない(ユーザ指摘の恒久対応)。
+  //   曖昧・LLM 分類による task は従来どおり plan+go ゲートを維持する。
+  const autoExec = forcedTask;
+  const footer = autoExec
+    ? `*🚀 明示的な依頼のため自動実行します（\`go\` 不要）。中断: \`cancel ${taskId}\`*`
+    : `*実行: \`go ${taskId}\` / キャンセル: \`cancel ${taskId}\`*`;
+
+  const headline = (reuseTaskId && !linkedIsn) ? 'Task 更新完了' : 'Task 分析完了';
+  await postLong(channelId,
+    `📋 *${headline}* (\`${taskId}\`)${isnLine}${closedNotice}\n\n${planContent}\n\n---\n${footer}`,
+    replyTs
+  );
+
+  if (autoExec) {
+    // pending → running へ即遷移して実行(go <id> と等価)。作業ツリー busy 時は
+    //   startTaskExecution が pending に戻し「go で後ほど再実行」を案内する(直列実行は維持)。
+    await startTaskExecution(convKey, taskState.pending[convKey], channelId, replyTs, taskState, workDir);
+  }
+}
+
+// pending/running task があるスレッドかどうかを確認
+function isActiveTaskThread(channelId, threadTs) {
+  if (!threadTs) return false;
+  const taskState = loadJSON(TASK_STATE_FILE, { pending: {}, running: {} });
+  const convKey = `${channelId}:${threadTs}`;
+  return !!(taskState.pending[convKey] || taskState.running[convKey]);
+}
+
+// ── メッセージ1件を処理 ───────────────────────────────────────────────────────
+async function processMessage({ channelId, msg, isDM, conversations, threadTs }) {
+  const effectiveThreadTs = threadTs || msg.thread_ts || null;
+  const mentionsBot = config.getBotUserId() && msg.text.includes(`<@${config.getBotUserId()}>`);
+  const isTaskReply = isActiveTaskThread(channelId, effectiveThreadTs);
+  // giip-729: 채널에서는 "명시 멘션 + 활성 태스크 스레드"만 응답한다.
+  // 과거의 isBotEngagedThread(7일간 봇이 한 번이라도 말한 스레드) 자동응답은
+  // 봇이 참여했던 스레드의 사람들끼리의 일반 대화(무멘션)까지 개입하게 만들어 제거.
+  // 활성 태스크(pending/running)의 후속 입력은 isTaskReply 로 계속 허용된다.
+
+  const rawCleanText = msg.text
+    .replace(/<@[A-Z0-9]+>/g, '')
+    // Slack tel: link <tel:0120...|0120...> → 数字だけ残す（タスク番号が電話番号リンク化される対策）
+    .replace(/<tel:(\d+)\|[^>]*>/g, '$1')
+    .replace(/<tel:(\d+)>/g, '$1')
+    // Slack URL形式 <https://url|表示テキスト> → URL本体だけ残す
+    .replace(/<(https?:\/\/[^|>]+)\|[^>]*>/g, '$1')
+    // Slack URL形式 <https://url> → URL本体だけ残す
+    .replace(/<(https?:\/\/[^>]+)>/g, '$1')
+    // Slack装飾記号を除去 (*bold* → bold, _italic_ → italic)
+    .replace(/[*_~]/g, '')
+    .replace(/`/g, '')
+    .trim();
+
+  // プロジェクトプレフィックス検出: "giipprj 何か" → giipprj フォルダに切り替え
+  //   さらにチャンネル固定マッピング(channel-project.json)を適用: 明示接頭辞が無ければ
+  //   このチャンネルの既定プロジェクトへ workDir/projectName を固定する（task giip-724）。
+  //   優先順位: 明示接頭辞(Rule 32) > チャンネル固定。cleanText は不変。
+  const { workDir, cleanText, projectName } =
+    config.applyChannelPin(channelId, parseProjectPrefix(rawCleanText));
+
+  const hasFiles = msg.files && msg.files.length > 0;
+  if (hasFiles && !cleanText) {
+    if (mentionsBot || isTaskReply) {
+      await postMessage(channelId, '画像やファイルのみのメッセージは処理できません。テキストで質問してください。', effectiveThreadTs || msg.ts);
+    }
+    return;
+  }
+  if (!cleanText) return;
+
+  if (isDM) {
+    await handleDM({ channelId, ts: msg.ts, threadTs: effectiveThreadTs, text: cleanText, conversations, workDir });
+  } else if (mentionsBot || isTaskReply) {
+    await handleChannelMention({ channelId, ts: msg.ts, threadTs: effectiveThreadTs, text: cleanText, workDir, projectName });
+  }
+}
+
+// ── Socket Mode イベントハンドラ ─────────────────────────────────────────────
+async function onSlackMessage(event, conversations) {
+  // 다른 봇과는 대화 가능(giip-773 후속 지시, 2026-07-26) — 자기 자신이 보낸 메시지만 걸러 무한루프 방지.
+  if ((event.bot_id && event.bot_id === config.getSelfBotId()) || event.subtype || !event.text) return;
+  const isDM = event.channel_type === 'im';
+  try {
+    await processMessage({ channelId: event.channel, msg: event, isDM, conversations });
+  } catch (err) {
+    console.error('[Bot] processMessage error:', err.message);
+  }
+  saveJSON(HISTORY_FILE, conversations);
+}
+
+module.exports = {
+  handleSimpleGitOp,
+  answerInChannel,
+  handleDM,
+  startTaskExecution,
+  drainNextQueued,     // index.js の起動/定期リカバリが凍結キューを解凍するために使う
+  handleChannelMention,
+  isActiveTaskThread,
+  processMessage,
+  onSlackMessage,
+};

--- a/slack-bot-minimax/index.js
+++ b/slack-bot-minimax/index.js
@@ -1,0 +1,292 @@
+/**
+ * giipclaude Bot — Task workflow mode
+ *
+ * 채널 mention 흐름:
+ *   1. mention 수신 → claude 로 TASK 파일 분석/생성 → Slack에 확인 요청
+ *   2. 사용자 "시작/go" → subagent (claude -p) 실행
+ *   3. 완료 → 결과 doc git push → GitHub URL을 Slack에 보고
+ *
+ * DM:
+ *   일반 Q&A 대화 (claude -p)
+ */
+
+require('dotenv').config();
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const tm = require('./task-manager');
+const { SocketModeClient } = require('@slack/socket-mode');
+
+// ── 機能別モジュール (index.js から behavior-preserving で切り出し) ───────────
+const config = require('./config');
+const { BOT_TOKEN, CHANNEL_IDS, SLACK_APP_TOKEN, AGENT_DIR, HISTORY_FILE, TASK_STATE_FILE } = config;
+const { loadJSON, saveJSON } = require('./state');
+const { slackGet } = require('./slack-api');
+const { onSlackMessage, drainNextQueued } = require('./handlers');
+
+// ── 重複プロセス検出・自己終了 ───────────────────────────────────────────────
+function killDuplicateBots() {
+  const myPid = process.pid;
+  const result = spawnSync('powershell', [
+    '-NonInteractive', '-NoProfile', '-Command',
+    `Get-WmiObject Win32_Process -Filter "Name='node.exe'" | Where-Object { $_.CommandLine -like '*index.js*' } | Select-Object -ExpandProperty ProcessId`,
+  ], { encoding: 'utf8', timeout: 6000, windowsHide: true });
+
+  if (result.error) return;
+
+  const otherPids = (result.stdout || '')
+    .split(/\r?\n/)
+    .map(l => parseInt(l.trim(), 10))
+    .filter(p => !isNaN(p) && p !== myPid);
+
+  if (otherPids.length === 0) return;
+
+  console.log(`[Bot] 重複インスタンス検出: PID ${otherPids.join(', ')} → 終了します`);
+  otherPids.forEach(p => {
+    spawnSync('taskkill', ['/F', '/PID', String(p)], { encoding: 'utf8', timeout: 3000, windowsHide: true });
+  });
+}
+
+// ── stale タスク状態のクリーンアップ（起動時 + 定期実行） ─────────────────────
+// running のまま滞留したタスクを実ファイルの位置と経過時間で最終化する。
+// 判定ソース = tasklist.json の running + .task-state.json の running（ライブロック）。
+//   - done/   にファイルあり → completed（resultUrl 付与）
+//   - cancel/ にファイルあり → cancelled（resultUrl 付与）
+//   - どちらでもない（tasks/ 直下に残る or 消失）＝ 中断された未完了タスク:
+//       経過が staleMinutes 以上なら pending へ復帰（再実行待ち）、未満なら実行中の可能性ありとして触らない。
+//
+// staleMinutes:
+//   0  … 起動時。再起動直後の running は全て孤児（サブプロセスは死んでいる）→ 即 reconcile。
+//   30 … 定期実行。生きている実行を巻き込まないよう 30 分以上経過したものだけ pending 復帰。
+function reconcileTaskState({ staleMinutes = 0 } = {}) {
+  const taskState = loadJSON(TASK_STATE_FILE, { pending: {}, running: {} });
+  const TASKS_DIR = path.join(AGENT_DIR, 'tasks');
+  const nowMs = Date.now();
+  let stateChanged = false;
+
+  // ── pending 스윕(신규) ────────────────────────────────────────────────────
+  // reconcile 은 원래 running 만 청소해 pending 은 무한 누적됐다(orphan). 세션·수동
+  // 처리 등 다른 경로로 이미 해소돼 task 파일이 done/·cancel/ 로 이동된 pending 항목을
+  // 여기서 정리한다. 파일이 tasks/ 직하에 남은 = 진짜 미착수 backlog 는 건드리지 않는다
+  // (마커 없는 pending = 수동 `go` 대기라는 drainNextQueued 설계를 존중).
+  const isResolved = (tid) =>
+    fs.existsSync(path.join(TASKS_DIR, 'done', `${tid}.md`)) ||
+    fs.existsSync(path.join(TASKS_DIR, 'cancel', `${tid}.md`));
+  for (const [key, entry] of Object.entries(taskState.pending || {})) {
+    if (entry && entry.taskId && isResolved(entry.taskId)) {
+      delete taskState.pending[key];
+      stateChanged = true;
+      console.log(`[Bot] reconcile: stale pending ${entry.taskId} 제거 (done/cancel 로 이미 해소)`);
+    }
+  }
+
+  // taskId → .task-state.running のキー（ライブロック除去用）
+  const runningKeyByTaskId = {};
+  for (const [key, entry] of Object.entries(taskState.running || {})) {
+    if (entry && entry.taskId) runningKeyByTaskId[entry.taskId] = key;
+  }
+
+  // 対象 = tasklist.json の running ∪ .task-state.json の running（片方漏れ対策）
+  const runningList = tm.getTasklistByStatus('running');
+  const startedAtByTaskId = {};
+  const runningTaskIds = new Set();
+  for (const t of runningList) {
+    runningTaskIds.add(t.taskId);
+    startedAtByTaskId[t.taskId] = t.startedAt || null;
+  }
+  for (const [taskId, key] of Object.entries(runningKeyByTaskId)) {
+    runningTaskIds.add(taskId);
+    if (!(taskId in startedAtByTaskId)) {
+      const e = taskState.running[key];
+      startedAtByTaskId[taskId] = (e && e.startedAt) || null;
+    }
+  }
+  if (!runningTaskIds.size) { if (stateChanged) saveJSON(TASK_STATE_FILE, taskState); return; }
+
+  for (const taskId of runningTaskIds) {
+    const inDone   = fs.existsSync(path.join(TASKS_DIR, 'done',   `${taskId}.md`));
+    const inCancel = fs.existsSync(path.join(TASKS_DIR, 'cancel', `${taskId}.md`));
+
+    let resolution;
+    if (inDone) {
+      resolution = 'completed';
+    } else if (inCancel) {
+      resolution = 'cancelled';
+    } else {
+      // tasks/ 直下に残る or 消失 = 中断された未完了。経過時間で pending 復帰を判断。
+      const started = startedAtByTaskId[taskId] ? Date.parse(startedAtByTaskId[taskId]) : NaN;
+      const ageMin = isNaN(started) ? Infinity : (nowMs - started) / 60000;
+      if (ageMin < staleMinutes) continue; // まだ実行中の可能性 → 触らない
+      resolution = 'pending';
+    }
+
+    if (resolution === 'completed' || resolution === 'cancelled') {
+      tm.updateTasklistEntry(taskId, {
+        status: resolution,
+        completedAt: new Date().toISOString(),
+        resultUrl: tm.getTaskFileUrl(taskId) || null,
+      });
+    } else { // pending 復帰
+      tm.updateTasklistEntry(taskId, { status: 'pending', startedAt: null, completedAt: null });
+    }
+
+    const key = runningKeyByTaskId[taskId];
+    if (key && taskState.running[key]) {
+      delete taskState.running[key];
+      stateChanged = true;
+    }
+    console.log(
+      `[Bot] reconcile: task ${taskId} → ${resolution}` +
+      (resolution === 'pending' ? ` (running ${staleMinutes}m+ 정체 → 재실행 대기)` : '')
+    );
+  }
+
+  if (stateChanged) saveJSON(TASK_STATE_FILE, taskState);
+}
+
+// ── 凍結キューのリカバリ（ghost-occupier freeze 対策） ────────────────────────
+// 直列実行のため、他タスクが作業ツリーを占有中に来たタスクは pending に
+// `queuedBehind` マーカ付きで積まれ、占有タスクの onComplete/onError が
+// drainNextQueued を呼んで初めて自動起動する。ところが占有タスク実行中にボットが
+// 再起動すると、そのサブプロセスは死に onComplete が永遠に発火しない＝
+// queuedBehind の待機タスクは誰にも起動されず「凍結」する（ユーザ報告の“멈춤”の主因）。
+// running が空なのに queuedBehind 待機タスクがある＝この凍結状態なので、ここで一度
+// drainNextQueued を叩いて直列キューを解凍する。running が生きていれば通常経路に任せる。
+async function recoverQueuedOnStartup(reason = 'startup-recovery') {
+  try {
+    const ts = loadJSON(TASK_STATE_FILE, { pending: {}, running: {} });
+    if (Object.keys(ts.running || {}).length > 0) return; // 実行中 → 通常の drain 経路が処理
+    const queued = Object.values(ts.pending || {}).filter(t => t && t.queuedBehind);
+    if (!queued.length) return;
+    console.log(`[Bot] ${reason}: 凍結された待機タスク ${queued.length}件 감지 → drain 시도`);
+    await drainNextQueued(reason);
+  } catch (e) {
+    console.error('[Bot] recoverQueuedOnStartup error:', e.message);
+  }
+}
+
+// ── 起動 ──────────────────────────────────────────────────────────────────────
+async function main() {
+  if (!BOT_TOKEN) { console.error('[Bot] SLACK_BOT_TOKEN が .env にありません'); process.exit(1); }
+  if (!SLACK_APP_TOKEN) { console.error('[Bot] SLACK_APP_TOKEN が .env にありません'); process.exit(1); }
+
+  const ver = spawnSync('claude', ['--version'], { encoding: 'utf8', windowsHide: true });
+  if (ver.error) { console.error('[Bot] claude CLI が見つかりません (PATH 確認)'); process.exit(1); }
+
+  const auth = await slackGet('auth.test');
+  if (!auth.ok) { console.error('[Bot] SLACK_BOT_TOKEN 無効:', auth.error); process.exit(1); }
+  config.setBotUserId(auth.user_id);
+  config.setSelfBotId(auth.bot_id || null);
+
+  console.log('[giipclaude Bot] 起動 — Socket Mode');
+  console.log(`[Bot] ID: ${config.getBotUserId()} (${auth.user}) PID: ${process.pid}`);
+  console.log(`[Bot] 監視チャンネル: ${CHANNEL_IDS.join(', ') || '(DM のみ)'}`);
+
+  killDuplicateBots();
+  // 起動時: 再起動で孤児化した running を即 reconcile（サブプロセスは既に死亡）
+  reconcileTaskState({ staleMinutes: 0 });
+  // 起動時: 占有タスクの死で凍結した queuedBehind 待機タスクを解凍（ghost-occupier freeze）
+  await recoverQueuedOnStartup('startup-recovery');
+
+  // 定期 reconcile: 30分以上 running のまま滞留したタスクを最終化 or pending 復帰。
+  // reconcileTaskState() が「루트에 남은 running」を拾えず再起動しても自動復旧しなかった空白を埋める。
+  const RECONCILE_INTERVAL_MS = 10 * 60 * 1000; // 10分ごと
+  const RECONCILE_STALE_MIN = 30;               // 30分以上経過した running が対象
+  setInterval(() => {
+    try {
+      reconcileTaskState({ staleMinutes: RECONCILE_STALE_MIN });
+      // reconcile で running が空になった直後にも凍結キューが残りうるので続けて解凍を試みる。
+      recoverQueuedOnStartup('periodic-recovery').catch(() => {});
+    } catch (e) {
+      console.error('[Bot] periodic reconcile error:', e.message);
+    }
+  }, RECONCILE_INTERVAL_MS);
+
+  const conversations = loadJSON(HISTORY_FILE, {});
+
+  const socketClient = new SocketModeClient({
+    appToken: SLACK_APP_TOKEN,
+    clientPingTimeout: 10000,  // 10s
+    serverPingTimeout: 60000,  // 1min
+  });
+
+  // ---- Self-healing watchdog (event-driven, zero polling) -----------------
+  // The process can stay "online" while the Slack WebSocket silently dies
+  // (ping/pong timeouts -> "no active connection"); pm2 cannot detect that
+  // because the process itself is alive. We exit(1) on a confirmed dead/stuck
+  // socket so pm2 restarts us with a fresh connection.
+  const RECONNECT_GRACE_MS = 120 * 1000; // must recover within 2min of losing the socket
+  const ACK_FAIL_LIMIT = 6;              // consecutive ack failures => socket is stuck
+  let ackFailStreak = 0;
+  let reconnectTimer = null;
+  const dieAndRestart = (why) => {
+    console.error(`[Bot] self-heal: ${why}. Exiting so pm2 restarts.`);
+    process.exit(1);
+  };
+  const markAlive = () => {
+    ackFailStreak = 0;
+    if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
+  };
+  const armReconnectWatch = (evt) => {
+    if (reconnectTimer) return;
+    console.warn(`[Bot] socket '${evt}' — must recover within ${RECONNECT_GRACE_MS / 1000}s...`);
+    reconnectTimer = setTimeout(() => dieAndRestart(`no reconnect after '${evt}'`), RECONNECT_GRACE_MS);
+  };
+  // Losing the socket arms a grace timer; recovering (or any inbound frame) clears it.
+  ['disconnecting', 'disconnected', 'reconnecting'].forEach(ev => socketClient.on(ev, () => armReconnectWatch(ev)));
+  ['connected', 'authenticated'].forEach(ev => socketClient.on(ev, markAlive));
+
+  const safeAck = async (ack) => {
+    try {
+      await ack();
+      markAlive();
+    } catch (e) {
+      ackFailStreak++;
+      console.warn(`[Bot] ack failed (${ackFailStreak}/${ACK_FAIL_LIMIT}):`, e.message);
+      if (ackFailStreak >= ACK_FAIL_LIMIT) dieAndRestart('too many consecutive ack failures (socket stuck)');
+    }
+  };
+
+  // チャンネルでの @mention (app_mention イベント)
+  socketClient.on('app_mention', async ({ event, ack }) => {
+    await safeAck(ack);
+    console.log('[Bot] app_mention:', event.channel, (event.text || '').slice(0, 60));
+    await onSlackMessage(event, conversations);
+  });
+
+  // DM・スレッド返信 (message イベント — message.im / message.channels 購読時)
+  // @mention を含むチャンネルメッセージは app_mention で処理済みのためスキップ
+  socketClient.on('message', async ({ event, ack }) => {
+    await safeAck(ack);
+    const isDM = event.channel_type === 'im';
+    const mentionsBot = config.getBotUserId() && (event.text || '').includes(`<@${config.getBotUserId()}>`);
+    if (!isDM && mentionsBot) return; // app_mention ハンドラで処理済み — 重複スキップ
+    console.log('[Bot] message:', event.channel_type, (event.text || '').slice(0, 60));
+    await onSlackMessage(event, conversations);
+  });
+
+  // 全WebSocketメッセージをデバッグログ
+  socketClient.on('ws_message', (data) => {
+    // NOTE: do NOT markAlive() here. Inbound frames only prove we can RECEIVE.
+    // The failure mode is a half-open socket that receives but cannot SEND (ack),
+    // so liveness must be confirmed by a successful ack or a 'connected' event only.
+    try {
+      const p = JSON.parse(data.toString());
+      if (p.type !== 'hello' && p.type !== 'disconnect') {
+        console.log('[Debug ws]', p.type, p.payload?.event?.type || '', p.payload?.event?.channel_type || '');
+      }
+    } catch {}
+  });
+
+  socketClient.on('error', (error) => {
+    console.error('[Bot] Socket Mode error:', error.message || error);
+  });
+
+  await socketClient.start();
+  console.log('[Bot] Socket Mode 接続完了 — イベント待機中');
+}
+
+if (require.main === module) {
+  main().catch(err => { console.error('[Bot] Fatal:', err); process.exit(1); });
+}

--- a/slack-bot-minimax/intent.js
+++ b/slack-bot-minimax/intent.js
@@ -1,0 +1,169 @@
+// intent.js — コマンド判定 + 意図分類（task / question）
+// index.js から behavior-preserving で切り出し（ロジック変更なし）。
+
+const { spawnAsync } = require('./claude-cli');
+const accounts = require('./claude-accounts');
+const { BASE_DIR } = require('./config');
+
+// ── 確認コマンド判定 ──────────────────────────────────────────────────────────
+const GO_WORDS = ['go', 'start', '시작', '실행', '진행', 'ok', 'yes', '예', '응', '開始', 'はい', 'よし', '実行', '進める'];
+const CANCEL_WORDS = ['cancel', '취소', 'no', '아니', '중단', 'stop', 'キャンセル', '中断', 'やめ'];
+
+function isGoCmd(text) {
+  const t = text.trim().toLowerCase();
+  // 完全一致 or 「<go語> 」で始まる場合のみ。以前は .includes('시작'/'진행') で
+  // 部分一致していたため「…태스크 파일 만들어서 진행해줘」等の作業依頼文が
+  // 誤って bare go コマンド扱いされていた（番号未発給の原因）。
+  return GO_WORDS.some(w => t === w || t.startsWith(w + ' '));
+}
+function isCancelCmd(text) {
+  const t = text.trim().toLowerCase();
+  return CANCEL_WORDS.some(w => t === w || t.startsWith(w + ' '));
+}
+
+// ── 明示的タスク作成キーワード → 分類器をバイパスして強制 task 化 ──────────────
+// 質問形で始まる複合文（「…맞아? … 태스크 파일 만들어」等）が classifyRequest で
+// question に誤分類され、書込権限を持つ Q&A サブエージェントが番号を発給せずに
+// ファイルを作ってしまう事故を防ぐ。これらの語があれば必ず管理タスク経路へ。
+const FORCE_TASK_PATTERNS = [
+  /태스크\s*등록/,
+  /태스크\s*파일\s*(을|를)?\s*(만들|생성|작성)/,
+  /태스크\s*(을|를)?\s*(만들|생성|작성)/,
+  /작업\s*의뢰/,
+  /タスク\s*(登録|作成|化)/,
+  /task\s*(등록|추가|생성|作成|登録)/i,
+  // 先頭が「태스크등록 …」または「task …」で始まる場合は強制タスク化。
+  //   利用形: `<プロジェクト名> 태스크등록 <内容>` / `<プロジェクト名> task <内容>`
+  //   （プロジェクト名は parseProjectPrefix で workDir に解決済み → ここでは cleanText の先頭）
+  //   tasklist / taskmerge / task7days 等の管理コマンドや「task list」誤爆は否定先読みで除外。
+  /^\s*(?:태스크\s*등록|task)\s+(?!list\b|리스트|목록|一覧|일람|merge\b|병합|7)\S/i,
+  // 実行形(命令形)の指示 — 実装/修正/解決 等ディスク変更を伴う命令は task。
+  //   命令形終結(…해줘/…해라/…해 주세요/…해봐)だけを対象にし、質問形(…돼 있어?/…했어?)と区別する。
+  //   例: "…해결을 해라" / "구현해줘" / "수정해라" / "반영해 주세요"
+  //   업데이트/갱신/번역/현행화 系(ディスク書込を伴う)も追加 — "…일본어로 업데이트 해줘"が
+  //   決定的 fast-path を素通りして flaky LLM classifier で question に誤分類され、質問経路で
+  //   ファイルが未コミットのまま残り PR 未生成になった事故(giip-629 追加依頼)を恒久修正する。
+  /(구현|수정|해결|반영|적용|배포|개선|보완|생성|작성|처리|점검|리팩터링?|리팩토링|업데이트|업뎃|갱신|번역|현행화|일본어화)\s*(을|를|이|가)?\s*(해\s*줘|해라|하라|해\s*주세요|하세요|해봐|해다오|해\s*주라)/,
+  //   고치다/만들다 系の命令形。
+  /고쳐\s*(줘|라|주세요|주라)/,
+  /만들어\s*(줘|라|주세요|주라)/,
+  // 「計算/集計/推定 …(해서) 보여줘/표시/출력/노출」= ページに計算結果を描画する ⇒ コード変更(task)。
+  //   「보여줘」単体は読み取り質問(例: "로그 보여줘" / "비용 보여줘")なので拾わず、計算系動詞との
+  //   共起時のみ task 化して誤爆を防ぐ。恒久修正の契機: "이번 달 예상 금액을 계산해서 보여줘" が
+  //   LLM classifier で question に誤分類され(実測 flaky: 프롬프트 예시조차 4/4 question)、giip issue
+  //   未登録・PR 未生成のまま質問経路で直接編集される事故が起きた。決定的 fast-path で恒久化する。
+  /(계산|집계|합산|추정|산출)\s*(을|를)?\s*(해서|하여|해\s*서|해|한|하도록)?\s*(보여|표시|노출|출력)\s*(해\s*)?(줘|주세요|주라|줄래|달라|다오|주세여)/,
+];
+function isForceTaskCmd(text) {
+  const t = text.replace(/`/g, '');
+  return FORCE_TASK_PATTERNS.some(re => re.test(t));
+}
+
+// ── 決定的 question fast-path: 純粋な「確認/照会」依頼 ─────────────────────────
+// ユーザ指摘: 「…확인 가능해?」「…확인해줘」のような読み取り専用の確認依頼が
+// LLM classifier(flaky)で task に誤分類され、不要な giip issue が発給された(#622)。
+// ディスク書込を伴う動詞(구현/수정/저장/파일… force-task 相当)を一切含まず、
+// 確認/照会マーカー(확인 가능/확인해줘/알려줘/뭐였는지/뭐야 等)のみで構成される
+// メッセージは、LLM を呼ばず決定的に question として即答経路へ回す。
+// 安全順序: 呼び出し側は必ず isForceTaskCmd を先に評価するため、書込を伴う命令形は
+// ここに到達しない。加えて WRITE_INTENT_MARKERS で二重に除外し誤爆を防ぐ。
+const CONFIRM_QUERY_MARKERS = [
+  /확인\s*(가능|할\s*수\s*있|해\s*줄|해\s*줘|해\s*주세요|해\s*주라|좀|부탁|돼|되나|되니|가능해|가능한가|가능할까)/,
+  /알려\s*(줘|주세요|주라|줄래|다오)/,
+  /뭐(였|야|예요|냐|니|지)/,
+  /뭔지|무엇\s*(인지|이야|인가)/,
+  /어떻게\s*(돼|되나|됐|되었)/,
+];
+// これらが含まれると「単なる確認」ではない(書込/実装/計算を伴う) → fast-path 対象外。
+const WRITE_INTENT_MARKERS = /(저장|파일|폴더|구현|수정|해결|반영|적용|배포|개선|보완|생성|작성|계산|집계|합산|추정|산출|만들|고쳐|고치|등록|추가|처리|점검|리팩터|리팩토|커밋|푸시|push|업데이트|업뎃|갱신|번역|현행화|일본어화)/;
+
+function isConfirmationQuery(text) {
+  const t = text.replace(/`/g, '');
+  if (WRITE_INTENT_MARKERS.test(t)) return false;
+  return CONFIRM_QUERY_MARKERS.some(re => re.test(t));
+}
+
+// ── 意図分類 (task / question) ────────────────────────────────────────────────
+// 「タスク登録」「task登録」等の明記、または明確な作業依頼 → "task"
+// 曖昧・質問・情報照会 → "question"
+async function classifyRequest(text, workDir = BASE_DIR) {
+  // git push / pull / stash などの単純操作はタスク不要 → 即 question
+  if (/^\s*(git\s+(push|pull|stash|fetch|merge|rebase|status|log|diff)|タスク(?:一覧|リスト|確認|状況)|tasklist|task7d)/i.test(text.replace(/[^\x00-\x7Fぁ-ん亜-熙ー]/g, ' '))) {
+    return 'question';
+  }
+
+  // 純粋な確認/照会依頼は LLM を呼ばず決定的に question へ（#622: 확인 요청が task 誤分類）。
+  if (isConfirmationQuery(text)) return 'question';
+
+  const prompt = `You are an assistant that classifies the intent of Slack messages.
+
+Message: "${text}"
+
+Classify using the following rules:
+- "task": applies when the request requires creating or modifying ANY file on disk:
+  1. Explicit registration instruction such as "태스크 등록", "task 추가", "작업 의뢰" etc.
+  2. Code change, feature addition, bug fix, refactoring, or configuration file modification
+  3. A combination like "do A, and also git push" where A involves file changes
+  4. Document/spec creation and saving: "사양서 만들어 저장", "문서로 저장", "파일로 저장해줘", "작성해서 저장", "만들어서 저장"
+  5. Any request that ends with saving/writing output to a file or folder on disk
+
+  6. Imperative requests to implement, fix, solve, add, change, or "calculate and show" a
+     page / feature / behavior — even when phrased as "…보여줘", "…체크하고 해결해라",
+     "…고쳐줘", "구현해줘" — because fulfilling them requires modifying code or config.
+     A request that reports something is missing/broken/unimplemented and then asks to fix
+     or realize it ("아직 구현이 안된 거 같아 … 계산해서 보여줘") is "task".
+
+- "question": applies when NO file needs to be created or modified:
+  1. Question, information inquiry, explanation request (no file output expected)
+  2. Status check, deployment check, environment check, log review
+  3. File path inquiry, dashboard check, system status confirmation
+  4. Investigation or research only (no file output expected)
+  5. Message consisting only of "git push" or "git pull" (no other work instructions)
+
+Key principle: If the request involves writing, saving, or creating ANY file on disk — classify as "task".
+A read-only phrasing like "보여줘/확인해줘" does NOT make it a question when satisfying it
+requires implementing or changing code.
+
+Examples:
+- "azure-cost 페이지에 이번 달 예상 금액을 계산해서 보여줘" → task (needs a code change to add the calculation)
+- "csn 2 에 등록된 logical machine 이 사라진 원인 체크하고 문제 해결을 해라" → task (fix requires code/query change)
+- "지금 배포 상태 어때?" → question
+- "azure-cost 페이지 URL 이 뭐야?" → question
+
+Reply with only one word: "task" or "question". No explanation needed.`;
+
+  try {
+    const acct = accounts.pickAccount();
+    const result = await spawnAsync('claude', ['-p', '--model', 'claude-opus-4-8'], {
+      cwd: workDir,
+      timeout: 60000,
+      env: accounts.envFor(acct),
+      input: prompt, // 프롬프트는 stdin 으로 (ENAMETOOLONG 회피)
+    });
+    if (result.status !== 0) {
+      // 한도 메시지가 stdout에 찍히는 경우가 있어(giip-759) 두 스트림 모두 확인한다.
+      const combinedOut = `${result.stdout || ''}\n${result.stderr || ''}`;
+      if (accounts.isUsageLimit(combinedOut)) accounts.noteUsageLimit(acct, combinedOut);
+      return 'question';
+    }
+    const out = (result.stdout || '').trim().toLowerCase();
+    return out.startsWith('task') ? 'task' : 'question';
+  } catch {
+    return 'question'; // timeout·오류 시 질문으로 폴백
+  }
+}
+
+// ── チャンネル Q&A (質問と判定されたときのインライン回答) ────────────────────
+// git push / pull のみ（他の作業を含まない）を実行して結果を返す
+// 「A機能を修正して git push して」のような複合指示には反応しない
+function isPureGitOp(text) {
+  // Korean/Chinese/全角を除去し、残ったテキストが git コマンドとその助詞のみか確認
+  const stripped = text
+    .replace(/<[^>]+>/g, '')          // Slack mrkdwn タグ除去
+    .replace(/[^\x00-\x7Fぁ-ん亜-熙ー]/g, ' ')  // Korean等を空白に
+    .trim();
+  // "git push [して/する/お願い/etc]" のみで構成されているか
+  return /^git\s+(push|pull)(\s+(して|する|してください|お願い|please|원|해줘|해주세요))?$/i.test(stripped);
+}
+
+module.exports = { isGoCmd, isCancelCmd, isForceTaskCmd, isConfirmationQuery, isPureGitOp, classifyRequest };

--- a/slack-bot-minimax/k-layer.js
+++ b/slack-bot-minimax/k-layer.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const path = require('path');
+
+const NOTES_DIR = path.join(__dirname, '..', '.agent', 'knowledge', 'notes');
+
+const KEYWORDS = {
+  'auth': ['auth', '인증', 'login', '로그인', 'jwt', 'token', 'sso'],
+  'mobile-order': ['order', '주문', 'code', 'access', 'mobile', '코드'],
+  'deployment': ['deploy', '배포', 'azure', 'git push', 'static', 'css'],
+  'debug': ['error', 'bug', 'fail', '오류', '에러', '버그', '실패', '무효'],
+  'api': ['api', 'endpoint', 'request', 'response', '엔드포인트'],
+  'storage': ['storage', 'blob', 'file', '파일', 'upload'],
+  'agent-setup': ['hook', 'trace', 'k-layer', 'skill', 'klayer'],
+  'design-references': ['pjcatapult', 'design', 'デザイン', 'mock', 'html', 'kashiwa', 'top page', 'トップ', 'ローカル', 'local', 'github', 'raw.github'],
+};
+
+function searchKLayer(prompt) {
+  const text = (prompt || '').toLowerCase();
+  const matchedTopics = new Set();
+
+  for (const [topic, keys] of Object.entries(KEYWORDS)) {
+    if (keys.some(k => text.includes(k))) matchedTopics.add(topic);
+  }
+
+  const relevantClaims = [];
+  try {
+    const noteFiles = fs.readdirSync(NOTES_DIR).filter(f => f.endsWith('.md'));
+    for (const file of noteFiles) {
+      const topicKey = file.replace('.md', '');
+      const isRelevant =
+        matchedTopics.size === 0 ||
+        [...matchedTopics].some(t => file.includes(t) || topicKey.includes(t));
+
+      if (!isRelevant) continue;
+
+      const content = fs.readFileSync(path.join(NOTES_DIR, file), 'utf8');
+      const claimBlocks = content.split(/\n(?=CLAIM-\d+:)/);
+      for (const block of claimBlocks) {
+        if (!block.startsWith('CLAIM-')) continue;
+        if (block.includes('invalidated_at**: null') || block.includes('invalidated_at: null')) {
+          const firstLine = block.split('\n')[0];
+          relevantClaims.push(`[${file}] ${firstLine}`);
+          if (relevantClaims.length >= 10) break;
+        }
+      }
+      if (relevantClaims.length >= 10) break;
+    }
+  } catch {}
+
+  return relevantClaims;
+}
+
+module.exports = { searchKLayer };

--- a/slack-bot-minimax/minimax-accounts.js
+++ b/slack-bot-minimax/minimax-accounts.js
@@ -1,0 +1,60 @@
+/**
+ * minimax-accounts.js — MiniMax Token Plan을 1순위 실행 엔진으로 쓰기 위한 pseudo-account.
+ *
+ * 우선순위(사용자 지정, giip-780대 후속): MiniMax 먼저 쓰고, MiniMax 한도 소진 시에만 Claude로 폴백.
+ * (claude-accounts.js 의 실제 Claude 구독 계정 로테이션이 최종 폴백 — 그쪽은 건드리지 않는다.)
+ *
+ * MiniMax는 Anthropic Messages API 호환 엔드포인트(https://api.minimax.io/anthropic)를 제공한다
+ * (실측: curl POST /anthropic/v1/messages 200, tool_use 블록 정상 반환 — 2026-07-27).
+ * 그래서 `claude` CLI 자체를 그대로 spawn하되 ANTHROPIC_BASE_URL/ANTHROPIC_API_KEY 만 바꿔치기하면
+ * 새 에이전트 루프를 만들 필요 없이 기존 파일편집/Bash/PR 흐름을 그대로 재사용할 수 있다.
+ *
+ * 키 종류 주의: MiniMax는 종량제 API Key 와 Token Plan 전용 Subscription Key(sk-cp- 접두)가
+ * 서로 호환되지 않는다. MINIMAX_API_KEY 에는 반드시 sk-cp- 로 시작하는 구독 키를 넣는다.
+ */
+
+const DEFAULT_MODEL = 'MiniMax-M2.7';
+const ANTHROPIC_BASE_URL = 'https://api.minimax.io/anthropic';
+const DEFAULT_COOLDOWN_MS = 60 * 60 * 1000; // 1h — MiniMax 쪽 리셋 주기를 모르므로 보수적 기본값
+
+let cooldownUntil = 0; // 단일 계정(구독 키 1개)이라 claude-accounts.js처럼 배열 대신 모듈 전역 상태로 충분
+
+/** 설정 여부 + 쿨다운 확인 후 pseudo-account 반환. 키 없음/쿨다운 중이면 null(호출측은 Claude로 폴백). */
+function resolve() {
+  const apiKey = process.env.MINIMAX_API_KEY;
+  if (!apiKey) return null;
+  if (cooldownUntil && cooldownUntil > Date.now()) return null;
+  return {
+    name: 'minimax',
+    provider: 'minimax',
+    model: process.env.MINIMAX_MODEL || DEFAULT_MODEL,
+    apiKey,
+  };
+}
+
+/** claude CLI spawn 용 env. CLAUDE_CONFIG_DIR(실 계정 OAuth 세션)은 반드시 제거 — 남아있으면
+ *  claude CLI 가 ANTHROPIC_API_KEY 대신 그 세션을 쓰려 해 혼선이 생길 수 있다. */
+function envFor(account) {
+  const env = { ...process.env };
+  delete env.CLAUDE_CONFIG_DIR;
+  env.ANTHROPIC_BASE_URL = ANTHROPIC_BASE_URL;
+  env.ANTHROPIC_API_KEY = account.apiKey;
+  env.ANTHROPIC_MODEL = account.model;
+  return env;
+}
+
+// MiniMax/일반 API 한도 표현(429, quota, insufficient balance 등) 휴리스틱 탐지.
+// 정확한 문구를 아직 실측하지 못했으므로 넓게 잡는다 — 오탐 시에도 Claude 폴백일 뿐 안전.
+const USAGE_LIMIT_RE = /\b429\b|rate limit|quota|insufficient balance|insufficient.{0,10}credit|too many requests/i;
+function isUsageLimit(text) {
+  return USAGE_LIMIT_RE.test(text || '');
+}
+
+/** 한도 감지 시 쿨다운 설정(기본 1h, MINIMAX_COOLDOWN_MS 로 조정 가능) — 그동안은 resolve()가 null. */
+function noteUsageLimit() {
+  const ms = Number(process.env.MINIMAX_COOLDOWN_MS) || DEFAULT_COOLDOWN_MS;
+  cooldownUntil = Date.now() + ms;
+  console.log(`[minimax-accounts] usage limit 감지 → cooldown ${Math.round(ms / 60000)}분 (Claude로 폴백)`);
+}
+
+module.exports = { resolve, envFor, isUsageLimit, noteUsageLimit, DEFAULT_MODEL, ANTHROPIC_BASE_URL };

--- a/slack-bot-minimax/package-lock.json
+++ b/slack-bot-minimax/package-lock.json
@@ -1,0 +1,677 @@
+{
+  "name": "smartorder-slack-bot",
+  "version": "2.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "smartorder-slack-bot",
+      "version": "2.0.0",
+      "dependencies": {
+        "@slack/socket-mode": "^2.0.7",
+        "dotenv": "^16.4.5"
+      },
+      "devDependencies": {
+        "bcryptjs": "^3.0.3",
+        "pg": "^8.21.0"
+      }
+    },
+    "node_modules/@slack/logger": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.1.tgz",
+      "integrity": "sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ==",
+      "dependencies": {
+        "@types/node": ">=18"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@slack/socket-mode": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@slack/socket-mode/-/socket-mode-2.0.7.tgz",
+      "integrity": "sha512-qYy07je71WnEHgRwmw12DlAnZLi5HXmdlI2WUzUK2LH/rYXQpP6uEg462S5CwfE8FoCKUdIigHtYnOOfzZH1lQ==",
+      "dependencies": {
+        "@slack/logger": "^4.0.1",
+        "@slack/web-api": "^7.15.0",
+        "@types/node": ">=18",
+        "@types/ws": "^8",
+        "eventemitter3": "^5",
+        "ws": "^8"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@slack/types": {
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.21.1.tgz",
+      "integrity": "sha512-I8vmSjNYWsaxuWPx6dz4yeh0h7vRBWbgAMK14LEmblbZ404BtrPbXs6jDPx4cYgGf8msDGF4A9opLZBu21FViQ==",
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/web-api": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.17.0.tgz",
+      "integrity": "sha512-jejr34a8B4L5AS713wOAx1LAqNkW16HVMDEa6sYBvFDc/llUBl8hXaiI4BwF+Al+Sug19Vn2O7iokTVIhVvZ1Q==",
+      "dependencies": {
+        "@slack/logger": "^4.0.1",
+        "@slack/types": "^2.21.0",
+        "@types/node": ">=18",
+        "@types/retry": "0.12.0",
+        "axios": "^1.16.0",
+        "eventemitter3": "^5.0.1",
+        "form-data": "^4.0.4",
+        "is-electron": "2.2.2",
+        "is-stream": "^2",
+        "p-queue": "^6",
+        "p-retry": "^4",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "dev": true,
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/is-electron": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg=="
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pg": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
+      "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
+      "dev": true,
+      "dependencies": {
+        "pg-connection-string": "^2.13.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.14.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
+      "dev": true
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "dev": true,
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
+      "dev": true
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dev": true,
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4"
+      }
+    }
+  }
+}

--- a/slack-bot-minimax/package.json
+++ b/slack-bot-minimax/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "giipclaude-bot",
+  "version": "2.0.0",
+  "description": "giipclaude Bot — claude CLI task workflow (no Anthropic API key needed)",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "@slack/socket-mode": "^2.0.7",
+    "dotenv": "^16.4.5"
+  },
+  "devDependencies": {
+    "bcryptjs": "^3.0.3",
+    "pg": "^8.21.0"
+  }
+}

--- a/slack-bot-minimax/project-csn.json
+++ b/slack-bot-minimax/project-csn.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "Slack에서 처음 언급한 프로젝트명(소문자) → giip csn 매핑. '<프로젝트명> issue 등록 <내용>' 로 말하면 그 프로젝트의 csn 으로 giip issue 를 등록한다(예: 'caci-mimity issue 등록 ...' → csn 70422). 다수 프로젝트는 여기 map 에 항목만 추가하면 된다(코드 변경 불필요). PROJECTS_ROOT 직하에 같은 이름 폴더가 있으면 그 폴더로 작업 전환도 되고, 폴더가 없어도 이 map 에 있으면 이름만으로 csn 라우팅된다(그 경우 workDir 은 lowyworkenv 로 안전 폴백). 여기에 없으면 account.csn(default)로 폴백. index.js/handlers.js에 하드코딩하지 말고 이 파일로만 관리한다. ⚠️ 새 csn 라우팅: (1) 여기 map 에 항목을 추가하고, (2) 봇 유저(uSn 29)가 그 csn 의 멤버여야 한다(tUserPerCorp). 멤버십이 없으면 SP pApiGiipIssuePutbyAK 의 게이트가 홈 csn(47)으로 조용히 클램프한다. 20260723부터 Slack `giip project set <프로젝트> <csn>` 이 (2)를 자동화한다: 봇 SK 로 pApiUserPerCorpGrantBotbySk 를 호출해 tUserPerCorp 에 (29,<csn>) 을 멱등 부여하므로 수동 시드/재배포가 불필요하다(계정 미설정 시엔 map 만 저장되고 부여는 스킵 → 경고 표시). 전체 재시드 SSOT 는 giipdb/data/seed_tUserPerCorp_botuser.sql. 또한 `giip project set` 으로만 넣은 항목은 미커밋이라 봇의 git churn 에 유실되므로, 항목은 반드시 이 파일에 커밋한다. 비밀 아님 → git 추적.",
+  "map": {
+    "lweb02": 2,
+    "ecokaku-aidc": 70417,
+    "caci-mimity": 70422,
+    "caci-aqchat": 70423,
+    "ssm": 70335,
+    "lowyworkenv": 33,
+    "giip-fde-agent": 70424
+  }
+}

--- a/slack-bot-minimax/register-startup.ps1
+++ b/slack-bot-minimax/register-startup.ps1
@@ -1,0 +1,43 @@
+# PM2 SlackBot 자동 시작 등록 스크립트
+# 관리자 권한으로 실행 필요
+# PC마다 사용자명·pm2 설치 경로가 다를 수 있어 현재 세션 기준으로 자동 탐지한다(하드코딩 금지).
+
+$currentUser = "$env:USERDOMAIN\$env:USERNAME"
+
+$pm2Cmd = Get-Command pm2.cmd -ErrorAction SilentlyContinue
+if (-not $pm2Cmd) { $pm2Cmd = Get-Command pm2 -ErrorAction SilentlyContinue }
+if (-not $pm2Cmd) {
+    Write-Error "pm2 실행 파일을 찾을 수 없습니다. 'npm install -g pm2' 후 다시 실행하세요."
+    exit 1
+}
+$pm2Path = $pm2Cmd.Source
+$taskName = "PM2-SlackBot-Resurrect"
+
+$action = New-ScheduledTaskAction `
+    -Execute "cmd.exe" `
+    -Argument "/c `"$pm2Path`" resurrect"
+
+$trigger = New-ScheduledTaskTrigger -AtLogOn -User $currentUser
+
+$settings = New-ScheduledTaskSettingsSet `
+    -ExecutionTimeLimit (New-TimeSpan -Minutes 5) `
+    -RestartCount 3 `
+    -RestartInterval (New-TimeSpan -Minutes 1) `
+    -StartWhenAvailable $true
+
+$principal = New-ScheduledTaskPrincipal `
+    -UserId $currentUser `
+    -LogonType Interactive `
+    -RunLevel Highest
+
+Register-ScheduledTask `
+    -TaskName $taskName `
+    -Action $action `
+    -Trigger $trigger `
+    -Settings $settings `
+    -Principal $principal `
+    -Description "PC 재기동 시 pm2 slack-bot 자동 시작" `
+    -Force
+
+Write-Host "✅ Task Scheduler 등록 완료: $taskName" -ForegroundColor Green
+Get-ScheduledTask -TaskName $taskName | Select-Object TaskName, State

--- a/slack-bot-minimax/repo-status.js
+++ b/slack-bot-minimax/repo-status.js
@@ -1,0 +1,76 @@
+// repo-status.js — git リポジトリスキャン + push 状況チェック
+// index.js から behavior-preserving で切り出し（ロジック変更なし）。
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const { PROJECTS_ROOT } = require('./config');
+
+// ── PROJECTS_ROOT 直下の git リポジトリを動的スキャン ────────────────────────
+function discoverGitRepos() {
+  let entries;
+  try { entries = fs.readdirSync(PROJECTS_ROOT, { withFileTypes: true }); }
+  catch { return []; }
+
+  return entries
+    .filter(e => e.isDirectory() && fs.existsSync(path.join(PROJECTS_ROOT, e.name, '.git')))
+    .map(e => {
+      const dir = path.join(PROJECTS_ROOT, e.name);
+      const branchRes = spawnSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+        cwd: dir, encoding: 'utf8', timeout: 5000, windowsHide: true,
+      });
+      const branch = (branchRes.stdout || '').trim() || 'main';
+      return { name: e.name, dir, branch };
+    });
+}
+
+// ── 全リポジトリ push 状況チェック ───────────────────────────────────────────
+function checkAllRepoStatus() {
+  const repos = discoverGitRepos();
+
+  const lines = ['*📊 全リポジトリ push 状況チェック*', ''];
+  let hasIssues = false;
+
+  for (const repo of repos) {
+    const unpushed = spawnSync('git', ['log', `origin/${repo.branch}..HEAD`, '--oneline'], {
+      cwd: repo.dir, encoding: 'utf8', timeout: 10000, windowsHide: true,
+    });
+    const unpushedLines = (unpushed.stdout || '').trim().split('\n').filter(Boolean);
+
+    const dirty = spawnSync('git', ['status', '--short'], {
+      cwd: repo.dir, encoding: 'utf8', timeout: 10000, windowsHide: true,
+    });
+    const dirtyLines = (dirty.stdout || '').trim().split('\n').filter(Boolean);
+
+    if (unpushedLines.length === 0 && dirtyLines.length === 0) {
+      lines.push(`✅ \`${repo.name}\` — clean`);
+    } else {
+      hasIssues = true;
+      lines.push(`⚠️ \`${repo.name}\`:`);
+      if (unpushedLines.length > 0) {
+        lines.push(`  • 未 push コミット: ${unpushedLines.length}件`);
+        unpushedLines.slice(0, 3).forEach(l => lines.push(`    \`${l.slice(0, 72)}\``));
+        if (unpushedLines.length > 3) lines.push(`    …他 ${unpushedLines.length - 3}件`);
+      }
+      if (dirtyLines.length > 0) {
+        lines.push(`  • 未コミット変更: ${dirtyLines.length}ファイル`);
+      }
+    }
+  }
+
+  if (repos.length === 0) lines.push('_(git リポジトリが見つかりません)_');
+  lines.push('');
+  lines.push(hasIssues
+    ? '🔧 未 push の変更があります。確認してください。'
+    : '✅ 全リポジトリ最新 — push 漏れなし'
+  );
+  return lines.join('\n');
+}
+
+function isPushFailureNotice(text) {
+  return /git\s*push\s*(失敗|failed|エラー|error)/i.test(text)
+    || /push\s*(失敗|failed)/i.test(text)
+    || /作業完了[^\n]*git\s*push\s*失敗/i.test(text);
+}
+
+module.exports = { discoverGitRepos, checkAllRepoStatus, isPushFailureNotice };

--- a/slack-bot-minimax/reset_password.js
+++ b/slack-bot-minimax/reset_password.js
@@ -1,0 +1,80 @@
+/**
+ * auth ユーザーのパスワードをリセット
+ * 使い方: node reset_password.js <email> <new_password> [env_file_path]
+ *
+ * DB接続情報は以下の順で読み込む:
+ *   1. 引数で指定した .env ファイル
+ *   2. ../vgt-vegetrade-auth-api/.env
+ *   3. 環境変数 (DB_HOST, DB_NAME, DB_USER, DB_PASSWORD)
+ */
+
+const fs = require('fs');
+const path = require('path');
+const bcrypt = require('bcryptjs');
+const { Client } = require('pg');
+
+function loadEnv(filePath) {
+  try {
+    const lines = fs.readFileSync(filePath, 'utf8').split('\n');
+    for (const line of lines) {
+      const m = line.match(/^\s*([^#=\s]+)\s*=\s*(.*)\s*$/);
+      if (m && !process.env[m[1]]) process.env[m[1]] = m[2].replace(/^['"]|['"]$/g, '');
+    }
+    console.log(`[設定] .env 読込: ${filePath}`);
+  } catch {}
+}
+
+// .env を探して読み込む
+const [,, email, newPassword, envArg] = process.argv;
+
+if (!email || !newPassword) {
+  console.error('使い方: node reset_password.js <email> <new_password> [.env_path]');
+  process.exit(1);
+}
+
+if (envArg) {
+  loadEnv(envArg);
+} else {
+  loadEnv(path.join(__dirname, '..', 'vgt-vegetrade-auth-api', '.env'));
+  loadEnv(path.join(__dirname, '.env'));
+}
+
+const dbConfig = {
+  host:     process.env.DB_HOST     || 'localhost',
+  port:     parseInt(process.env.DB_PORT || '5432'),
+  database: process.env.DB_NAME     || '',
+  user:     process.env.DB_USER     || '',
+  password: process.env.DB_PASSWORD || '',
+  ssl: (process.env.DB_SSLMODE || 'require') === 'disable' ? false : { rejectUnauthorized: false },
+};
+
+if (!dbConfig.database || !dbConfig.user) {
+  console.error('エラー: DB_HOST / DB_NAME / DB_USER / DB_PASSWORD が未設定です。');
+  console.error('  → ../vgt-vegetrade-auth-api/.env に記載するか、環境変数をセットしてください。');
+  process.exit(1);
+}
+
+(async () => {
+  const hashed = await bcrypt.hash(newPassword, 12);
+  const client = new Client(dbConfig);
+
+  try {
+    await client.connect();
+    const res = await client.query(
+      `UPDATE public.user_accounts
+         SET encrypted_password = $1, updated_at = NOW()
+       WHERE lower(email) = $2`,
+      [hashed, email.toLowerCase()]
+    );
+    if (res.rowCount === 0) {
+      console.error(`エラー: '${email}' が見つかりません。`);
+      process.exit(1);
+    }
+    console.log(`完了: ${email} のパスワードを変更しました。`);
+  } catch (err) {
+    console.error('DB エラー:', err.message);
+    process.exit(1);
+  } finally {
+    await client.end();
+  }
+})();

--- a/slack-bot-minimax/slack-api.js
+++ b/slack-bot-minimax/slack-api.js
@@ -1,0 +1,143 @@
+// slack-api.js — Slack Web API 呼び出し + メッセージ整形/スレッド取得
+// index.js から behavior-preserving で切り出し（ロジック変更なし）。
+
+const https = require('https');
+const config = require('./config');
+const { BOT_TOKEN } = config;
+const { markThreadEngaged } = require('./state');
+
+// ── Slack API ─────────────────────────────────────────────────────────────────
+function slackGet(method, params = {}) {
+  return new Promise((resolve) => {
+    const qs = new URLSearchParams(params).toString();
+    const req = https.get({
+      hostname: 'slack.com',
+      path: `/api/${method}${qs ? '?' + qs : ''}`,
+      headers: { 'Authorization': `Bearer ${BOT_TOKEN}`, 'User-Agent': 'giipclaude-bot/1.0' },
+    }, (res) => {
+      let d = ''; res.on('data', c => { d += c; }); res.on('end', () => {
+        try { resolve(JSON.parse(d)); } catch { resolve({ ok: false }); }
+      });
+    });
+    req.on('error', () => resolve({ ok: false }));
+    req.setTimeout(10000, () => { req.destroy(); resolve({ ok: false }); });
+  });
+}
+
+function slackPost(method, body) {
+  return new Promise((resolve) => {
+    const payload = JSON.stringify(body);
+    const req = https.request({
+      hostname: 'slack.com', path: `/api/${method}`, method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${BOT_TOKEN}`,
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(payload),
+        'User-Agent': 'giipclaude-bot/1.0',
+      },
+    }, (res) => {
+      let d = ''; res.on('data', c => { d += c; }); res.on('end', () => {
+        try { resolve(JSON.parse(d)); } catch { resolve({ ok: false }); }
+      });
+    });
+    req.on('error', () => resolve({ ok: false }));
+    req.write(payload); req.end();
+  });
+}
+
+async function postMessage(channel, text, thread_ts) {
+  const body = { channel, text };
+  if (thread_ts) body.thread_ts = thread_ts;
+  const res = await slackPost('chat.postMessage', body);
+  if (!res.ok) console.error(`[Bot] postMessage error: ${res.error}`);
+  // ボットが返答したスレッドを記録 → 以降の返信にも反応する
+  if (res.ok && res.ts) markThreadEngaged(channel, thread_ts || res.ts);
+  return res;
+}
+
+async function postLong(channel, text, thread_ts) {
+  const MAX = 3800;
+  if (text.length <= MAX) { await postMessage(channel, text, thread_ts); return; }
+  let remaining = text;
+  while (remaining.length > MAX) {
+    let cut = remaining.lastIndexOf('\n', MAX);
+    if (cut < MAX * 0.6) cut = MAX;
+    await postMessage(channel, remaining.slice(0, cut), thread_ts);
+    remaining = remaining.slice(cut).trimStart();
+  }
+  if (remaining) await postMessage(channel, remaining, thread_ts);
+}
+
+// ── スレッド全体を読み取る (conversations.replies) ───────────────────────────
+// Bot は mention された1件のメッセージしか event で受け取らないため、スレッドの
+// 前後文脈は Slack API で明示的に取得しないと Claude からは全く見えない。
+// これを行わないと「이전 대화 기록이 없습니다」等の誤答になる（本 fix の主眼）。
+const _userNameCache = new Map();
+let _usersReadMissing = false; // users:read スコープ無し → users.info 呼び出しを打ち切る
+async function resolveUserName(userId) {
+  if (!userId) return null;
+  if (config.getBotUserId() && userId === config.getBotUserId()) return 'giipclaude';
+  if (_userNameCache.has(userId)) return _userNameCache.get(userId);
+  // users:read が無い環境では users.info が missing_scope になる。一度失敗したら
+  // 以降は API を叩かず ID をそのまま話者ラベルにフォールバック（同一話者は同一IDで一貫）。
+  if (_usersReadMissing) { _userNameCache.set(userId, userId); return userId; }
+  const res = await slackGet('users.info', { user: userId });
+  if (res && res.ok === false && res.error === 'missing_scope') _usersReadMissing = true;
+  const name = (res.ok && res.user)
+    ? ((res.user.profile && res.user.profile.display_name) || res.user.real_name || res.user.name || userId)
+    : userId;
+  _userNameCache.set(userId, name);
+  return name;
+}
+
+// Slack メッセージ本文を人間可読テキストへ整形（mention/tel/url/装飾記号を除去）
+function cleanThreadText(t) {
+  return (t || '')
+    .replace(/<@[A-Z0-9]+>/g, '@멘션')
+    .replace(/<tel:(\d+)\|[^>]*>/g, '$1')
+    .replace(/<tel:(\d+)>/g, '$1')
+    .replace(/<(https?:\/\/[^|>]+)\|[^>]*>/g, '$1')
+    .replace(/<(https?:\/\/[^>]+)>/g, '$1')
+    .replace(/`/g, '')
+    .trim();
+}
+
+// threadTs のスレッド全体を「話者: 発言」形式のテキストで返す。取得不可なら ''。
+// 他の bot/app（giipgravity, Manus 등）の発言も username 付きで含める。
+async function fetchThreadTranscript(channelId, threadTs) {
+  if (!threadTs) return '';
+  const res = await slackGet('conversations.replies', {
+    channel: channelId, ts: threadTs, limit: 200,
+  });
+  if (!res.ok || !Array.isArray(res.messages) || res.messages.length === 0) {
+    if (res && res.ok === false) console.error(`[Bot] conversations.replies error: ${res.error}`);
+    return '';
+  }
+  const lines = [];
+  for (const m of res.messages) {
+    let name = m.username || null;
+    if (!name && m.user) name = await resolveUserName(m.user);
+    if (!name) name = m.bot_id ? 'bot' : 'unknown';
+    let body = cleanThreadText(m.text);
+    if (!body && m.files && m.files.length) body = `(첨부파일 ${m.files.length}건)`;
+    if (!body && m.attachments && m.attachments.length) {
+      body = cleanThreadText(m.attachments.map(a => a.text || a.fallback || '').join(' '));
+    }
+    if (!body) continue;
+    lines.push(`${name}: ${body}`);
+  }
+  let transcript = lines.join('\n');
+  const MAX = 12000; // プロンプト肥大を防ぐ上限（超過分は古い側を切る）
+  if (transcript.length > MAX) transcript = '…(앞부분 생략)\n' + transcript.slice(-MAX);
+  return transcript;
+}
+
+module.exports = {
+  slackGet,
+  slackPost,
+  postMessage,
+  postLong,
+  resolveUserName,
+  cleanThreadText,
+  fetchThreadTranscript,
+};

--- a/slack-bot-minimax/state.js
+++ b/slack-bot-minimax/state.js
@@ -1,0 +1,35 @@
+// state.js — JSON I/O + ボット関与スレッド追跡
+// index.js から behavior-preserving で切り出し（ロジック変更なし）。
+
+const fs = require('fs');
+const { BOT_THREADS_FILE } = require('./config');
+
+// ── JSON I/O ─────────────────────────────────────────────────────────────────
+function loadJSON(file, def) {
+  try { return JSON.parse(fs.readFileSync(file, 'utf8')); } catch { return def; }
+}
+function saveJSON(file, data) {
+  try { fs.writeFileSync(file, JSON.stringify(data, null, 2)); } catch {}
+}
+
+// ── ボットが返答したスレッドを追跡 ───────────────────────────────────────────
+function markThreadEngaged(channelId, threadTs) {
+  if (!threadTs) return;
+  const threads = loadJSON(BOT_THREADS_FILE, {});
+  const key = `${channelId}:${threadTs}`;
+  threads[key] = Date.now();
+  // 7日以上前のエントリを削除
+  const cutoff = Date.now() - 7 * 24 * 60 * 60 * 1000;
+  for (const k of Object.keys(threads)) {
+    if (threads[k] < cutoff) delete threads[k];
+  }
+  saveJSON(BOT_THREADS_FILE, threads);
+}
+
+function isBotEngagedThread(channelId, threadTs) {
+  if (!threadTs) return false;
+  const threads = loadJSON(BOT_THREADS_FILE, {});
+  return !!threads[`${channelId}:${threadTs}`];
+}
+
+module.exports = { loadJSON, saveJSON, markThreadEngaged, isBotEngagedThread };

--- a/slack-bot-minimax/task-dedup.js
+++ b/slack-bot-minimax/task-dedup.js
@@ -1,0 +1,220 @@
+// task-dedup.js — 既存タスクID抽出 + 類似/重複タスク検出・統合
+// index.js から behavior-preserving で切り出し（ロジック変更なし）。
+
+const fs = require('fs');
+const path = require('path');
+const { AGENT_DIR } = require('./config');
+const tm = require('./task-manager');
+
+// ── 既存タスクIDをメッセージから抽出 ────────────────────────────────────────
+// 14桁数字 (自動生成) と YYYYMMDD_名前形式 (手動作成) の両方に対応
+function extractExistingTaskIds(text) {
+  const numericIds = text.match(/\b(\d{14})\b/g) || [];
+  const namedIds   = text.match(/\b(\d{8}_[\w-]+)\b/g) || [];
+  const candidates = [...new Set([...numericIds, ...namedIds])];
+  return candidates.filter(id => {
+    return [
+      path.join(AGENT_DIR, 'tasks', `${id}.md`),
+      path.join(AGENT_DIR, 'tasks', 'done', `${id}.md`),
+      path.join(AGENT_DIR, 'tasks', 'cancel', `${id}.md`),
+    ].some(f => fs.existsSync(f));
+  });
+}
+
+// ── 既存 giip issue 番号をメッセージから抽出 ─────────────────────────────────
+//   `admin/giip-issues/609`, `giip issue #609`, `issue 609`, `이슈 #609` 等から ISN を得る。
+//   ユーザ指摘(D): issue 番号が既にあるなら task 番号を新規発給せず、二重 issue(#610 等)も作らない。
+//   ISN は小さい整数(1〜6桁)に限定し、14桁タスクIDや電話番号等の誤検知を防ぐ。無ければ null。
+function extractGiipIssueRef(text) {
+  const t = String(text || '').replace(/`/g, '');
+  // issue/이슈/giip の明示的な文脈を必須にする(bare `#609` は `PR #123` 等の誤検知源なので拾わない)。
+  const patterns = [
+    /giip[-\s]?issues?\s*[/#]?\s*(\d{1,6})\b/i, // giip-issues/609, giip issue #609, giip issue 609
+    /\bissues?\s*#?\s*(\d{1,6})\b/i,            // issue #609, issue 609
+    /이슈\s*#?\s*(\d{1,6})\b/,                  // 이슈 609, 이슈 #609
+  ];
+  for (const re of patterns) {
+    const m = t.match(re);
+    if (m) return Number(m[1]);
+  }
+  return null;
+}
+
+// ── 類似 pending タスクを検索 ──────────────────────────────────────────────
+function findSimilarPendingTasks(requestText) {
+  const taskDir = path.join(AGENT_DIR, 'tasks');
+  let files;
+  try { files = fs.readdirSync(taskDir).filter(f => /^\d{14}\.md$/.test(f)); }
+  catch { return []; }
+
+  // ブラケット記法から内容を抽出: [SO/SS売上集計リデザイン] → "SO/SS売上集計リデザイン"
+  const bracketM = requestText.match(/\[([^\]]{4,})\]/);
+  const bracketKey = bracketM ? bracketM[1].slice(0, 20) : null;
+
+  // 4文字以上の単語を抽出（日本語・英数字）
+  const words = [...new Set(
+    requestText.replace(/[^\w぀-鿿a-zA-Z0-9]/g, ' ')
+      .split(/\s+/).filter(w => w.length >= 4)
+  )];
+
+  const similar = [];
+  for (const file of files) {
+    try {
+      const content = fs.readFileSync(path.join(taskDir, file), 'utf8');
+      const statusM = content.match(/^status:\s*(.+)$/m);
+      const status = (statusM ? statusM[1].trim() : 'pending');
+      if (status !== 'pending') continue;
+
+      const reqLine = (content.match(/request:\s*"?([^\n"]{1,300})/) || [])[1] || '';
+      const titleLine = (content.match(/# TASK:\s*(.+)/) || [])[1] || '';
+      const combined = reqLine + ' ' + titleLine;
+
+      let matched = false;
+      if (bracketKey && combined.includes(bracketKey)) matched = true;
+      if (!matched && words.length >= 2) {
+        const hits = words.filter(w => combined.includes(w)).length;
+        if (hits / words.length >= 0.5) matched = true;
+      }
+
+      if (matched) {
+        const title = titleLine || reqLine.slice(0, 50);
+        similar.push({ taskId: file.replace('.md', ''), title });
+      }
+    } catch {}
+  }
+  return similar;
+}
+
+// ── 未完了(pending)タスクのメタ情報を全件読み込む ────────────────────────────
+// taskmerge 用。各タスクの request/title と、類似判定用の単語集合・ブラケットキーを返す。
+function loadPendingTaskMeta() {
+  const taskDir = path.join(AGENT_DIR, 'tasks');
+  let files;
+  try { files = fs.readdirSync(taskDir).filter(f => /^\d{14}\.md$/.test(f)); }
+  catch { return []; }
+
+  const metas = [];
+  for (const file of files) {
+    try {
+      const content = fs.readFileSync(path.join(taskDir, file), 'utf8');
+      const statusM = content.match(/^status:\s*(.+)$/m);
+      const status = statusM ? statusM[1].trim() : 'pending';
+      if (status !== 'pending') continue;
+
+      const request = (content.match(/request:\s*"?([^\n"]{1,300})/) || [])[1] || '';
+      const titleLine = (content.match(/# TASK:\s*(.+)/) || [])[1] || '';
+      const title = (titleLine || request.slice(0, 50)).trim();
+      const combined = `${request} ${titleLine}`;
+      const bracketM = combined.match(/\[([^\]]{4,})\]/);
+      const bracketKey = bracketM ? bracketM[1].slice(0, 20) : null;
+      // Hangul(가-힣) を含めて分割する。旧 findSimilarPendingTasks の `぀-鿿` は
+      // Hangul(U+AC00〜) を範囲外にしてしまい韓国語タスクが全く語を持たず重複判定できなかった。
+      const words = new Set(
+        combined.replace(/[^0-9A-Za-z가-힣ぁ-んァ-ヶー一-龥]/g, ' ')
+          .split(/\s+/).filter(w => w.length >= 2)
+      );
+      metas.push({ taskId: file.replace('.md', ''), title, request: request.trim(), words, bracketKey });
+    } catch {}
+  }
+  return metas;
+}
+
+// ── 2つのタスクmetaが重複（類似）かを判定 ────────────────────────────────────
+// findSimilarPendingTasks と同じ発想: ブラケットキー一致 or 単語集合の重なり >= 50%。
+function tasksAreSimilar(a, b) {
+  if (a.bracketKey && b.bracketKey && a.bracketKey === b.bracketKey) return true;
+  const smaller = a.words.size <= b.words.size ? a.words : b.words;
+  const larger  = smaller === a.words ? b.words : a.words;
+  if (smaller.size < 2) return false;
+  let hits = 0;
+  for (const w of smaller) if (larger.has(w)) hits++;
+  // 共有語 >= 2（generic な1語だけの誤マッチ防止）かつ 重なり率 >= 50%
+  return hits >= 2 && hits / smaller.size >= 0.5;
+}
+
+// ── 未完了の重複タスクをクラスタリング ──────────────────────────────────────
+// 貪欲法で similar なもの同士をまとめ、2件以上のクラスタのみ返す。
+// survivor（残す代表）= タスク番号が最も新しい（=最新の意図を反映）もの。
+function findDuplicatePendingClusters() {
+  const metas = loadPendingTaskMeta();
+  const assigned = new Set();
+  const clusters = [];
+  for (let i = 0; i < metas.length; i++) {
+    if (assigned.has(metas[i].taskId)) continue;
+    const members = [metas[i]];
+    assigned.add(metas[i].taskId);
+    for (let j = i + 1; j < metas.length; j++) {
+      if (assigned.has(metas[j].taskId)) continue;
+      if (members.some(m => tasksAreSimilar(m, metas[j]))) {
+        members.push(metas[j]);
+        assigned.add(metas[j].taskId);
+      }
+    }
+    if (members.length >= 2) {
+      const survivor = [...members].sort((a, b) => b.taskId.localeCompare(a.taskId))[0];
+      clusters.push({ members, survivor });
+    }
+  }
+  return clusters;
+}
+
+// ── 重複クラスタを実際に統合する ────────────────────────────────────────────
+// survivor に重複分の request を「統合された重複タスク」節として追記し、
+// 残りは統合案内を書いてから cancel/ へ移動・tasklist を cancelled 化・pending state から除去。
+function applyTaskMerge(clusters, taskState) {
+  const now = new Date().toISOString();
+  const lines = [`*🔀 タスク統合完了 — ${clusters.length}グループ*`, ''];
+
+  for (const cl of clusters) {
+    const survivor = cl.survivor;
+    const merged = cl.members.filter(m => m.taskId !== survivor.taskId);
+
+    // ① survivor ファイルに統合記録を追記
+    const survivorFile = path.join(AGENT_DIR, 'tasks', `${survivor.taskId}.md`);
+    try {
+      let sc = fs.readFileSync(survivorFile, 'utf8');
+      const section = [
+        '',
+        '## 🔀 統合された重複タスク',
+        `統合日時: ${now}`,
+        ...merged.map(m => `- \`${m.taskId}\` — ${m.title}${m.request ? `\n  - 요청: ${m.request}` : ''}`),
+        '',
+      ].join('\n');
+      fs.writeFileSync(survivorFile, `${sc.trimEnd()}\n${section}`);
+    } catch {}
+
+    // ② 残りを統合案内付きで取り消し
+    const cancelledIds = [];
+    for (const m of merged) {
+      try {
+        const mf = path.join(AGENT_DIR, 'tasks', `${m.taskId}.md`);
+        if (fs.existsSync(mf)) {
+          const mc = fs.readFileSync(mf, 'utf8');
+          fs.writeFileSync(mf, `${mc.trimEnd()}\n\n## 統合案内\n${now} — このタスクは \`${survivor.taskId}\` へ統合され取り消されました。\n`);
+        }
+        tm.cancelTaskFile(m.taskId);
+        tm.updateTasklistEntry(m.taskId, { status: 'cancelled', completedAt: now });
+        Object.keys(taskState.pending || {}).forEach(k => {
+          if ((taskState.pending[k] || {}).taskId === m.taskId) delete taskState.pending[k];
+        });
+        cancelledIds.push(m.taskId);
+      } catch {}
+    }
+
+    lines.push(`• 維持 \`${survivor.taskId}\` — ${survivor.title}`);
+    cancelledIds.forEach(id => lines.push(`    ↳ 統合取消 \`${id}\``));
+  }
+
+  lines.push('', '維持されたタスクは `go <番号>` で実行してください。');
+  return lines.join('\n');
+}
+
+module.exports = {
+  extractExistingTaskIds,
+  extractGiipIssueRef,
+  findSimilarPendingTasks,
+  loadPendingTaskMeta,
+  tasksAreSimilar,
+  findDuplicatePendingClusters,
+  applyTaskMerge,
+};

--- a/slack-bot-minimax/task-manager.js
+++ b/slack-bot-minimax/task-manager.js
@@ -1,0 +1,1436 @@
+/**
+ * task-manager.js
+ * Task lifecycle: 분석 → 파일 생성 → subagent 실행 → git push → GitHub URL 반환
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync, spawn } = require('child_process');
+const { searchKLayer } = require('./k-layer');
+const accounts = require('./claude-accounts');
+const minimax = require('./minimax-accounts');
+
+const BASE_DIR = path.join(__dirname, '..');
+const TASKS_DIR = path.join(BASE_DIR, '.agent', 'tasks');
+const RESULTS_DIR = path.join(BASE_DIR, '.agent', 'results');
+const ROLES_DIR = path.join(BASE_DIR, '.agent', 'roles');
+const TASKLIST_FILE = path.join(__dirname, 'tasklist.json');
+
+function ensureDirs() {
+  [TASKS_DIR, RESULTS_DIR].forEach(d => {
+    try { fs.mkdirSync(d, { recursive: true }); } catch {}
+  });
+}
+
+function getTimestampId() {
+  const now = new Date();
+  const p = n => String(n).padStart(2, '0');
+  return `${now.getFullYear()}${p(now.getMonth()+1)}${p(now.getDate())}${p(now.getHours())}${p(now.getMinutes())}${p(now.getSeconds())}`;
+}
+
+// baseDir 配下の .agent/roles/ を読む。なければ Lowyworkenv の roles にフォールバック
+// filesRead に読んだファイルの絶対パスを push する
+function readRolesContext(baseDir = BASE_DIR, filesRead = []) {
+  const dirs = [
+    path.join(baseDir, '.agent', 'roles'),
+    ROLES_DIR,
+  ];
+  for (const dir of dirs) {
+    try {
+      const files = fs.readdirSync(dir).filter(f => f.endsWith('.md'));
+      if (files.length === 0) continue;
+      return files.map(f => {
+        const fullPath = path.join(dir, f);
+        filesRead.push(fullPath);
+        const content = fs.readFileSync(fullPath, 'utf8');
+        return `### ${f}\n${content.slice(0, 800)}`;
+      }).join('\n\n---\n\n');
+    } catch {}
+  }
+  return '';
+}
+
+function getCurrentBranch(cwd = BASE_DIR) {
+  const res = spawnSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd, encoding: 'utf8', windowsHide: true });
+  return (res.stdout || '').trim() || 'master';
+}
+
+// リポジトリの base ブランチ (PR の向き先) を判定。origin/HEAD → master/main 等。
+function getBaseBranch(cwd = BASE_DIR) {
+  const res = spawnSync('git', ['symbolic-ref', 'refs/remotes/origin/HEAD'], { cwd, encoding: 'utf8', windowsHide: true });
+  const m = (res.stdout || '').trim().match(/refs\/remotes\/origin\/(.+)$/);
+  if (m) return m[1];
+  // origin/HEAD 未設定時のフォールバック: main → master の順で存在する方
+  for (const b of ['main', 'master']) {
+    const chk = spawnSync('git', ['show-ref', '--verify', '--quiet', `refs/remotes/origin/${b}`], { cwd, windowsHide: true });
+    if (chk.status === 0) return b;
+  }
+  return 'master';
+}
+
+// 単一 bot プロセス内で作業ツリー(共有)を同時に切り替えないための簡易ガード。
+// prepareTaskBranch が成功時に true、restoreTaskBranch で false に戻す。
+let gitTreeBusy = false;
+
+function runClaude(args, cwd = BASE_DIR, input = null) {
+  // 계정 라우팅: weight 비율대로 계정 선택 → 한도면 다음 계정으로 재시도
+  const maxTries = accounts.count();
+  let result;
+  for (let i = 0; i < maxTries; i++) {
+    const acct = accounts.pickAccount();
+    if (!acct) throw new Error('claude 전 계정 사용량 한도 소진 — 잠시 후 재시도 필요');
+    result = spawnSync('claude', args, {
+      cwd,
+      encoding: 'utf8',
+      maxBuffer: 10 * 1024 * 1024,
+      timeout: 20 * 60 * 1000, // 20分
+      windowsHide: true,
+      env: accounts.envFor(acct),
+      // 프롬프트는 argv 대신 stdin 으로 전달(ENAMETOOLONG 회피). null 이면 미전달.
+      ...(input != null ? { input } : {}),
+    });
+    if (result.error) throw result.error;
+    if (result.status === 0) return (result.stdout || '').trim();
+    // 한도 메시지가 stdout에 찍히는 경우가 있어(giip-759) 두 스트림 모두 확인한다.
+    const combinedOut = `${result.stdout || ''}\n${result.stderr || ''}`;
+    if (accounts.isUsageLimit(combinedOut)) { accounts.noteUsageLimit(acct, combinedOut); continue; }
+    break; // 한도 외 실패 — 기존 관대한 동작(부분 출력 반환) 유지
+  }
+  return (result?.stdout || '').trim();
+}
+
+// ── Rule 43: 컨텍스트 파일 provenance (경로 + 로드 사유) ──────────────────────
+// 전량 무선별 주입(readRolesContext) 대신, 요청 관련 role/rule/skill 만 사유와 함께 선별 로드한다.
+
+// .agent/roles·rules·skills 의 파일 카탈로그(경로 + 짧은 설명). skills 는 dir(SKILL.md) 또는 *.md.
+function buildContextCatalog(baseDir = BASE_DIR) {
+  const out = [];
+  const firstDesc = (text) => {
+    const fm = text.match(/description:\s*(.+)/i);
+    if (fm) return fm[1].trim().replace(/^["']|["']$/g, '').slice(0, 140);
+    const line = text.split(/\r?\n/).map(l => l.trim()).find(l => l && l !== '---');
+    return (line || '').replace(/^#+\s*/, '').slice(0, 140);
+  };
+  const addFile = (type, absPath) => {
+    try {
+      const rel = path.relative(baseDir, absPath).replace(/\\/g, '/');
+      out.push({ type, path: rel, desc: firstDesc(fs.readFileSync(absPath, 'utf8')) });
+    } catch {}
+  };
+  // roles/rules: project baseDir 우선, 없으면 Lowyworkenv(.agent) 로 폴백
+  for (const [type, sub] of [['role', 'roles'], ['rule', 'rules']]) {
+    let dir = path.join(baseDir, '.agent', sub);
+    try { if (!fs.readdirSync(dir).some(f => f.endsWith('.md'))) dir = path.join(BASE_DIR, '.agent', sub); }
+    catch { dir = path.join(BASE_DIR, '.agent', sub); }
+    try { fs.readdirSync(dir).filter(f => f.endsWith('.md')).forEach(f => addFile(type, path.join(dir, f))); } catch {}
+  }
+  // skills: dir 안 SKILL.md, 또는 top-level *.md
+  let skillsDir = path.join(baseDir, '.agent', 'skills');
+  if (!fs.existsSync(skillsDir)) skillsDir = path.join(BASE_DIR, '.agent', 'skills');
+  try {
+    for (const e of fs.readdirSync(skillsDir, { withFileTypes: true })) {
+      if (e.isDirectory()) {
+        const sk = path.join(skillsDir, e.name, 'SKILL.md');
+        if (fs.existsSync(sk)) addFile('skill', sk);
+      } else if (e.name.endsWith('.md')) {
+        addFile('skill', path.join(skillsDir, e.name));
+      }
+    }
+  } catch {}
+  return out;
+}
+
+// 요청에 관련된 컨텍스트 파일을 LLM 으로 선별하고 각 파일의 로드 사유를 받는다. → [{path, reason}]
+function selectContextFiles(requestText, catalog, baseDir = BASE_DIR) {
+  if (!catalog.length) return [];
+  const catalogText = catalog.map((c, i) => `${i + 1}. [${c.type}] ${c.path} — ${c.desc}`).join('\n');
+  const prompt = `너는 아래 Slack 요청을 분석·수행하기 위해 참조해야 할 컨텍스트 파일(role/rule/skill)을 고르는 큐레이터다.
+
+요청:
+"${requestText}"
+
+사용 가능한 컨텍스트 파일:
+${catalogText}
+
+이 요청 처리에 "실제로 관련 있는" 파일만 골라라(무관한 것은 넣지 말 것, 보통 2~8개). 각 파일에 대해
+"이 태스크에서 그 파일의 무엇을 참조/적용하려는지"를 한국어 한 줄 사유로 적어라.
+아래 JSON 배열만 출력한다(코드펜스·설명 금지):
+[{"path":"<위 목록의 정확한 경로>","reason":"<한 줄 사유>"}]`;
+  const raw = runClaude(['-p', '--model', 'claude-opus-4-8'], baseDir, prompt);
+  let parsed = [];
+  try { const m = raw.match(/\[[\s\S]*\]/); parsed = m ? JSON.parse(m[0]) : []; } catch { parsed = []; }
+  const valid = new Set(catalog.map(c => c.path));   // 카탈로그에 없는(할루시네이션) 경로 차단
+  const seen = new Set();
+  return parsed
+    .filter(x => x && typeof x.path === 'string' && valid.has(x.path) && !seen.has(x.path) && seen.add(x.path))
+    .map(x => ({ path: x.path, reason: (String(x.reason || '').trim().slice(0, 200)) || '(사유 미기재)' }));
+}
+
+// 선별된 파일 내용을 읽어 분석 프롬프트용 컨텍스트 문자열과 filesRead([{path,reason}]) 를 만든다.
+function readSelectedContext(selected, baseDir = BASE_DIR) {
+  const parts = [], filesRead = [];
+  for (const s of selected) {
+    try {
+      const content = fs.readFileSync(path.join(baseDir, s.path), 'utf8');
+      parts.push(`### ${s.path} (로드 사유: ${s.reason})\n${content.slice(0, 800)}`);
+      filesRead.push({ path: s.path, reason: s.reason });
+    } catch {}
+  }
+  return { context: parts.join('\n\n---\n\n'), filesRead };
+}
+
+// filesRead 항목을 {path, reason} 로 정규화(문자열/절대경로 입력 후방호환 — 예: wfrun 의 [wfPath]).
+function normalizeFilesRead(filesRead) {
+  return (filesRead || []).map(f => {
+    if (typeof f === 'string') {
+      const rel = path.isAbsolute(f) ? path.relative(BASE_DIR, f).replace(/\\/g, '/') : f.replace(/\\/g, '/');
+      return { path: rel, reason: '(직접 지정)' };
+    }
+    return { path: String(f.path || '').replace(/\\/g, '/'), reason: f.reason || '(사유 미기재)' };
+  });
+}
+
+// ── Phase 1: 요청 분석 → TASK 파일 생성 ─────────────────────────────────────
+// returns { planContent, filesRead: [{path, reason}] }
+function analyzeRequest(requestText, taskId, baseDir = BASE_DIR) {
+  ensureDirs();
+
+  const claims = searchKLayer(requestText);
+  const projectName = path.basename(baseDir);
+  // Rule 43: 요청 관련 role/rule/skill 만 사유와 함께 선별 로드하고, 그 사유를 태스크 파일에 남긴다.
+  const catalog = buildContextCatalog(baseDir);
+  const selected = selectContextFiles(requestText, catalog, baseDir);
+  const { context: rolesContext, filesRead } = readSelectedContext(selected, baseDir);
+
+  const analysisPrompt = `You are a senior software architect. Always respond in Korean.
+
+Working project: ${projectName}
+Working directory: ${baseDir}
+
+A team member sent this request via Slack:
+"${requestText}"
+${rolesContext ? `\n=== 프로젝트 역할/컨텍스트 ===\n${rolesContext}\n` : ''}${claims.length > 0 ? `\n=== K-Layer 관련 지식 ===\n${claims.map(c => `• ${c}`).join('\n')}\n` : ''}
+Analyze the request and output a task specification in this EXACT format (in Korean):
+
+# TASK: [짧은 제목]
+
+## 요청 내용
+[요청 요약 — 1~2줄]
+
+## 실행 계획
+1. [구체적인 실행 단계]
+2. [단계 2]
+3. [단계 3]
+(최대 7단계)
+
+## 영향 파일/서브시스템
+- [변경될 파일 또는 서브시스템]
+
+## 주의사항
+- [배포 주의사항, 부작용 등]
+
+Output ONLY the task specification, no extra commentary.`;
+
+  const planContent = runClaude(['-p', '--model', 'claude-opus-4-8'], baseDir, analysisPrompt);
+  return { planContent, filesRead };
+}
+
+function createTaskFile(taskId, requestText, planContent, filesRead = []) {
+  ensureDirs();
+
+  const norm = normalizeFilesRead(filesRead);   // Rule 43: 경로 + 로드 사유
+  const fileList = norm.length > 0
+    ? '\n' + norm.map(f => `#   - ${f.path} — ${f.reason}`).join('\n')
+    : '\n#   (없음)';
+
+  const header = `---
+task_id: ${taskId}
+status: pending
+requested_at: ${new Date().toISOString()}
+request: "${requestText.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"
+# 분석에 로드된 컨텍스트 파일 (role/rule/skill — 경로 — 로드 사유):${fileList}
+---
+
+`;
+  const taskFile = path.join(TASKS_DIR, `${taskId}.md`);
+  fs.writeFileSync(taskFile, header + planContent);
+  return taskFile;
+}
+
+// 既存タスクファイルを「更新」する（新規IDを発給しない）。
+// 参照されたタスク番号に改訂を追記し、done/cancel にあれば tasks/ に戻して pending に再オープンする。
+// 見つからなければ createTaskFile にフォールバック。返り値は tasks/{taskId}.md の絶対パス。
+function updateTaskFile(taskId, requestText, planContent, filesRead = []) {
+  ensureDirs();
+  const activePath = path.join(TASKS_DIR, `${taskId}.md`);
+  const existing = [
+    activePath,
+    path.join(TASKS_DIR, 'done', `${taskId}.md`),
+    path.join(TASKS_DIR, 'cancel', `${taskId}.md`),
+  ].find(f => fs.existsSync(f));
+
+  // 元ファイルが見つからない場合のみ新規作成（実質 createTaskFile と同じ挙動）
+  if (!existing) return createTaskFile(taskId, requestText, planContent, filesRead);
+
+  let content = fs.readFileSync(existing, 'utf8');
+
+  // status を pending に戻して再オープン
+  content = /status:\s*.+/i.test(content)
+    ? content.replace(/status:\s*.+/i, 'status: pending')
+    : `status: pending\n${content}`;
+
+  // 改訂を追記（元タスクの内容・成果物は保持したまま）
+  const now = new Date().toISOString();
+  const norm = normalizeFilesRead(filesRead);   // Rule 43: 경로 + 로드 사유
+  const fileList = norm.length > 0
+    ? '\n' + norm.map(f => `-   ${f.path} — ${f.reason}`).join('\n')
+    : '\n-   (없음)';
+  content = `${content.trimEnd()}\n\n---\n\n## 개정 (${now})\n\n### 추가 요청\n${requestText}\n\n### 갱신된 계획\n${planContent}\n\n### 로드된 컨텍스트 파일 (role/rule/skill — 경로 — 사유)${fileList}\n`;
+
+  // done/cancel にあった場合は tasks/ 直下へ戻す
+  fs.writeFileSync(activePath, content);
+  if (existing !== activePath) {
+    try { fs.rmSync(existing); } catch {}
+  }
+  return activePath;
+}
+
+// giip issue 재처리용: 로컬 태스크 파일이 없을 때 DB 이력(본문+전체 코멘트)으로 태스크 파일을 재생성한다.
+//   done/ 이동·타 클론 처리·워킹트리 churn 등으로 .agent/tasks/{giip-isn}.md 가 사라져도, DB(SSOT)에서
+//   복원한 히스토리 다이제스트를 계획 본문으로 삼아 서브에이전트가 코멘트 이력 전체를 읽고 이어서 처리하게 한다.
+//   (이 파일이 없어서 startExecution 이 "タスクファイルが見つかりません" 로 실패하던 문제의 항구 대책.)
+function rebuildTaskFileFromIssue(taskId, isn, requestText, historyDigest) {
+  ensureDirs();
+  const plan = [
+    `# TASK: giip issue #${isn} 재처리`,
+    '',
+    '## 원 요청',
+    (requestText && requestText.trim()) || `(giip issue #${isn} 처리 요청)`,
+    '',
+    '## DB에서 복원한 이슈 이력 (본문 + 전체 코멘트 — 반드시 시간순으로 모두 읽고 맥락을 반영)',
+    historyDigest || '(이력 없음 — DB 조회 실패. giip issue get 로 직접 확인하라)',
+    '',
+    '## 지시',
+    '- 위 코멘트 이력을 모두 읽고, 아직 처리되지 않았거나 새로 추가된 요청을 파악해 처리하라.',
+    `- 새 issue/task 번호를 만들지 말고 #${isn} 에 결과를 코멘트하고 상태를 전이하라.`,
+  ].join('\n');
+  return createTaskFile(taskId, (requestText && requestText.trim()) || `giip issue #${isn} 재처리`, plan, []);
+}
+
+function extractTitle(planContent) {
+  const match = planContent.match(/^#\s*TASK:\s*(.+)$/m);
+  return match ? match[1].trim() : '作業';
+}
+
+// ── Phase 2: subagent 실행 (비동기) ─────────────────────────────────────────
+function startExecution(taskId, taskFilePath, { onComplete, onError, isn = null }, baseDir = BASE_DIR, ctx = null) {
+  ensureDirs();
+
+  // taskFilePath が未指定 or 存在しない場合は TASKS_DIR/{taskId}.md にフォールバック
+  if (!taskFilePath || !fs.existsSync(taskFilePath)) {
+    const fallback = path.join(TASKS_DIR, `${taskId}.md`);
+    if (fs.existsSync(fallback)) {
+      taskFilePath = fallback;
+    } else {
+      const err = new Error(`タスクファイルが見つかりません: ${taskId}`);
+      if (onError) setImmediate(() => onError(err, null));
+      return;
+    }
+  }
+
+  const taskContent = fs.readFileSync(taskFilePath, 'utf8');
+  const resultFile = path.join(RESULTS_DIR, `${taskId}.md`);
+  const rolesContext = readRolesContext(baseDir);
+  const claims = searchKLayer(taskContent);
+
+  // ctx が渡されていれば prepareTaskBranch 済みの専用ブランチ。無ければ現在ブランチ(後方互換)。
+  const currentBranch = (ctx && ctx.branch) || getCurrentBranch(baseDir);
+  const baseBranch = (ctx && ctx.base) || getBaseBranch(baseDir);
+
+  // 進捗コメント・プロトコル(PROTOCOL_PROGRESS_COMMENT.md): giip issue に連携済み(isn あり)の時だけ
+  // 注入する。isn が無ければ giip 未連携なのでブロック全体を省く(条件「giip issue api 접근 가능한 환경이면」)。
+  const addCommentScript = path.join(BASE_DIR, '..', 'giipprj', 'giipdb', 'mgmt', 'addIssueComment.ps1');
+  const progressBlock = isn ? `
+
+=== 진행 코멘트 프로토콜 (정본 .agent/rules/PROTOCOL_PROGRESS_COMMENT.md) ===
+이 태스크는 giip issue #${isn} 에 연동돼 있다. 진행 상황을 자주 코멘트로 남겨, 코멘트만 봐도 어디까지
+왔고 무엇이 바뀌었는지 재구성되게 하라. 파일 1개당 코멘트 1개를 강제하지 말고 "논리 묶음" 단위로
+각 1~3줄 짧게 남긴다(같은 내용 연타·스팸 금지). 남기는 시점:
+  1) 착수: 로드해서 따르는 role/rule/skill/workflow 를 명시.
+  2) 참조 정본 변경: 따라야 할 role/rule/skill/workflow 파일 자체를 수정할 때 — 무엇을 왜.
+  3) 대상 파일 변경: 실제 수정/생성/삭제한 소스·문서가 생길 때마다(논리 묶음마다) — 경로 + 한 줄.
+  4) 검색 발생: 부득이 grep/find 했으면 (a)왜 (b)어디에 링크로 흡수했는지(Search→Link→Report).
+  5) 분기·막힘·판단: 에러·사람 확인 필요, 중요한 설계 판단이 생길 때.
+빈도: 몇 분 이상 걸리는 작업이면 최소 시작·중간·끝이 코멘트로 남게 한다.
+명령(직접-DB append, 한글 안 깨짐):
+  pwsh -File "${addCommentScript}" -isn ${isn} -content "<본문>" -issuetype note -author "slack-bot"
+  (중간 진행은 issuetype=note. 상태 전이/최종 코멘트는 봇이 별도 처리하므로 여기서 상태는 바꾸지 말 것.)
+` : '';
+  const executionPrompt = `You are a senior software engineer working in the Lowyworkenv workspace. Always respond in Korean.
+Working directory: ${baseDir}
+Current branch: ${currentBranch} (task 전용 브랜치, base=${baseBranch} 최신 기준)
+
+=== 담당 태스크 ===
+${taskContent}
+
+=== 사용 가능한 역할 ===
+${rolesContext || '(roles not found)'}
+
+=== K-LAYER 지식 ===
+${claims.length > 0 ? claims.map(c => `• ${c}`).join('\n') : '(없음)'}
+
+=== 작업 지시 ===
+0. **되묻지 말고 실측하라**: 경로·설정·사양 등 조회로 확정 가능한 값은 사용자에게 다시 묻지 말고 직접 찾아 결정한다.
+   - giip 서비스 설정(SMTP·메일·인증 등)의 정본은 **giipdb 사양서(\`giipprj/giipdb/docs/30_Specs/\`)와 DB**다. 사람에게 묻기 전에 반드시 그곳부터 grep/조회하라. 예: SMTP 설정은 \`tEmailServerConfig\` 테이블에 있고 giip API \`EmailServerConfigGetActive\`(SP \`pApiEmailServerConfigGetActivebyAK\`, 서버측 \`bySk\`)로 조회한다.
+   - 정말로 사람만 아는 값(외부 자격증명 실물, 사용자의 의도적 선택)만 질문한다.
+1. 위 태스크의 실행 계획을 순서대로 실행하세요.
+2. Read/Edit/Write/Bash 도구를 사용해 이 저장소(${baseDir}) 안에서 실제 코드 변경을 수행하세요.
+3. **git 커밋·push·PR·브랜치 전환은 절대 하지 마세요.** 작업트리는 이미 태스크 전용 브랜치 \`${currentBranch}\`(base=${baseBranch} 최신 fetch 기준)로 준비돼 있습니다. 파일 변경만 마치면, 봇이 작업 종료 후 자동으로 이 브랜치에 커밋·push 하고 \`${baseBranch}\` 로 PR 을 생성합니다. (당신이 직접 git 을 만지면 브랜치/PR 흐름이 깨집니다.)
+4. 모든 단계 완료 후 반드시 다음 경로에 결과 보고서를 작성하세요:
+   ${resultFile}
+
+결과 보고서 형식:
+---
+# 작업 완료 보고서: [태스크 제목]
+
+## 완료 일시
+${new Date().toISOString()}
+
+## 실시 내용
+(실제 수행한 작업의 상세 설명)
+
+## 변경 파일
+- path/to/file — 변경 내용 요약
+
+## 결과/상태
+(성공 / 부분 완료 / 실패, 이유)
+
+## 다음 단계
+(후속 작업이 필요한 경우 명기)
+---
+${progressBlock}
+지금 바로 작업을 시작하세요.`;
+
+  // 実行サブエージェントが roles/rules/skills/workflows を参照できるよう .agent を許可
+  // （baseDir に .agent が無ければ BASE_DIR/.agent にフォールバック — index.js の getAgentDir と同じ規則）
+  const agentDir = fs.existsSync(path.join(baseDir, '.agent'))
+    ? path.join(baseDir, '.agent')
+    : path.join(BASE_DIR, '.agent');
+  // 프롬프트는 argv 대신 stdin 으로 전달(ENAMETOOLONG 회피) → proc.stdin 으로 씀
+  const args = ['-p', '--dangerously-skip-permissions', '--add-dir', agentDir];
+
+  // 계정 라우팅: weight 비율대로 계정 선택. 실행 중 사용량 한도에 걸리면
+  // 해당 계정을 쿨다운하고 다음 계정으로 태스크를 처음부터 재실행한다.
+  // (주의: 재실행이므로 이미 push된 커밋이 있으면 중복 커밋 가능 — fail보다 나은 동작)
+  const tried = new Set();
+  // 우선순위(사용자 지정): MiniMax 먼저, MiniMax 한도 소진 시에만 Claude로 폴백.
+  // mmExhausted=true 가 되면(이번 태스크 한정) 이후 attempt() 는 MiniMax를 다시 시도하지 않는다
+  // (minimax.resolve() 는 별도로 자체 쿨다운을 갖고 있어 다음 태스크에서는 그 쿨다운을 그대로 따른다).
+  let mmExhausted = false;
+
+  function attempt() {
+    let acct = mmExhausted ? null : minimax.resolve();
+    let env;
+    if (acct) {
+      env = minimax.envFor(acct);
+      console.log(`[TaskManager] task ${taskId}: MiniMax(${acct.model}) 로 실행`);
+    } else {
+      acct = accounts.pickAccount();
+      if (!acct) {
+        onError(new Error('MiniMax 미설정/한도 소진 + Claude 전 계정 사용량 한도 소진 — 잠시 후 재실행 필요'), null);
+        return null;
+      }
+      env = accounts.envFor(acct);
+      if (mmExhausted) console.log(`[TaskManager] task ${taskId}: MiniMax 한도 소진 → Claude(${acct.name}) 폴백`);
+    }
+    // tried 는 Claude 계정 로테이션 가드(tried.size < accounts.count())에만 쓰인다.
+    // MiniMax 는 별도 mmExhausted 플래그로 추적하므로 여기 섞으면 카운트가 어긋난다(오프바이원 방지).
+    if (acct.provider !== 'minimax') tried.add(acct.name);
+    // MiniMax 폴백은 claude CLI 기본 모델 선택을 안 타므로 --model 로 명시 지정한다.
+    const spawnArgs = acct.provider === 'minimax' ? [...args, '--model', acct.model] : args;
+    const proc = spawn('claude', spawnArgs, {
+      cwd: baseDir,
+      stdio: ['pipe', 'pipe', 'pipe'], // stdin 으로 프롬프트 전달(ENAMETOOLONG 회피)
+      env,
+    });
+    proc.stdin.on('error', () => {}); // 자식이 먼저 종료하면 EPIPE — 무시
+    proc.stdin.end(executionPrompt);
+
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', d => { stdout += d; process.stdout.write(`[Subagent:${acct.name}] ${d}`); });
+    proc.stderr.on('data', d => { stderr += d; });
+
+    proc.on('close', (code) => {
+      const combinedOut = `${stdout}\n${stderr}`;
+
+      // MiniMax(1순위) 실패 → 이번 태스크는 더 이상 MiniMax를 시도하지 않고 Claude 풀로 전환.
+      // 한도성 실패면 minimax 자체 쿨다운도 걸어(다음 태스크들도 그동안 Claude 사용), 원인 불명 실패는
+      // 쿨다운 없이(다음 태스크는 다시 MiniMax부터 시도) 이번만 Claude로 넘어간다.
+      if (code !== 0 && acct.provider === 'minimax') {
+        mmExhausted = true;
+        if (minimax.isUsageLimit(combinedOut)) minimax.noteUsageLimit();
+        console.log(`[TaskManager] task ${taskId}: MiniMax 실패 → Claude 폴백으로 전환`);
+        attempt();
+        return;
+      }
+
+      // 사용량 한도로 실패 & 아직 안 쓴 계정이 남아 있으면 다음 계정으로 재실행
+      // 한도 메시지("You've hit your weekly limit ...")는 stderr가 아니라 stdout에
+      // 찍히는 경우가 있어(giip-759, PR #430) 두 스트림을 모두 확인한다.
+      if (code !== 0 && acct.provider !== 'minimax' && accounts.isUsageLimit(combinedOut) && tried.size < accounts.count()) {
+        accounts.noteUsageLimit(acct, combinedOut);
+        console.log(`[TaskManager] task ${taskId}: ${acct.name} usage limit → 다음 계정으로 재실행`);
+        attempt();
+        return;
+      }
+
+      // 결과 파일이 없으면 기본 파일 생성
+      if (!fs.existsSync(resultFile)) {
+        fs.writeFileSync(resultFile, [
+          `# 작업 결과: ${taskId}`,
+          `\n완료 일시: ${new Date().toISOString()}`,
+          `\n## Claude 출력\n${stdout.slice(0, 3000)}`,
+          stderr ? `\n## Errors\n${stderr.slice(0, 500)}` : '',
+        ].join('\n'));
+      }
+
+      if (code === 0) {
+        onComplete(resultFile);
+      } else {
+        onError(new Error(`claude exit ${code}: ${stderr.slice(0, 200)}`), resultFile);
+      }
+    });
+
+    proc.on('error', (err) => onError(err, null));
+    return proc;
+  }
+
+  return attempt();
+}
+
+// ── 작업 완료: 결과를 태스크 파일에 추가 후 done/ 폴더로 이동 ─────────────────
+function completeTaskFile(taskId, resultContent) {
+  const candidates = [
+    path.join(TASKS_DIR, `${taskId}.md`),
+    path.join(TASKS_DIR, `task-${taskId}.md`),
+  ];
+  const taskFile = candidates.find(f => fs.existsSync(f));
+  if (!taskFile) throw new Error(`Task file not found for ${taskId}`);
+
+  const now = new Date().toISOString();
+  let content = fs.readFileSync(taskFile, 'utf8');
+
+  // status を completed に更新
+  content = /status:\s*.+/i.test(content)
+    ? content.replace(/status:\s*.+/i, 'status: completed')
+    : `status: completed\ncompleted_at: ${now}\n${content}`;
+
+  // 결과 보고서를 파일 말미에 추가
+  content = `${content.trimEnd()}\n\n---\n\n## 작업 완료 보고서\n\n완료 일시: ${now}\n\n${(resultContent || '').trim()}\n`;
+  fs.writeFileSync(taskFile, content);
+
+  // done/ 폴더로 이동
+  const doneDir = path.join(TASKS_DIR, 'done');
+  if (!fs.existsSync(doneDir)) fs.mkdirSync(doneDir, { recursive: true });
+  const destPath = path.join(doneDir, path.basename(taskFile));
+  fs.renameSync(taskFile, destPath);
+
+  console.log(`[TaskManager] task ${taskId} → done/${path.basename(taskFile)}`);
+  return destPath;
+}
+
+// go <番号> の後ろに付いた「追加指示」を Task ファイル末尾に追記する。
+//   Task ファイルの mutation は本モジュールに集約する(handlers は fs で直接書かず tm 経由)。
+//   note が空、または対象ファイルが無ければ何もせず false を返す。
+function appendTaskNote(taskId, note) {
+  if (!note) return false;
+  const candidates = [
+    path.join(TASKS_DIR, `${taskId}.md`),
+    path.join(TASKS_DIR, `task-${taskId}.md`),
+  ];
+  const taskFile = candidates.find(f => fs.existsSync(f));
+  if (!taskFile) return false;
+  fs.appendFileSync(taskFile, `\n\n## 추가 지시 (Slack, ${new Date().toISOString()})\n${note}\n`);
+  console.log(`[TaskManager] task ${taskId}: 追加指示 ${note.length}字 追記`);
+  return true;
+}
+
+// ── Phase 3: Git commit + push → GitHub URL 반환 ─────────────────────────────
+// doneTaskFile が指定された場合はそのファイルを優先的に stage し URL を返す
+function gitPushResult(taskId, taskTitle, resultFile, doneTaskFile = null) {
+  const branch = getCurrentBranch();
+  const relResult = path.relative(BASE_DIR, resultFile).replace(/\\/g, '/');
+
+  // done task file の URL 用に相対パスだけ先に確定（stage は下の add -A が担う）
+  let relDoneTask = null;
+  if (doneTaskFile && fs.existsSync(doneTaskFile)) {
+    relDoneTask = path.relative(BASE_DIR, doneTaskFile).replace(/\\/g, '/');
+  }
+
+  // 스테이지 범위 = 태스크가 실제로 만든/바꾼 산출물 전부(경로 무관). 固定パス（結果ファイル +
+  // .agent/tasks/<id>.md）だけ add すると 02-ActiveProjects/** 等の任意パス成果物が取りこぼされ
+  // 「ファイルは出来たのにコミットされない」事故になる（2026-07-08 mimity 事件, task 20260708174823）。
+  // ランタイム状態 json(.bot-threads/.task-state/tasklist/claude-accounts/.conversations)は
+  // .gitignore 済みなので add -A に混入しない。→ rule 35「스테이지 범위」/ rule 38 ②.
+  spawnSync('git', ['add', '-A'], { cwd: BASE_DIR, encoding: 'utf8', windowsHide: true });
+
+  // commit
+  const msg = `task(${taskId}): ${taskTitle.slice(0, 60)}\n\nAuto-committed by giipclaude Bot\n\nDirective: task result push on ${branch}`;
+  const commitRes = spawnSync('git', ['commit', '-m', msg], { cwd: BASE_DIR, encoding: 'utf8', windowsHide: true });
+  if (commitRes.status !== 0 && !(commitRes.stdout || '').includes('nothing to commit')) {
+    console.error('[TaskManager] git commit:', (commitRes.stderr || '').trim());
+    return null;
+  }
+
+  // Rebase onto latest remote and push, retrying once on non-fast-forward.
+  // --autostash so uncommitted runtime state (bot json) never blocks the rebase. This was the
+  // bug that silently dropped result URLs: dirty tree → rebase refused → push rejected → null.
+  const runGit = (args) => spawnSync('git', args, { cwd: BASE_DIR, encoding: 'utf8', windowsHide: true });
+  const rebaseAndPush = () => {
+    const pull = runGit(['pull', '--rebase', '--autostash', 'origin', branch]);
+    if (pull.status !== 0) {
+      console.error('[TaskManager] git pull --rebase:', (pull.stderr || '').trim());
+      runGit(['rebase', '--abort']); // never leave the repo mid-rebase
+    }
+    return runGit(['push', 'origin', branch]);
+  };
+  let pushRes = rebaseAndPush();
+  if (pushRes.status !== 0) {
+    console.error('[TaskManager] git push rejected, retrying after fetch:', (pushRes.stderr || '').trim());
+    runGit(['fetch', 'origin', branch]);
+    pushRes = rebaseAndPush();
+  }
+  if (pushRes.status !== 0) {
+    console.error('[TaskManager] git push:', (pushRes.stderr || '').trim());
+    return null;
+  }
+
+  // done task file の URL を優先返却
+  return buildGitHubUrl(relDoneTask || relResult);
+}
+
+function buildGitHubUrl(relativePath) {
+  const remoteRes = spawnSync('git', ['remote', 'get-url', 'origin'], { cwd: BASE_DIR, encoding: 'utf8', windowsHide: true });
+  const remote = (remoteRes.stdout || '').trim();
+
+  // git@github.com:Owner/Repo.git  →  https://github.com/Owner/Repo
+  // https://github.com/Owner/Repo.git  →  https://github.com/Owner/Repo
+  const base = remote
+    .replace(/^git@github\.com:/, 'https://github.com/')
+    .replace(/\.git$/, '');
+
+  const branchRes = spawnSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: BASE_DIR, encoding: 'utf8', windowsHide: true });
+  const branch = (branchRes.stdout || '').trim() || 'master';
+
+  return `${base}/blob/${branch}/${relativePath}`;
+}
+
+// remote(origin) → PR compare URL (gh pr create 실패 시 폴백)
+function buildCompareUrl(branch, base, baseDir = BASE_DIR) {
+  const remoteRes = spawnSync('git', ['remote', 'get-url', 'origin'], { cwd: baseDir, encoding: 'utf8', windowsHide: true });
+  const remote = (remoteRes.stdout || '').trim();
+  const b = remote.replace(/^git@github\.com:/, 'https://github.com/').replace(/\.git$/, '');
+  return `${b}/compare/${base}...${branch}?expand=1`;
+}
+
+// ── 작업 전: 최신 base 에서 태스크 전용 브랜치를 만들어 checkout ────────────────
+// 반환 ctx 는 gitPushResultAndPR 에서 push·PR·작업트리 복원에 사용한다.
+// 핵심: 반드시 `git fetch origin <base>` 직후 `origin/<base>` 를 기점으로 브랜치를 만든다.
+// (오래된 로컬 base 위에서 브랜치를 파면 나중에 PR/merge conflict → 이번 재발방지의 요체.)
+function prepareTaskBranch(taskId, baseDir = BASE_DIR) {
+  const git = (args) => spawnSync('git', args, { cwd: baseDir, encoding: 'utf8', windowsHide: true });
+  const isRepo = git(['rev-parse', '--git-dir']);
+  if (isRepo.status !== 0) return { ok: false, notRepo: true, error: 'git 저장소가 아님' };
+  if (gitTreeBusy) {
+    return { ok: false, busy: true, error: '다른 태스크가 작업트리(git)를 점유 중 — 완료 후 다시 go 하세요.' };
+  }
+
+  const originalBranch = getCurrentBranch(baseDir);
+  const base = getBaseBranch(baseDir);
+  const branch = `bot/task-${taskId}`;
+
+  // 드리프트 조기 감지: 새 작업은 항상 기본 브랜치에서 쉬고 있어야 한다(rule 41).
+  // 시작 시점에 비-기본 브랜치(대개 이전 태스크의 bot/task-*)에 있다면 과거에 복원이
+  // 누락됐다는 증거 → 로그로 남긴다. restoreTaskBranch 가 base 로 복원하므로 이번 턴에 자가 치유된다.
+  if (originalBranch !== base) {
+    console.error(`[TaskManager] prepareTaskBranch: ⚠️ 작업 시작 시 트리가 base(${base})가 아닌 '${originalBranch}' 에 있었음 (드리프트 흔적). 이번 작업 종료 시 ${base} 로 복원됩니다.`);
+  }
+
+  const fetched = git(['fetch', 'origin', base]);
+  const startPoint = fetched.status === 0 ? `origin/${base}` : base;
+
+  // 자가 치유: 워킹트리에 커밋 안 된 tracked 변경이 있으면 `checkout -B` 가
+  // "your local changes would be overwritten by checkout … Aborting" 으로 중단한다
+  // (02-ActiveProjects/README.md 수정 등). 아무도 치우지 않으므로 go 가 영구 루프로 실패했다.
+  // → checkout 을 막는 tracked 변경만 stash 하고 restoreTaskBranch 에서 pop 한다.
+  //   untracked(.agent/tasks/<id>.md = 실행할 태스크 파일)은 checkout 을 막지 않고
+  //   서브에이전트가 봐야 하므로 stash 에 넣지 않는다(-u 금지).
+  //   gitPushResult 의 `pull --rebase --autostash` 와 같은 철학.
+  let stashed = false;
+  const dirtyTracked = git(['status', '--porcelain', '--untracked-files=no']);
+  if ((dirtyTracked.stdout || '').trim()) {
+    const stash = git(['stash', 'push', '-m', `giipclaude-autostash-${taskId}`]);
+    stashed = stash.status === 0 && !/No local changes/.test(stash.stdout || '');
+  }
+
+  // 자가 치유 ②: untracked 태스크 파일이 startPoint(origin/base)에 이미 tracked 로
+  // 존재하면(과거 시도가 PR 로 base 에 머지된 경우 — giip-645), `checkout -B` 가
+  // "untracked working tree files would be overwritten by checkout … Aborting" 으로
+  // 영구 실패한다. autostash 는 tracked 변경만 다루므로 이 충돌은 치우지 못한다.
+  //   → 현재 요청(untracked)본을 보존하고 파일을 잠시 치워 checkout 을 통과시킨 뒤,
+  //     checkout 후 다시 써서 서브에이전트가 최신 요청을 보게 한다.
+  const taskRel = `.agent/tasks/${taskId}.md`;
+  const taskAbs = path.join(baseDir, taskRel);
+  let savedTaskFile = null;
+  const taskTracked = git(['ls-files', '--error-unmatch', taskRel]).status === 0;
+  const taskOnStart = git(['cat-file', '-e', `${startPoint}:${taskRel}`]).status === 0;
+  if (!taskTracked && taskOnStart) {
+    try {
+      savedTaskFile = fs.readFileSync(taskAbs, 'utf8');
+      fs.rmSync(taskAbs);
+    } catch { savedTaskFile = null; }
+  }
+
+  const co = git(['checkout', '-B', branch, startPoint]);
+  if (co.status !== 0) {
+    if (savedTaskFile != null) { try { fs.writeFileSync(taskAbs, savedTaskFile); } catch {} }
+    if (stashed) git(['stash', 'pop']); // 실패 시 사용자 변경을 되돌려 유실 방지
+    return { ok: false, error: `브랜치 생성 실패: ${(co.stderr || '').trim().slice(0, 200)}` };
+  }
+  // checkout 성공: base 의 옛 태스크 파일이 트리에 올라왔을 수 있으므로 현재 요청본으로
+  // 덮어써 서브에이전트가 최신 요청을 실행하게 한다(커밋되면 이번 태스크 변경으로 남음).
+  if (savedTaskFile != null) { try { fs.writeFileSync(taskAbs, savedTaskFile); } catch {} }
+
+  gitTreeBusy = true;
+  return { ok: true, branch, base, originalBranch, fetchedBase: fetched.status === 0, stashed };
+}
+
+// 작업트리를 기본(base) 브랜치로 복원하고 busy 락을 해제한다. (성공/실패 무관 항상 호출)
+//
+// rule 41(브랜치 생명주기): 한 작업의 종료 = PR 생성 + 기본 브랜치(master/main) 복귀.
+// ⚠️ 근본 원인 수정(giip-633): 예전에는 `ctx.originalBranch`(작업 시작 시점의 브랜치)로 복원했다.
+//   그러나 트리가 한 번이라도 비-master 브랜치(강제종료로 남은 bot/task-*, 이전 복원 실패,
+//   수동 checkout 등)에 놓이면, 그 브랜치가 다음 태스크의 originalBranch 로 기록되고 복원도
+//   다시 그 브랜치로 돌아가, 작업트리가 영구히 master 로 못 돌아오는 드리프트가 됐다
+//   (= 사용자가 지적한 "자꾸 디폴트 브랜치에서 시작 안 함"). 복원 목적지를 항상 base 로 고정해
+//   태스크가 끝날 때마다 트리를 master 로 되돌려(self-heal) 드리프트를 끊는다.
+function restoreTaskBranch(ctx, baseDir = BASE_DIR) {
+  const git = (args) => spawnSync('git', args, { cwd: baseDir, encoding: 'utf8', windowsHide: true });
+  // ctx 가 없으면 prepareTaskBranch 가 트리를 전환하지 않은 경우(비-repo/busy 등) → 복원할 것이 없다.
+  if (!ctx) { gitTreeBusy = false; return; }
+  try {
+    // 복원 목적지 = 기본 브랜치. ctx.base 우선, 없으면 실측(getBaseBranch).
+    const base = ctx.base || getBaseBranch(baseDir);
+    const co = git(['checkout', base]);
+    if (co.status !== 0) {
+      console.error(`[TaskManager] restoreTaskBranch: base(${base}) 체크아웃 실패 —`, (co.stderr || '').trim());
+    } else {
+      // rule 41 step 5: 기본 브랜치를 origin 최신으로 ff 동기화(다음 태스크의 startPoint 신선도 확보).
+      // 절대 로컬 base 에 커밋하지 않으므로 diverge 없음 → ff-only 로 안전. 실패해도 비치명(로그만).
+      const pull = git(['pull', '--ff-only', 'origin', base]);
+      if (pull.status !== 0) {
+        console.error(`[TaskManager] restoreTaskBranch: ${base} ff-pull 실패(비치명) —`, (pull.stderr || '').trim());
+      }
+    }
+    // prepareTaskBranch 에서 autostash 한 tracked 변경을 기본 브랜치로 되돌린다.
+    // (정상 경로에서는 originalBranch == base 이므로 팝 대상 브랜치가 동일. 드리프트 상황이었다면
+    //  변경을 master 로 합류시켜 브랜치 오염을 정리한다.)
+    if (ctx.stashed) {
+      const pop = git(['stash', 'pop']);
+      if (pop.status !== 0) {
+        // pop 충돌 시 stash 는 보존된다(git 기본 동작) — 사용자 변경을 유실하지 않는다.
+        console.error('[TaskManager] restoreTaskBranch stash pop 충돌 — stash 보존:', (pop.stderr || '').trim());
+      }
+    }
+  } finally {
+    gitTreeBusy = false;
+  }
+}
+
+// 태스크 브랜치 → base 로 PR 을 보장한다. 이미 열린 PR 이 있으면 그 URL, 없으면 새로 만든다.
+function ensurePR(taskId, taskTitle, branch, base, baseDir = BASE_DIR) {
+  // gh 는 GH_TOKEN/GITHUB_TOKEN 이 있으면 그 토큰을 우선 사용한다. 봇 .env 의 GITHUB_TOKEN 은
+  // PR 생성 권한이 없어 `gh pr create` 가 "Resource not accessible by personal access token" 로
+  // 실패하고 compare 링크로 폴백됐다. 이 두 토큰을 제거해 gh 자체 로그인(gh auth login — PR 권한 보유)을
+  // 쓰게 한다. (github-issues.js 등 다른 곳의 GITHUB_TOKEN 사용에는 영향 없음: 여기 spawn 에만 적용.)
+  const ghEnv = { ...process.env };
+  delete ghEnv.GITHUB_TOKEN;
+  delete ghEnv.GH_TOKEN;
+  const gh = (args) => spawnSync('gh', args, { cwd: baseDir, encoding: 'utf8', windowsHide: true, env: ghEnv });
+
+  // 기존 PR 확인 (재실행/중복 방지)
+  const existing = gh(['pr', 'list', '--head', branch, '--state', 'open', '--json', 'url', '--jq', '.[0].url']);
+  const existingUrl = (existing.stdout || '').trim();
+  if (existing.status === 0 && existingUrl.startsWith('http')) return existingUrl;
+
+  const title = `task(${taskId}): ${taskTitle.slice(0, 60)}`;
+  const body = [
+    'giipclaude Bot 자동 생성 PR.',
+    '',
+    `- 태스크: \`${taskId}\``,
+    `- 브랜치: \`${branch}\` → \`${base}\``,
+    `- 결과 보고서: \`.agent/results/${taskId}.md\``,
+    '',
+    '🤖 Generated by giipclaude Bot',
+  ].join('\n');
+
+  const create = gh(['pr', 'create', '--base', base, '--head', branch, '--title', title, '--body', body]);
+  if (create.status === 0) {
+    const url = (create.stdout || '').trim().split(/\s+/).filter(u => u.startsWith('http')).pop();
+    if (url) return url;
+  }
+  console.error('[TaskManager] gh pr create 실패:', (create.stderr || create.stdout || '').trim().slice(0, 300));
+  return buildCompareUrl(branch, base, baseDir); // 폴백: compare 링크 (수동 PR 생성 가능)
+}
+
+// ── PR 충돌 게이트: 변경 파일이 '미머지 열린 PR'의 대상이면 그 PR 목록을 돌려준다 ──────
+// 목적(사용자 요청): 같은 파일을 대상으로 한 PR 이 아직 머지 안 된 상태에서 또 다른 작업이
+//   같은 파일을 건드리면 나중에 반드시 conflict 가 난다(#84/#85 사례). PR 을 새로 만들기
+//   '직전'에 검사해 경쟁 PR 을 만들지 않고 멈춘 뒤, 사용자에게 "먼저 그 PR 을 머지하라"고 알린다.
+//   서브에이전트는 작업이 끝나기 전엔 어떤 파일을 바꿀지 알 수 없으므로, 확실한 차단 지점은
+//   '변경 파일이 확정된 = PR 생성 직전'이다.
+// selfBranch(= 지금 만들 브랜치)의 PR 은 제외한다(자기 자신과는 충돌 아님).
+// gh 실패/파싱 실패는 비치명 → 빈 배열(게이트 미적용). 데이터 안전 원칙상 '막지 못해도 진행'.
+function findBlockingPRs(root, changedFiles, selfBranch) {
+  if (!changedFiles || changedFiles.length === 0) return [];
+  const ghEnv = { ...process.env };
+  delete ghEnv.GITHUB_TOKEN; // ensurePR 과 동일: 봇 PAT 대신 gh 자체 로그인 사용
+  delete ghEnv.GH_TOKEN;
+  const r = spawnSync('gh', ['pr', 'list', '--state', 'open', '--json', 'number,headRefName,url,files', '--limit', '100'],
+    { cwd: root, encoding: 'utf8', windowsHide: true, env: ghEnv });
+  if (r.status !== 0) {
+    console.error('[TaskManager] findBlockingPRs: gh pr list 실패(게이트 미적용):', (r.stderr || '').trim().slice(0, 120));
+    return [];
+  }
+  let prs;
+  try { prs = JSON.parse(r.stdout || '[]'); } catch { return []; }
+  const changed = new Set(changedFiles); // repo-relative path 로 비교(양쪽 동일 기준)
+  const blocking = [];
+  for (const pr of (prs || [])) {
+    if (pr.headRefName === selfBranch) continue;
+    const overlap = (pr.files || []).map(f => f.path).filter(p => changed.has(p));
+    if (overlap.length) blocking.push({ number: pr.number, url: pr.url, branch: pr.headRefName, files: overlap });
+  }
+  return blocking;
+}
+
+// ── Phase 3': 태스크 브랜치에 커밋·push → base 로 PR 생성 → 작업트리 복원 ────────
+// 반환값 = PR URL(성공) / compare URL(폴백) / null(push 실패). 항상 작업트리를 원복한다.
+function gitPushResultAndPR(taskId, taskTitle, resultFile, doneTaskFile, ctx, baseDir = BASE_DIR) {
+  const git = (args) => spawnSync('git', args, { cwd: baseDir, encoding: 'utf8', windowsHide: true });
+  try {
+    const branch = (ctx && ctx.branch) || getCurrentBranch(baseDir);
+    const base = (ctx && ctx.base) || getBaseBranch(baseDir);
+
+    // 산출물 전부 스테이지(경로 무관, rule 35). 런타임 json 은 .gitignore 처리됨.
+    git(['add', '-A']);
+    const msg = `task(${taskId}): ${taskTitle.slice(0, 60)}\n\nAuto-committed by giipclaude Bot\n\nDirective: ${branch} → PR to ${base}`;
+    const commitRes = git(['commit', '-m', msg]);
+    if (commitRes.status !== 0 && !(commitRes.stdout || '').includes('nothing to commit')) {
+      console.error('[TaskManager] git commit:', (commitRes.stderr || '').trim());
+      return null;
+    }
+
+    // 태스크 전용 브랜치 push. 신규면 -u, 이미 있으면 rebase 후 재시도.
+    let push = git(['push', '-u', 'origin', branch]);
+    if (push.status !== 0) {
+      console.error('[TaskManager] push rejected, retry after fetch+rebase:', (push.stderr || '').trim());
+      git(['fetch', 'origin', branch]);
+      git(['pull', '--rebase', '--autostash', 'origin', branch]);
+      push = git(['push', '-u', 'origin', branch]);
+    }
+    if (push.status !== 0) {
+      console.error('[TaskManager] git push:', (push.stderr || '').trim());
+      return null;
+    }
+
+    return ensurePR(taskId, taskTitle, branch, base, baseDir);
+  } finally {
+    restoreTaskBranch(ctx, baseDir); // 성공/실패/예외 무관 항상 원복 + busy 해제
+  }
+}
+
+// ── Phase 3'': タスクが実際に変更した「全リポジトリ」を安全に commit·push·PR ──────
+//
+// 背景: サブエージェントは effWorkDir 直下のリポだけでなく、その配下の独立した
+//   nested git repo (例: giipprj/giipv3, giipprj/giipdb) も変更しうる。従来は単一リポ
+//   しか扱わず、nested repo の変更は commit も push も PR もされず「作業ツリーに孤児の
+//   未コミット変更」として取り残されていた。ここではそれを解消する。
+//
+// データ安全性が最優先ルール:
+//   ① 実行「前」に clean だったリポだけを自動 PR する。実行前から dirt があったリポは
+//      一切触らず skip+報告する（ユーザの未コミット作業を絶対に失わない/上書きしない）。
+//   ② タスク由来の変更は git stash で退避してから origin/base 起点の bot/task ブランチへ
+//      pop する。pop が conflict した場合は必ず元ブランチへ変更を戻し、stash を捨てない。
+//   ③ 各リポは try/finally 相当で必ず元ブランチへ復元する。conflict のまま放置しない。
+
+function gitC(root, args) {
+  return spawnSync('git', args, { cwd: root, encoding: 'utf8', windowsHide: true });
+}
+
+// リポジトリ root を Windows 大小文字無視で正規化（除外集合との突合に使う）
+function normRoot(p) {
+  return path.resolve(p).replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+}
+
+// dir を含む git リポジトリの toplevel（無ければ null）
+function repoToplevel(dir) {
+  const r = gitC(dir, ['rev-parse', '--show-toplevel']);
+  if (r.status !== 0) return null;
+  return (r.stdout || '').trim() || null;
+}
+
+function isGitRepoDir(dir) {
+  try { return fs.existsSync(path.join(dir, '.git')); } catch { return false; }
+}
+
+// `git status --porcelain` の各行から「変更パス」だけを Set で返す。
+// rename(`old -> new`)は new 側、quoted path は unquote して比較キーにする。
+function porcelainPathSet(root) {
+  const set = new Set();
+  const r = gitC(root, ['status', '--porcelain']);
+  if (r.status !== 0) return set;
+  (r.stdout || '').split('\n').forEach(line => {
+    if (!line.trim()) return;
+    let p = line.slice(3); // 先頭3文字はステータス(XY + 空白)
+    const arrow = p.indexOf(' -> ');
+    if (arrow >= 0) p = p.slice(arrow + 4);
+    p = p.trim().replace(/^"(.*)"$/, '$1');
+    if (p) set.add(p);
+  });
+  return set;
+}
+
+// 実行「前」に候補リポの dirty 状態をスナップショットする。
+// 候補 = effWorkDir を含むリポ(toplevel) + その 1〜2 階層下の nested git repo。
+// 返り値: [{ root, normRoot, originalBranch, preDirt:Set<path> }]
+// 候補リポの root 一覧(Map<normRoot, root>)を返す。
+// = effWorkDir を含むリポ(toplevel) + その 1〜2 階層下の nested git repo。
+// repo を見つけたらその中へは降りない(サブサブ repo は追わない)。
+function candidateRepoRoots(effWorkDir) {
+  const roots = new Map(); // normRoot -> 実際の root
+  const addRoot = (dir) => {
+    const top = repoToplevel(dir);
+    if (top) roots.set(normRoot(top), top);
+  };
+
+  addRoot(effWorkDir); // primary: effWorkDir を含むリポ
+
+  // nested repo 探索(1〜2 階層)。repo を見つけたらその中へは降りない(サブサブ repo は追わない)。
+  const listDirs = (base) => {
+    try {
+      return fs.readdirSync(base, { withFileTypes: true })
+        .filter(d => d.isDirectory() && !d.name.startsWith('.') && d.name !== 'node_modules')
+        .map(d => path.join(base, d.name));
+    } catch { return []; }
+  };
+  const scanNested = (base) => {
+    for (const d1 of listDirs(base)) {
+      if (isGitRepoDir(d1)) { addRoot(d1); continue; }
+      for (const d2 of listDirs(d1)) {
+        if (isGitRepoDir(d2)) addRoot(d2);
+      }
+    }
+  };
+  scanNested(effWorkDir);
+
+  // ── 追加: effWorkDir の「兄弟」リポも候補に含める(root cause 修正) ──
+  // 背景: プレフィックス無しのタスク(例:「azure-rg …修正」)は effWorkDir=BASE_DIR(lowyworkenv)
+  //   になるが、サブエージェントは projects/giipprj/giipv3 のような lowyworkenv の兄弟パスを編集する。
+  //   effWorkDir 配下しか見ない従来スキャンでは、その変更は発見されず auto-PR から丸ごと漏れ、
+  //   コードは commit も PR もされないまま「完了」報告される(= giipv3 を直したのに PR が無い、の根因)。
+  //   → PROJECTS_ROOT を常に 1〜2 階層スキャンして兄弟 repo(giipprj/giipv3, giipprj/giipdb 等)も候補化。
+  //   実際に「このタスクが変更した」repo だけが後段(commitAndPRChangedRepos)で preDirt 差分により
+  //   commit/PR/skip 判定されるため、候補を広げても無関係リポには一切触れない。
+  const PROJECTS_ROOT = path.dirname(BASE_DIR); // …/projects
+  scanNested(PROJECTS_ROOT);
+
+  return roots;
+}
+
+// ── 作業「前」: 候補 nested repo の base ブランチを origin 最新へ ff 同期する ──
+// 根本原因(ユーザ指摘「giipv3 は毎回 conflict」): prepareTaskBranch/restoreTaskBranch の
+//   ff-pull は BASE_DIR(lowyworkenv) だけを同期し、nested repo(giipprj/giipv3 等)の
+//   ローカル base は誰も更新しなかった。その結果サブエージェントは「数コミット遅れた
+//   stale な base」上でファイルを編集し、後段 auto-PR が最新 origin/base から切った
+//   ブランチへ replay する時に、既に origin へ merge 済みの変更と衝突していた
+//   (= giip-701 が作った SES ファイルを giip-705 が「新規」として再作成 → add/add conflict)。
+// 対策: 作業を始める前に、各候補 repo が「base ブランチ上」かつ「クリーン(未コミット無し)」
+//   の時だけ origin/base へ ff 同期する。feature ブランチや dirty(= 未統合 WIP)は触らない。
+// 安全性: 常に ff-only。ローカル base に独自コミットは積まない前提なので diverge しない。
+//   失敗・skip は非致命(ログのみ) — 同期できなくても従来同様に実行は続く。
+function syncCandidateReposBase(effWorkDir) {
+  const results = [];
+  let roots;
+  try { roots = candidateRepoRoots(effWorkDir); }
+  catch (e) { console.error('[TaskManager] syncCandidateReposBase: 列挙失敗 —', e.message); return results; }
+  for (const [, root] of roots) {
+    try {
+      const base = getBaseBranch(root);
+      const cur = getCurrentBranch(root);
+      if (cur !== base) { results.push({ root, base, synced: false, reason: `on '${cur}' (not base)` }); continue; }
+      if (porcelainPathSet(root).size > 0) { results.push({ root, base, synced: false, reason: 'dirty working tree' }); continue; }
+      const fetched = gitC(root, ['fetch', 'origin', base]);
+      if (fetched.status !== 0) { results.push({ root, base, synced: false, reason: `fetch failed: ${(fetched.stderr || '').trim().slice(0, 80)}` }); continue; }
+      const ff = gitC(root, ['merge', '--ff-only', `origin/${base}`]);
+      if (ff.status !== 0) { results.push({ root, base, synced: false, reason: `ff-merge failed: ${(ff.stderr || '').trim().slice(0, 80)}` }); continue; }
+      results.push({ root, base, synced: true, advanced: !/Already up to date/i.test(ff.stdout || '') });
+    } catch (e) {
+      results.push({ root, synced: false, reason: e.message });
+    }
+  }
+  for (const r of results) {
+    if (r.synced) console.log(`[TaskManager] syncCandidateReposBase: ${r.root} ${r.base} ${r.advanced ? 'ff-synced to origin' : 'up to date'}`);
+    else console.log(`[TaskManager] syncCandidateReposBase: skip ${r.root} — ${r.reason}`);
+  }
+  return results;
+}
+
+// ── 作業「前」: 候補 nested repo を「このタスク専用ブランチ」へ切り替える(スト孤児化の根本予防) ──
+//
+// 근본원인: prepareTaskBranch/restoreTaskBranch 는 BASE_DIR(lowyworkenv)만 bot/task-<id> 로
+//   전환·복원했고, nested repo(giipprj/giipv3, giipprj/giipdb)는 직전 태스크가 남긴 브랜치
+//   (예: bot/task-giip-705)에 파킹된 채 방치됐다. 그래서 서브에이전트의 nested 편집은
+//   '남의 브랜치'에 쌓였고, 후단 commitAndPRChangedRepos 는 originalBranch≠bot/task-<id> 를
+//   'foreign branch' 로 판정해 skip → 코드가 PR 없이 스트랜드됐다(= "REVIEW인데 배포 0"의 뿌리).
+//
+// 대책: 서브에이전트 실행 '전'에, base 위에서 clean 한 후보 repo 만 origin/base 起点의
+//   bot/task-<id> 로 checkout 한다. 그러면 편집이 올바른 전용 브랜치에 쌓여 자동 commit·PR 이
+//   성립하고, unlanded(스트랜드)가 정상 경로에서 사라진다.
+//
+// 안전 원칙(데이터 최우선):
+//   · clean(미커밋 0) & base 브랜치 위 인 repo 만 만진다.
+//   · dirty(미정리 WIP) 나 이미 비-base(foreign)에 있는 repo 는 절대 건드리지 않는다
+//     (= 기존 스트랜드/사용자 WIP 를 덮지 않음 — 그건 감사/재개가 별도 처리).
+//   · BASE_DIR 은 prepareTaskBranch 가 이미 담당하므로 제외.
+// 반환: [{ root, base, branch, restoreTo }] — restoreNestedBranches 로 원복할 목록.
+function prepareNestedBranches(effWorkDir, taskId, excludeRoots = [BASE_DIR]) {
+  const branch = `bot/task-${taskId}`;
+  const exclude = new Set((excludeRoots || []).map(normRoot));
+  const prepared = [];
+  let roots;
+  try { roots = candidateRepoRoots(effWorkDir); }
+  catch (e) { console.error('[TaskManager] prepareNestedBranches: 열거 실패 —', e.message); return prepared; }
+  for (const [nr, root] of roots) {
+    if (exclude.has(nr)) continue;
+    try {
+      const base = getBaseBranch(root);
+      const cur = getCurrentBranch(root);
+      if (porcelainPathSet(root).size > 0) {
+        console.log(`[TaskManager] prepareNestedBranches: skip ${root} — dirty(미정리 WIP); ${branch} 전환 안 함`);
+        continue;
+      }
+      if (cur !== base) {
+        console.log(`[TaskManager] prepareNestedBranches: skip ${root} — '${cur}'(≠base ${base}); 스트랜드 흔적, 이번엔 만지지 않음`);
+        continue;
+      }
+      const fetched = gitC(root, ['fetch', 'origin', base]);
+      const startPoint = fetched.status === 0 ? `origin/${base}` : base;
+      const co = gitC(root, ['checkout', '-B', branch, startPoint]);
+      if (co.status !== 0) {
+        console.error(`[TaskManager] prepareNestedBranches: ${root} checkout 실패 —`, (co.stderr || '').trim().slice(0, 120));
+        continue;
+      }
+      prepared.push({ root, base, branch, restoreTo: base });
+      console.log(`[TaskManager] prepareNestedBranches: ${root} → ${branch} (from ${startPoint})`);
+    } catch (e) {
+      console.error(`[TaskManager] prepareNestedBranches: ${root} 오류 —`, e.message);
+    }
+  }
+  return prepared;
+}
+
+// ── 作業「後」: prepareNestedBranches 로 전환한 nested repo 를 base 로 복원한다 ──
+// commitAndPRChangedRepos 가 이미 각 repo 를 commit·push·PR 하고 그 전용 브랜치로 checkout 해 둔다.
+//   여기서 base 로 되돌려(ff-pull) 다음 태스크가 clean·on-base 에서 시작하게 한다
+//   (= restoreTaskBranch 의 nested 판; 드리프트 누적을 끊는다).
+// 안전: 커밋 안 된 변경이 남은 repo 는 base 로 옮기면 변경이 딸려가 오염되므로 복원을 보류한다
+//   (= commitAndPR 가 skip/blocked 로 남긴 잔여물은 그대로 두고 감사/재개가 처리).
+function restoreNestedBranches(prepared) {
+  for (const p of (prepared || [])) {
+    const root = p.root, base = p.restoreTo || p.base;
+    try {
+      if (porcelainPathSet(root).size > 0) {
+        console.log(`[TaskManager] restoreNestedBranches: ${root} 에 미커밋 변경 잔존 → base 복원 보류(스트랜드 방지)`);
+        continue;
+      }
+      const co = gitC(root, ['checkout', base]);
+      if (co.status !== 0) { console.error(`[TaskManager] restoreNestedBranches: ${root} base(${base}) 복원 실패 —`, (co.stderr || '').trim().slice(0, 120)); continue; }
+      const pull = gitC(root, ['pull', '--ff-only', 'origin', base]);
+      if (pull.status !== 0) console.error(`[TaskManager] restoreNestedBranches: ${root} ${base} ff-pull 실패(비치명) —`, (pull.stderr || '').trim().slice(0, 80));
+    } catch (e) {
+      console.error(`[TaskManager] restoreNestedBranches: ${root} 오류 —`, e.message);
+    }
+  }
+}
+
+function snapshotCandidateRepos(effWorkDir) {
+  const roots = candidateRepoRoots(effWorkDir);
+  const snaps = [];
+  for (const [norm, root] of roots) {
+    snaps.push({
+      root,
+      normRoot: norm,
+      originalBranch: getCurrentBranch(root),
+      preDirt: porcelainPathSet(root),
+    });
+  }
+  return snaps;
+}
+
+// スナップショットした候補リポのうち、タスクが実際に変更したものを各々 commit·push·PR する。
+// opts.excludeRoots: ここで扱わないリポ(既存の gitPushResultAndPR が扱う BASE_DIR 等)。
+// 返り値: { prs:[{repo,url}], skipped:[{repo,reason}] }
+function commitAndPRChangedRepos(taskId, taskTitle, snapshots, opts = {}) {
+  const excludeRoots = new Set((opts.excludeRoots || []).map(normRoot));
+  const prs = [];
+  const skipped = [];
+  const blocked = []; // PR 충돌 게이트에 걸려 PR 생성을 보류한 저장소(브랜치는 push 됨)
+  const branch = `bot/task-${taskId}`;
+  const coAuthor = 'Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>';
+
+  for (const snap of (snapshots || [])) {
+    const root = snap.root;
+    const nr = snap.normRoot || normRoot(root);
+    if (excludeRoots.has(nr)) continue; // 別経路が担当 → ここでは扱わない
+
+    const git = (args) => gitC(root, args);
+    const originalBranch = snap.originalBranch || getCurrentBranch(root);
+
+    try {
+      const postDirt = porcelainPathSet(root);
+      const newPaths = [...postDirt].filter(p => !snap.preDirt.has(p));
+      if (newPaths.length === 0) continue; // タスクはこのリポを変更していない → 静かに skip
+
+      // ── データ安全ガード ①: 実行前から dirt があったリポの扱い ──
+      // 背景: giipv3/giipdb 等の nested repo は、サブエージェントが「git 操作禁止」指示の下で
+      //   作業ツリーにのみ変更を残す（あるいは前段セッションが残す）ため、スナップショット時点で
+      //   ほぼ常に preDirt > 0 になる。旧実装はこれを一律 skip していたため nested repo の変更は
+      //   永遠に自動 PR されなかった（= ユーザ指摘の「毎回 手動 PR」問題の根因）。
+      //
+      // 判別の鍵: 「専用 feature/task ブランチ上の dirt」はそのタスクの作業とみなせる（base で
+      //   ないブランチに居る = 誰かが意図してそのブランチを切って作業した強いシグナル）。一方
+      //   「base ブランチ上の dirt」はユーザの無関係な WIP かもしれず、従来通り触らない。
+      if (snap.preDirt.size > 0) {
+        const base0 = getBaseBranch(root);
+        const onFeatureBranch = originalBranch && originalBranch !== base0 && originalBranch !== 'HEAD';
+        if (!onFeatureBranch) {
+          // base ブランチ上の未コミット変更 = 曖昧な WIP。安全側に倒して従来通り skip。
+          skipped.push({ repo: root, reason: `pre-existing uncommitted changes on base branch '${base0}'; manual PR needed`, files: newPaths });
+          continue;
+        }
+        // ── 誤帰属ガード: 「別タスクのブランチ」に停まった共有チェックアウトは自動 commit しない ──
+        // 背景(giip-720 実例): giipprj/giipv3 は複数タスクで共有される単一チェックアウトで、
+        //   別タスクのブランチ(例 bot/task-giip-705)に停まったまま、そのタスクの未コミット変更と
+        //   今回タスクの変更が同じ作業ツリーで混在する。ここで git add -A + commit すると
+        //   (1) 他タスクの churn まで巻き込み、(2) 他タスクのブランチ/PR へ push してしまう。
+        //   → このタスク専用ブランチ(bot/task-<taskId>)に居る時だけ自動 commit。そうでなければ
+        //     手動 PR が必要な旨を明示して skip(= 後段の完了報告で警告される)。
+        if (originalBranch !== branch) {
+          skipped.push({
+            repo: root,
+            reason: `changes tangled on foreign branch '${originalBranch}' (≠ ${branch}); shared checkout — manual PR needed`,
+            files: newPaths,
+          });
+          continue;
+        }
+        // 専用 feature/task ブランチ上の変更 → そのブランチのまま commit·push·PR する。
+        // (stash→bot/task ブランチ の付け替えはしない: ブランチは既にセッション/前段が選んでいる。)
+        git(['add', '-A']);
+        const msgF = `task(${taskId}): ${String(taskTitle).slice(0, 60)}\n\nAuto-committed by giipclaude Bot\n\n${coAuthor}`;
+        const commitF = git(['commit', '-m', msgF]);
+        if (commitF.status !== 0 && !/nothing to commit/.test(commitF.stdout || '')) {
+          skipped.push({ repo: root, reason: `commit failed on '${originalBranch}': ${(commitF.stderr || '').trim().slice(0, 120)}` });
+          continue;
+        }
+        let pushF = git(['push', '-u', 'origin', originalBranch]);
+        if (pushF.status !== 0) {
+          git(['pull', '--rebase', '--autostash', 'origin', originalBranch]);
+          pushF = git(['push', '-u', 'origin', originalBranch]);
+        }
+        if (pushF.status !== 0) {
+          skipped.push({ repo: root, reason: `push failed: ${(pushF.stderr || '').trim().slice(0, 120)} (commit is local on '${originalBranch}')` });
+          continue;
+        }
+        // ── PR 충돌 게이트: 변경 파일이 미머지 열린 PR 대상이면 PR 생성 보류(브랜치는 이미 push) ──
+        const blkF = findBlockingPRs(root, newPaths, originalBranch);
+        if (blkF.length) {
+          blocked.push({ repo: root, branch: originalBranch, base: base0, prs: blkF, files: newPaths });
+          continue; // 경쟁 PR 을 만들지 않는다. "머지완료 <taskid>" 로 재개.
+        }
+        const urlF = ensurePR(taskId, taskTitle, originalBranch, base0, root);
+        prs.push({ repo: root, url: urlF });
+        continue; // このリポは完了。以降の clean-before(stash) フローには進まない。
+      }
+
+      const base = getBaseBranch(root);
+
+      // タスク由来の変更を stash に退避(未追跡ファイル含む -u)
+      const stash = git(['stash', 'push', '-u', '-m', `bot-task-${taskId}`]);
+      if (stash.status !== 0) {
+        skipped.push({ repo: root, reason: `stash failed: ${(stash.stderr || '').trim().slice(0, 120)}` });
+        continue;
+      }
+      if (/No local changes to save/.test(stash.stdout || '')) continue; // 念のため
+
+      // origin/base 起点で bot/task ブランチを作る(常に最新 base 基準)
+      const fetched = git(['fetch', 'origin', base]);
+      const startPoint = fetched.status === 0 ? `origin/${base}` : base;
+      const co = git(['checkout', '-B', branch, startPoint]);
+      if (co.status !== 0) {
+        // ブランチ作成失敗 → まだ originalBranch に居るので stash を戻して skip(データ保全)
+        git(['checkout', originalBranch]);
+        git(['stash', 'pop']);
+        skipped.push({ repo: root, reason: `branch create failed; changes restored to ${originalBranch}` });
+        continue;
+      }
+
+      // 退避した変更を bot ブランチへ適用
+      const pop = git(['stash', 'pop']);
+      const conflicts = git(['diff', '--name-only', '--diff-filter=U']);
+      const hasConflict = (conflicts.stdout || '').trim().length > 0;
+      if (pop.status !== 0 || hasConflict) {
+        // ── conflict 回復(データ非損失を保証) ──
+        // pop が conflict した場合、stash エントリは list に残る(pop は drop しない)。
+        // bot ブランチ側の部分適用を破棄 → 元ブランチへ戻り → そこへ stash を再適用する。
+        // clean-before 保証があるため、この reset --hard + clean は「タスク由来の未追跡物」
+        // だけを消し、stash に全て残っているので損失ゼロ。
+        git(['reset', '--hard', 'HEAD']);
+        git(['clean', '-fd']); // clean-before なので untracked は全てタスク/stash 由来 = 復元可能
+        git(['checkout', originalBranch]);
+        const pop2 = git(['stash', 'pop']); // clean な元ブランチへ再適用
+        git(['branch', '-D', branch]);       // 空の bot ブランチを削除
+        skipped.push({
+          repo: root,
+          reason: pop2.status === 0
+            ? 'auto-PR conflict; changes left on original branch'
+            : 'auto-PR conflict; stash retained (see `git stash list`) — manual recovery needed',
+        });
+        continue;
+      }
+
+      // clean pop → commit
+      git(['add', '-A']);
+      const msg = `task(${taskId}): ${String(taskTitle).slice(0, 60)}\n\nAuto-committed by giipclaude Bot\n\n${coAuthor}`;
+      const commit = git(['commit', '-m', msg]);
+      if (commit.status !== 0 && !/nothing to commit/.test(commit.stdout || '')) {
+        git(['checkout', originalBranch]);
+        skipped.push({ repo: root, reason: `commit failed: ${(commit.stderr || '').trim().slice(0, 120)}` });
+        continue;
+      }
+
+      // push(新規は -u、拒否時は fetch+rebase して再試行)
+      let push = git(['push', '-u', 'origin', branch]);
+      if (push.status !== 0) {
+        git(['fetch', 'origin', branch]);
+        git(['pull', '--rebase', '--autostash', 'origin', branch]);
+        push = git(['push', '-u', 'origin', branch]);
+      }
+      if (push.status !== 0) {
+        // push 失敗: commit はローカル bot ブランチに残る(損失なし)。元ブランチへ戻して報告。
+        git(['checkout', originalBranch]);
+        skipped.push({ repo: root, reason: `push failed: ${(push.stderr || '').trim().slice(0, 120)} (commit is local on ${branch})` });
+        continue;
+      }
+
+      // ── PR 충돌 게이트: 변경 파일이 미머지 열린 PR 대상이면 PR 생성 보류(브랜치는 이미 push) ──
+      const blk = findBlockingPRs(root, newPaths, branch);
+      if (blk.length) {
+        blocked.push({ repo: root, branch, base, prs: blk, files: newPaths });
+        git(['checkout', originalBranch]); // 작업트리 복원(PR 은 보류)
+        continue; // 경쟁 PR 을 만들지 않는다. "머지완료 <taskid>" 로 재개.
+      }
+      // PR 作成(gh 失敗時は ensurePR が compare URL にフォールバック)
+      const url = ensurePR(taskId, taskTitle, branch, base, root);
+      prs.push({ repo: root, url });
+      git(['checkout', originalBranch]); // 作業ツリーを元ブランチへ復元
+    } catch (e) {
+      // best-effort: 例外時も必ず元ブランチへ戻し、mid-conflict のまま放置しない
+      try { git(['checkout', originalBranch]); } catch {}
+      skipped.push({ repo: root, reason: `error: ${e.message}` });
+    }
+  }
+  return { prs, skipped, blocked };
+}
+
+// ── 재개: 사용자가 "머지완료 <taskid>" 로 선행 PR 머지를 알리면, 보류했던 저장소들을
+//   최신 base 로 rebase 후 PR 을 생성한다. 머지된 변경이 base 에 들어왔으므로 대개 자동 해소.
+//   여전히 같은 라인을 건드려 conflict 나면 그 저장소는 수동 필요로 보고(브랜치는 보존).
+// blockedRecords: commitAndPRChangedRepos 가 tasklist 에 남긴 [{repo,branch,base,prs,files}].
+// 반환: { prs:[{repo,url}], stillBlocked:[{repo,reason,branch,prs?}], failed:[{repo,reason}] }.
+function resumeBlockedTask(taskId, taskTitle, blockedRecords) {
+  const prs = [], stillBlocked = [], failed = [];
+  for (const rec of (blockedRecords || [])) {
+    const root = rec.repo;
+    const branch = rec.branch;
+    const base = rec.base || getBaseBranch(root);
+    const git = (args) => gitC(root, args);
+    let originalBranch = null;
+    try {
+      originalBranch = getCurrentBranch(root);
+      git(['fetch', 'origin', base]);
+      git(['fetch', 'origin', branch]);
+      const co = git(['checkout', branch]);
+      if (co.status !== 0) { failed.push({ repo: root, reason: `checkout '${branch}' 실패: ${(co.stderr || '').trim().slice(0, 120)}` }); continue; }
+      const rb = git(['rebase', `origin/${base}`]);
+      if (rb.status !== 0) {
+        git(['rebase', '--abort']);
+        if (originalBranch) git(['checkout', originalBranch]);
+        stillBlocked.push({ repo: root, branch, reason: `origin/${base} 로 rebase conflict — 수동 해소 필요` });
+        continue;
+      }
+      const push = git(['push', '--force-with-lease', 'origin', branch]);
+      if (push.status !== 0) {
+        if (originalBranch) git(['checkout', originalBranch]);
+        failed.push({ repo: root, reason: `push 실패: ${(push.stderr || '').trim().slice(0, 120)} (커밋은 로컬 '${branch}' 에 보존)` });
+        continue;
+      }
+      // 재검사: rebase 후에도 아직 겹치는 미머지 PR 이 있으면 또 보류
+      const blk = findBlockingPRs(root, rec.files || [], branch);
+      if (blk.length) {
+        if (originalBranch) git(['checkout', originalBranch]);
+        stillBlocked.push({ repo: root, branch, prs: blk, reason: `아직 미머지 PR ${blk.map(b => '#' + b.number).join(', ')} 대상` });
+        continue;
+      }
+      const url = ensurePR(taskId, taskTitle, branch, base, root);
+      prs.push({ repo: root, url });
+      if (originalBranch) git(['checkout', originalBranch]);
+    } catch (e) {
+      try { if (originalBranch) git(['checkout', originalBranch]); } catch {}
+      failed.push({ repo: root, reason: e.message });
+    }
+  }
+  return { prs, stillBlocked, failed };
+}
+
+// ── Tasklist ファイル管理 ──────────────────────────────────────────────────────
+function loadTasklist() {
+  try { return JSON.parse(fs.readFileSync(TASKLIST_FILE, 'utf8')); } catch { return []; }
+}
+
+function saveTasklist(list) {
+  try { fs.writeFileSync(TASKLIST_FILE, JSON.stringify(list, null, 2)); } catch {}
+}
+
+function extractSummary(planContent) {
+  // "## リクエスト内容" の直後の行を1行サマリとして使う
+  const m = planContent.match(/##\s*リクエスト内容\s*\n+(.+)/);
+  if (m) return m[1].trim().slice(0, 80);
+  // フォールバック: 最初の非ヘッダ行
+  const line = planContent.split('\n').find(l => l.trim() && !l.startsWith('#'));
+  return (line || '').trim().slice(0, 80);
+}
+
+function addToTasklist(taskId, title, summary, requestText) {
+  const list = loadTasklist();
+  list.push({
+    taskId,
+    title,
+    summary: summary || requestText.slice(0, 80),
+    status: 'pending',
+    createdAt: new Date().toISOString(),
+    startedAt: null,
+    completedAt: null,
+    resultUrl: null,
+  });
+  saveTasklist(list);
+}
+
+function updateTasklistEntry(taskId, updates) {
+  const list = loadTasklist();
+  const idx = list.findIndex(t => t.taskId === taskId);
+  if (idx >= 0) {
+    list[idx] = { ...list[idx], ...updates };
+    saveTasklist(list);
+  }
+}
+
+// status: 'pending' | 'running' | 'completed' | 'cancelled' | null(全件)
+function getTasklistByStatus(status = null) {
+  const list = loadTasklist();
+  return status ? list.filter(t => t.status === status) : list;
+}
+
+// ステータス絵文字
+function statusEmoji(status) {
+  return { pending: '🕐', running: '⚙️', completed: '✅', cancelled: '🚫', blocked: '⏸️' }[status] || '❓';
+}
+
+// タスクファイルの GitHub URL を動的に生成
+function getTaskFileUrl(taskId) {
+  const candidates = [
+    path.join(TASKS_DIR, `${taskId}.md`),
+    path.join(TASKS_DIR, 'done', `${taskId}.md`),
+    path.join(TASKS_DIR, 'cancel', `${taskId}.md`),
+  ];
+  const found = candidates.find(f => fs.existsSync(f));
+  if (!found) return null;
+  const rel = path.relative(BASE_DIR, found).replace(/\\/g, '/');
+  return buildGitHubUrl(rel);
+}
+
+// タスクファイルをキャンセル状態にして cancel/ フォルダへ移動
+function cancelTaskFile(taskId) {
+  const candidates = [
+    path.join(TASKS_DIR, `${taskId}.md`),
+    path.join(TASKS_DIR, `task-${taskId}.md`),
+  ];
+  const taskFile = candidates.find(f => fs.existsSync(f));
+  if (!taskFile) throw new Error(`Task file not found for ${taskId}`);
+
+  const now = new Date().toISOString();
+  let content = fs.readFileSync(taskFile, 'utf8');
+  content = /status:\s*.+/i.test(content)
+    ? content.replace(/status:\s*.+/i, 'status: cancelled')
+    : `status: cancelled\n${content}`;
+  if (content.includes('## 進捗ログ')) {
+    content = content.replace(/(## 進捗ログ[\s\S]*?)(\n## |\s*$)/, (m, s, n) => `${s.trimEnd()}\n| ${now} | Slack cancel |\n${n}`);
+  } else {
+    content = `${content.trimEnd()}\n\n## 進捗ログ\n\n| ${now} | Slack cancel |\n`;
+  }
+  fs.writeFileSync(taskFile, content);
+
+  const cancelDir = path.join(TASKS_DIR, 'cancel');
+  if (!fs.existsSync(cancelDir)) fs.mkdirSync(cancelDir, { recursive: true });
+  const destPath = path.join(cancelDir, path.basename(taskFile));
+
+  // task files are untracked runtime files — use fs.rename instead of git mv
+  fs.renameSync(taskFile, destPath);
+
+  return path.relative(BASE_DIR, destPath).replace(/\\/g, '/');
+}
+
+module.exports = {
+  getTimestampId,
+  analyzeRequest,
+  createTaskFile,
+  updateTaskFile,
+  rebuildTaskFileFromIssue,
+  extractTitle,
+  extractSummary,
+  startExecution,
+  completeTaskFile,
+  appendTaskNote,
+  gitPushResult,
+  prepareTaskBranch,
+  restoreTaskBranch,
+  gitPushResultAndPR,
+  snapshotCandidateRepos,
+  syncCandidateReposBase,
+  prepareNestedBranches,
+  restoreNestedBranches,
+  commitAndPRChangedRepos,
+  findBlockingPRs,
+  resumeBlockedTask,
+  getBaseBranch,
+  addToTasklist,
+  updateTasklistEntry,
+  getTasklistByStatus,
+  statusEmoji,
+  cancelTaskFile,
+  getTaskFileUrl,
+  buildContextCatalog,
+  selectContextFiles,
+  normalizeFilesRead,
+};

--- a/slack-bot-minimax/tools/trace-api-server.js
+++ b/slack-bot-minimax/tools/trace-api-server.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * trace-api-server.js — ローカル Trace Review API サーバー
+ * ポータル(Azure)からローカルのtraceファイルを読み書きする
+ * 起動: node slack-bot/tools/trace-api-server.js
+ * 接続: http://localhost:3001
+ */
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const TRACES_DIR = path.resolve(__dirname, '../../.agent/traces');
+const PORT = 3001;
+
+function cors(res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, PATCH, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+}
+
+const server = http.createServer((req, res) => {
+  cors(res);
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  // GET /traces — steps>=1 かつ completed_at あるものを返す
+  if (req.method === 'GET' && req.url === '/traces') {
+    try {
+      const files = fs.readdirSync(TRACES_DIR)
+        .filter(f => f.endsWith('.json') && f !== '.current');
+      const traces = files
+        .map(f => {
+          try { return JSON.parse(fs.readFileSync(path.join(TRACES_DIR, f), 'utf8')); }
+          catch { return null; }
+        })
+        .filter(t => t && t.completed_at && Array.isArray(t.steps) && t.steps.length >= 1)
+        .sort((a, b) => b.trace_id.localeCompare(a.trace_id));
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(traces));
+    } catch (e) {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: e.message }));
+    }
+    return;
+  }
+
+  // PATCH /traces/:id — reward と feedback を更新
+  const m = req.url.match(/^\/traces\/(\d+)$/);
+  if (req.method === 'PATCH' && m) {
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', () => {
+      try {
+        const file = path.join(TRACES_DIR, `${m[1]}.json`);
+        if (!fs.existsSync(file)) {
+          res.writeHead(404, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'trace not found' }));
+          return;
+        }
+        const trace = JSON.parse(fs.readFileSync(file, 'utf8'));
+        const update = JSON.parse(body);
+        if (update.reward !== undefined) trace.reward = update.reward;
+        if (update.feedback !== undefined) trace.feedback = update.feedback;
+        fs.writeFileSync(file, JSON.stringify(trace, null, 2));
+        console.log(`[PATCH] ${m[1]} → reward=${trace.reward}`);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true }));
+      } catch (e) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: e.message }));
+      }
+    });
+    return;
+  }
+
+  res.writeHead(404);
+  res.end();
+});
+
+server.listen(PORT, '127.0.0.1', () => {
+  console.log(`[Trace API] http://localhost:${PORT}`);
+  console.log(`[Traces]   ${TRACES_DIR}`);
+  console.log(`Ctrl+C で停止`);
+});

--- a/slack-bot-minimax/tools/trace-review.js
+++ b/slack-bot-minimax/tools/trace-review.js
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+/**
+ * trace-review.js — トレース一括レビュー管理
+ *
+ * 使い方:
+ *   node slack-bot/tools/trace-review.js export   → _review.json 生成
+ *   node slack-bot/tools/trace-review.js apply    → _review.json の reward を各 JSON に反映
+ *   node slack-bot/tools/trace-review.js status   → 入力状況サマリー
+ */
+
+const fs   = require('fs');
+const path = require('path');
+
+const TRACES_DIR  = path.resolve(__dirname, '../../.agent/traces');
+const REVIEW_FILE = path.join(TRACES_DIR, '_review.json');
+
+// ── ユーティリティ ─────────────────────────────────────────────────────────
+
+function loadTraces() {
+  return fs.readdirSync(TRACES_DIR)
+    .filter(f => f.endsWith('.json') && !f.startsWith('_'))
+    .map(f => {
+      try { return JSON.parse(fs.readFileSync(path.join(TRACES_DIR, f), 'utf8')); }
+      catch { return null; }
+    })
+    .filter(t => t && t.trace_id)
+    .sort((a, b) => a.trace_id.localeCompare(b.trace_id));
+}
+
+// ── export ─────────────────────────────────────────────────────────────────
+
+function doExport(onlyPending) {
+  const traces = loadTraces();
+  const list = traces
+    .filter(t => !onlyPending || t.reward === null || t.reward === undefined)
+    .map(t => ({
+      id:       t.trace_id,
+      steps:    Array.isArray(t.steps) ? t.steps.length : 0,
+      reward:   t.reward !== undefined ? t.reward : null,
+      feedback: t.feedback || '',
+      task:     (t.task || '').replace(/\n/g, ' ').slice(0, 120),
+    }));
+
+  fs.writeFileSync(REVIEW_FILE, JSON.stringify(list, null, 2), 'utf8');
+  console.log(`[export] ${list.length} 件 → ${REVIEW_FILE}`);
+  console.log('reward が null の行に 0.0〜1.0 の数値を入力し、apply を実行してください。');
+}
+
+// ── apply ──────────────────────────────────────────────────────────────────
+
+function doApply() {
+  if (!fs.existsSync(REVIEW_FILE)) {
+    console.error('_review.json が見つかりません。先に export を実行してください。');
+    process.exit(1);
+  }
+
+  const review = JSON.parse(fs.readFileSync(REVIEW_FILE, 'utf8'));
+  let updated = 0, skipped = 0, errors = 0;
+
+  for (const entry of review) {
+    const file = path.join(TRACES_DIR, `${entry.id}.json`);
+    if (!fs.existsSync(file)) { errors++; continue; }
+
+    const r = entry.reward;
+    if (r === null || r === undefined) { skipped++; continue; }
+    const num = parseFloat(r);
+    if (isNaN(num) || num < 0 || num > 1) {
+      console.warn(`[skip] ${entry.id}: reward=${r} は無効値 (0.0〜1.0)`);
+      skipped++;
+      continue;
+    }
+
+    const trace = JSON.parse(fs.readFileSync(file, 'utf8'));
+    trace.reward   = Math.round(num * 10) / 10;
+    trace.feedback = entry.feedback || trace.feedback || '';
+    fs.writeFileSync(file, JSON.stringify(trace, null, 2), 'utf8');
+    updated++;
+  }
+
+  console.log(`[apply] 更新=${updated}  スキップ=${skipped}  エラー=${errors}`);
+}
+
+// ── status ─────────────────────────────────────────────────────────────────
+
+function doStatus() {
+  const traces = loadTraces();
+  const total   = traces.length;
+  const done    = traces.filter(t => t.reward !== null && t.reward !== undefined).length;
+  const pending = total - done;
+  const avg     = done
+    ? (traces.filter(t => t.reward != null).reduce((s, t) => s + t.reward, 0) / done).toFixed(2)
+    : '-';
+
+  console.log(`トレース合計: ${total}`);
+  console.log(`  入力済み  : ${done}  (平均 reward: ${avg})`);
+  console.log(`  未入力    : ${pending}`);
+
+  if (pending > 0) {
+    console.log('\n未入力 trace 一覧:');
+    traces
+      .filter(t => t.reward === null || t.reward === undefined)
+      .filter(t => Array.isArray(t.steps) && t.steps.length >= 1)
+      .forEach(t => {
+        const taskLine = (t.task || '(task未記録)').replace(/\n/g, ' ').slice(0, 80);
+        console.log(`  ${t.trace_id}  steps=${Array.isArray(t.steps)?t.steps.length:0}  ${taskLine}`);
+      });
+  }
+}
+
+// ── main ───────────────────────────────────────────────────────────────────
+
+const cmd = process.argv[2];
+if (cmd === 'export')        doExport(false);
+else if (cmd === 'pending')  doExport(true);
+else if (cmd === 'apply')    doApply();
+else if (cmd === 'status')   doStatus();
+else {
+  console.log('使い方:');
+  console.log('  node slack-bot/tools/trace-review.js export   # 全 trace を _review.json へ');
+  console.log('  node slack-bot/tools/trace-review.js pending  # reward 未入力のみ export');
+  console.log('  node slack-bot/tools/trace-review.js apply    # _review.json の reward を反映');
+  console.log('  node slack-bot/tools/trace-review.js status   # 入力状況サマリー');
+}

--- a/slack-bot-openclaw/.gitignore
+++ b/slack-bot-openclaw/.gitignore
@@ -1,0 +1,2 @@
+openclaw.json
+.env

--- a/slack-bot-openclaw/README.md
+++ b/slack-bot-openclaw/README.md
@@ -1,0 +1,79 @@
+# Slack Bot — OpenClaw 버전
+
+> `slack-bot`(Claude CLI 직접 spawn)이나 `slack-bot-minimax`(MiniMax 우선 폴백)와 달리, 이 변형은
+> 자체 코드를 작성하지 않고 [OpenClaw](https://docs.openclaw.ai/)라는 멀티 프로바이더 에이전트
+> 게이트웨이 프레임워크를 그대로 설치해 Slack 채널 플러그인으로 구동한다.
+>
+> **여기 담긴 것은 OpenClaw 프레임워크 소스 자체가 아니라, 그 위에서 이 Slack 봇을 재현하기 위한
+> 설정 템플릿 + 설치/기동 스크립트다.** OpenClaw 본체는 npm/pnpm 의존성으로 설치하고, 실제 소스는
+> 건드리지 않는다(수백 개 파일 규모의 별도 오픈소스 모노레포라 vendoring 대상이 아님).
+
+## 왜 이 폴더가 별도인가
+
+- `slack-bot`/`slack-bot-minimax`는 Node.js로 직접 짠 코드가 `claude` CLI를 spawn하는 구조.
+- OpenClaw는 완전히 다른 런타임(자체 Gateway 프로세스 + 플러그인 시스템 + 멀티 프로바이더 모델 라우팅)이라
+  코드 구조 자체가 호환되지 않는다. 억지로 "공통 서비스"로 묶으면 과거 사고(다른 봇 코드가 섞여
+  들어와 실행 로직이 몰래 치환된 사례, PR #416 in `lowyworkenv`)와 같은 위험이 재발할 수 있어
+  **의도적으로 독립 폴더로 분리**했다.
+
+## 사전 준비
+
+```bash
+# OpenClaw 설치(전역)
+npm install -g openclaw
+# 또는 pnpm add -g openclaw
+
+openclaw --version
+```
+
+## 설정
+
+1. `openclaw.json.example`을 실제 설정 위치로 복사한다(기본: `~/.openclaw/openclaw.json`).
+   ```bash
+   openclaw setup   # 최초 1회: ~/.openclaw 초기화
+   # 이후 openclaw.json.example 내용을 참고해 models.providers.minimax / agents.defaults.model 등을 채운다
+   ```
+2. `openclaw.json.example`의 플레이스홀더를 실제 값으로 교체한다:
+   - `channels.slack.botToken` / `appToken` — Slack App(Socket Mode) 발급값
+   - `models.providers.minimax.apiKey` — MiniMax Token Plan Subscription Key(`sk-cp-` 접두, 종량제 API Key와 다름)
+   - `gateway.auth.token` — 게이트웨이 로컬 인증 토큰(임의 생성)
+3. 비대화형으로 MiniMax 인증만 추가하고 싶다면:
+   ```bash
+   openclaw onboard --non-interactive --accept-risk \
+     --auth-choice minimax-api --minimax-api-key <sk-cp-...> \
+     --skip-channels --skip-daemon --skip-skills --skip-ui --skip-health
+   ```
+   (채널/데몬/스킬 설정은 건드리지 않고 인증 프로필만 추가 — 이미 운영 중인 게이트웨이가 있으면
+   `--skip-*` 없이 돌리지 말 것. 전체 마법사가 채널/데몬 설정까지 재구성할 수 있다.)
+
+## 기동
+
+```bash
+openclaw gateway install   # 최초 1회: OS 서비스(schtasks/launchd/systemd) 등록
+openclaw gateway start
+openclaw gateway status    # 확인
+```
+
+로컬에서 포그라운드로 바로 띄우려면:
+```bash
+openclaw gateway run
+```
+
+## 모델 우선순위(이 템플릿 기준)
+
+`openclaw.json.example`은 MiniMax를 1순위로 설정해뒀다(사용자 지정):
+
+```
+agents.defaults.model.primary   = minimax/MiniMax-M2.7
+agents.defaults.model.fallbacks = [기존 provider들...]
+```
+
+MiniMax가 한도 소진되면 OpenClaw 자체 라우팅이 fallbacks 순서대로 다음 provider로 넘어간다
+(`slack-bot-minimax`처럼 별도 쿨다운 로직을 우리가 짤 필요 없음 — OpenClaw가 provider 단위로
+이미 처리한다).
+
+## 참고
+
+- MiniMax Anthropic 호환 엔드포인트: https://platform.minimax.io/docs/api-reference/text-anthropic-api
+- OpenClaw MiniMax 프로바이더 문서: https://docs.openclaw.ai/providers/minimax
+- OpenClaw CLI 문서: https://docs.openclaw.ai/cli/

--- a/slack-bot-openclaw/openclaw.json.example
+++ b/slack-bot-openclaw/openclaw.json.example
@@ -1,0 +1,95 @@
+{
+  "auth": {
+    "profiles": {}
+  },
+  "models": {
+    "providers": {
+      "minimax": {
+        "baseUrl": "https://api.minimax.io/anthropic",
+        "apiKey": "sk-cp-YOUR-SUBSCRIPTION-KEY-HERE",
+        "api": "anthropic-messages",
+        "models": [
+          {
+            "id": "MiniMax-M2.7",
+            "name": "MiniMax M2.7",
+            "reasoning": true,
+            "input": ["text"],
+            "cost": { "input": 0.3, "output": 1.2, "cacheRead": 0.06, "cacheWrite": 0.375 },
+            "contextWindow": 204800,
+            "maxTokens": 131072
+          },
+          {
+            "id": "MiniMax-M3",
+            "name": "MiniMax M3",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "cost": { "input": 0.6, "output": 2.4, "cacheRead": 0.12, "cacheWrite": 0 },
+            "contextWindow": 1000000,
+            "maxTokens": 131072
+          }
+        ]
+      }
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": {
+        "primary": "minimax/MiniMax-M2.7",
+        "fallbacks": []
+      },
+      "models": {
+        "minimax/MiniMax-M2.7": {},
+        "minimax/MiniMax-M3": {}
+      },
+      "workspace": "~/.openclaw/workspace",
+      "contextTokens": 1048576,
+      "maxConcurrent": 1,
+      "subagents": { "maxConcurrent": 2 }
+    },
+    "list": [
+      {
+        "id": "main",
+        "name": "openclaw",
+        "identity": { "name": "your-bot-name" }
+      }
+    ]
+  },
+  "tools": {
+    "profile": "messaging",
+    "exec": { "host": "gateway", "security": "full", "ask": "off" }
+  },
+  "commands": {
+    "native": "auto",
+    "nativeSkills": "auto",
+    "restart": true,
+    "ownerAllowFrom": ["slack:YOUR_SLACK_USER_ID"]
+  },
+  "approvals": {
+    "exec": {
+      "enabled": true,
+      "mode": "targets",
+      "targets": [{ "channel": "slack", "to": "YOUR_SLACK_USER_ID" }]
+    }
+  },
+  "channels": {
+    "slack": {
+      "mode": "socket",
+      "webhookPath": "/slack/events",
+      "enabled": true,
+      "botToken": "xoxb-YOUR-BOT-TOKEN",
+      "appToken": "xapp-YOUR-APP-LEVEL-TOKEN",
+      "userTokenReadOnly": true,
+      "allowBots": false,
+      "groupPolicy": "open"
+    }
+  },
+  "gateway": {
+    "port": 18789,
+    "mode": "local",
+    "bind": "loopback",
+    "auth": {
+      "mode": "token",
+      "token": "GENERATE-A-RANDOM-TOKEN-HERE"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `slack-bot-minimax`: `lowyworkenv/slack-bot`(2026-07-27, MiniMax 1순위 폴백 로직 포함)을 그대로 복사한 독립 배포본
- `slack-bot-openclaw`: OpenClaw 프레임워크는 vendoring하지 않고, 그 위에서 이 Slack 봇을 재현하기 위한 설정 템플릿(`openclaw.json.example`, 시크릿 제거) + 설치/기동 가이드
- 기존 `slack-bot`(Claude 전용) 폴더는 그대로 유지 — 서로 다른 런타임(직접 spawn vs OpenClaw 게이트웨이)을 억지로 공통 서비스로 묶지 않고 의도적으로 폴더 분리(과거 lowyworkenv PR #416 코드 혼입 사고 재발 방지)

## Test plan
- [x] `slack-bot-minimax`: 복사된 36개 파일이 시크릿(.env/.secrets) 없이 git-tracked 파일만 포함되는지 확인
- [x] `slack-bot-openclaw/openclaw.json.example`: JSON 유효성 검증(`node -e "JSON.parse(...)"`)
- [ ] 실제 설치 후 각 변형이 독립적으로 기동되는지는 별도 검증 필요