### PR TITLE
sync(slack-bot): allowlist 명령어 등 lowyworkenv/slack-bot 최신화 반영

### DIFF
--- a/slack-bot/.env.example
+++ b/slack-bot/.env.example
@@ -9,6 +9,11 @@ SLACK_APP_TOKEN=xapp-your-app-level-token-here
 # Comma-separated channel IDs the bot listens to (optional — DMs always work)
 # SLACK_CHANNEL_IDS=C0123456789,C9876543210
 
+# Comma-separated Slack user IDs allowed to interact with the bot (whitelist).
+# Leave empty to allow every user (default). Find a user's ID via their
+# profile → More (...) → Copy member ID.
+# SLACK_ALLOWED_USERS=
+
 # ── Bot identity ──────────────────────────────────────────────────────────────
 # Display name used in Slack messages
 BOT_NAME=giipclaude Bot
@@ -39,3 +44,22 @@ WORKSPACE_DIR=/path/to/your/workspace
 # Example: REPOS_TO_CHECK=frontend:apps/web:main,backend:services/api:main
 # If not set, auto-detects git repos inside WORKSPACE_DIR
 # REPOS_TO_CHECK=
+
+# ── MiniMax fallback engine (optional) ───────────────────────────────────────
+# Token Plan Subscription Key (sk-cp-..., NOT a regular API key).
+# When set, MiniMax is tried first for Q&A / task execution / planning; the
+# Claude account pool (see claude-accounts.example.json) is only used as a
+# fallback when MiniMax fails or is rate-limited. Leave unset to skip MiniMax
+# entirely and always use Claude (see the startup log's "engine" line).
+# Get one at: platform.minimax.io → Console → Account / Token Plan
+# MINIMAX_API_KEY=sk-cp-your-subscription-key-here
+# MINIMAX_MODEL=MiniMax-M2.7
+# Cooldown (ms) before retrying MiniMax after hitting its limit (default 3600000 = 1h)
+# MINIMAX_COOLDOWN_MS=3600000
+
+# ── Claude account rotation (optional) ───────────────────────────────────────
+# To spread `claude` CLI calls across multiple subscription accounts
+# (weighted round-robin, with automatic cooldown on usage-limit errors),
+# copy claude-accounts.example.json to claude-accounts.json (git-ignored,
+# machine-local) and list your accounts there. With no file present, the
+# bot falls back to a single default account (current `claude` login).

--- a/slack-bot/claude-accounts.example.json
+++ b/slack-bot/claude-accounts.example.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "main",
+    "dir": "C:/claude-accounts/main",
+    "weight": 1,
+    "email": "yusuke.shikatani@bloomin.world"
+  }
+]

--- a/slack-bot/claude-accounts.js
+++ b/slack-bot/claude-accounts.js
@@ -1,0 +1,140 @@
+/**
+ * claude-accounts.js — 구독 계정 Weighted Round-Robin 라우터
+ *
+ * slack-bot이 spawn하는 모든 `claude` 호출의 계정(CLAUDE_CONFIG_DIR)을
+ * 플랜 가중치(weight) 비율대로 고르게 분산(Smooth WRR, nginx 방식)하고,
+ * 사용량 한도(usage limit)에 걸린 계정은 쿨다운으로 잠시 제외한다.
+ *
+ * 설정: slack-bot/claude-accounts.json (git-ignored, 머신 로컬)
+ *   [{ "name": "main", "dir": "C:/claude-accounts/main", "weight": 1, "email": "..." }, ...]
+ *   - dir  : 그 계정으로 `claude auth login` 해 둔 CLAUDE_CONFIG_DIR 경로
+ *   - weight: 플랜 비중 (Pro=1, Max5x=5, Max20x=20 식으로 상대값, 기본 1)
+ *   - email: (선택) 재인증 시 --email 로 전달
+ *
+ * 파일이 없거나 비어 있으면 → 기본 로그인(현재 계정) 1개로 동작(dir:null, CLAUDE_CONFIG_DIR 미설정).
+ * 계정 추가는 이 JSON에 항목만 넣으면 되고 코드 변경은 불필요하다.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const CONFIG_FILE = path.join(__dirname, 'claude-accounts.json');
+const DEFAULT_COOLDOWN_MS = 5 * 60 * 60 * 1000; // 5h — 구독 롤링 한도 리셋 근사치
+
+let accounts = null; // [{ name, dir, weight, email, current, cooldownUntil }]
+let cachedMtimeMs = -1;
+
+// JSON을 읽어 계정 목록을 만든다. mtime 기반 핫리로드 — 봇 재시작 없이 계정 추가 반영.
+function loadAccounts() {
+  let mtimeMs = 0;
+  let raw = [];
+  try {
+    mtimeMs = fs.statSync(CONFIG_FILE).mtimeMs;
+    if (accounts && mtimeMs === cachedMtimeMs) return accounts; // 변경 없음 → 캐시
+    raw = JSON.parse(fs.readFileSync(CONFIG_FILE, 'utf8'));
+  } catch {
+    // 파일 없음/파싱 실패 → 기본 계정 1개로 폴백. 최초 1회만 구성.
+    if (accounts && cachedMtimeMs === 0) return accounts;
+    mtimeMs = 0;
+    raw = [];
+  }
+
+  const list = (Array.isArray(raw) ? raw : [])
+    .filter(a => a && a.dir)
+    .map(a => ({
+      name: String(a.name || path.basename(String(a.dir))),
+      dir: String(a.dir),
+      weight: Math.max(1, Number(a.weight) || 1),
+      email: a.email ? String(a.email) : null,
+    }));
+
+  if (list.length === 0) {
+    // 기본 계정 — CLAUDE_CONFIG_DIR 미설정(현재 로그인 그대로 사용)
+    list.push({ name: 'default', dir: null, weight: 1, email: null });
+  }
+
+  // 이전 SWRR 상태(current)/쿨다운을 이름 기준으로 보존 (핫리로드 시 분산 연속성 유지)
+  const prev = new Map((accounts || []).map(a => [a.name, a]));
+  accounts = list.map(a => ({
+    ...a,
+    current: prev.get(a.name)?.current || 0,
+    cooldownUntil: prev.get(a.name)?.cooldownUntil || 0,
+  }));
+  cachedMtimeMs = mtimeMs;
+  return accounts;
+}
+
+function count() {
+  return loadAccounts().length;
+}
+
+// Smooth Weighted Round Robin (nginx 방식) + 쿨다운 제외.
+// weight 비율대로 고르게 섞어 반환. 전부 쿨다운이면 null.
+function pickAccount() {
+  const all = loadAccounts();
+  const now = Date.now();
+  const pool = all.filter(a => !a.cooldownUntil || a.cooldownUntil < now);
+  if (pool.length === 0) return null;
+
+  const total = pool.reduce((s, a) => s + a.weight, 0);
+  let best = null;
+  for (const a of pool) {
+    a.current += a.weight;
+    if (!best || a.current > best.current) best = a;
+  }
+  best.current -= total;
+  return best;
+}
+
+// 계정에 맞는 spawn env. dir이 없으면(기본 계정) 현재 env 그대로.
+function envFor(account) {
+  if (!account || !account.dir) return process.env;
+  return { ...process.env, CLAUDE_CONFIG_DIR: account.dir };
+}
+
+// "usage limit"/"rate limit" 같은 옛 문구뿐 아니라 실제 CLI가 내는
+// "You've hit your weekly limit · resets Jul 28, 6am (Asia/Tokyo)" 류(= "...limit"와
+// "reset(s)"가 근처에 같이 나오는 문구)도 잡는다. giip-759: 이 문구가 안 잡혀 계정
+// 로테이션이 전혀 발동하지 않고 task가 그냥 실패로 끝났다.
+const USAGE_LIMIT_RE = /usage limit|rate limit|weekly limit|session limit|too many requests|\b429\b|quota exceeded|\blimit\b[\s\S]{0,40}\breset/i;
+function isUsageLimit(text) {
+  return USAGE_LIMIT_RE.test(text || '');
+}
+
+// 메시지 중 "resets <Mon> <D>, <H>(am|pm)" 형태에서 리셋 시각을 추정해 쿨다운 ms를 구한다.
+// 파싱 실패 시: "weekly" 한도면 옛 5h 쿨다운으로는 매번 헛 재시도만 반복하므로 24h로,
+// 그 외는 기존 기본값(5h)으로 폴백한다.
+function parseResetCooldownMs(text) {
+  const m = /resets?\s+([A-Za-z]{3,9}\s+\d{1,2}),?\s*(\d{1,2})\s*(am|pm)/i.exec(text || '');
+  if (m) {
+    let hour = parseInt(m[2], 10) % 12;
+    if (/pm/i.test(m[3])) hour += 12;
+    const guess = new Date(`${m[1]} ${new Date().getFullYear()} ${String(hour).padStart(2, '0')}:00:00`);
+    if (!Number.isNaN(guess.getTime())) {
+      const ms = guess.getTime() - Date.now() + 5 * 60 * 1000; // +5분 여유
+      if (ms > 0) return ms;
+    }
+  }
+  return /weekly/i.test(text || '') ? 24 * 60 * 60 * 1000 : DEFAULT_COOLDOWN_MS;
+}
+
+// 한도 걸린 계정을 쿨다운 처리. text(= claude 출력)에서 실제 리셋 시각을 추정해 쓰고,
+// 못 구하면 기존처럼 기본 쿨다운(weekly 문구면 24h, 아니면 5h)으로 폴백한다.
+function noteUsageLimit(account, text = '') {
+  if (!account) return;
+  const a = loadAccounts().find(x => x.name === account.name);
+  if (a) {
+    const cooldownMs = parseResetCooldownMs(text);
+    a.cooldownUntil = Date.now() + cooldownMs;
+    console.log(`[claude-accounts] ${a.name} usage limit → cooldown ${Math.round(cooldownMs / 3600000)}h`);
+  }
+}
+
+module.exports = {
+  loadAccounts,
+  count,
+  pickAccount,
+  envFor,
+  isUsageLimit,
+  noteUsageLimit,
+  DEFAULT_COOLDOWN_MS,
+};

--- a/slack-bot/claude-cli.js
+++ b/slack-bot/claude-cli.js
@@ -1,40 +1,25 @@
-/**
- * claude-cli.js — child-process / spawn ヘルパーと claude CLI 呼び出し
- *
- * index.js から behavior-preserving に切り出したモジュール。
- * gitPullBeforeWork は spawnAsync に依存するためここに同居させ、
- * モジュール間依存を減らしている。
- */
+// claude-cli.js — claude CLI 呼び出し（非同期 spawn ラッパ + 認証 + callClaude）
+// index.js から behavior-preserving で切り出し（ロジック変更なし）。
 
 const { spawn } = require('child_process');
-const config = require('./config');
-const { BASE_DIR, PROJECTS_ROOT, getAgentDir } = config;
-
-// ── 作業前 git pull (非同期、git repo でない場合はスキップ) ─────────────────
-async function gitPullBeforeWork(workDir) {
-  const check = await spawnAsync('git', ['rev-parse', '--git-dir'], { cwd: workDir, timeout: 5000 });
-  if (check.status !== 0) {
-    return { ok: true, skipped: true, branch: '', stdout: '', stderr: '' };
-  }
-  const branchRes = await spawnAsync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: workDir, timeout: 10000 });
-  const branch = (branchRes.stdout || '').trim() || 'main';
-  const res = await spawnAsync('git', ['pull', '--rebase', 'origin', branch], { cwd: workDir, timeout: 60000 });
-  return {
-    ok: res.status === 0,
-    skipped: false,
-    branch,
-    stdout: (res.stdout || '').trim(),
-    stderr: (res.stderr || '').trim(),
-  };
-}
+const accounts = require('./claude-accounts');
+const minimax = require('./minimax-accounts');
+const { getAgentDir, BASE_DIR, PROJECTS_ROOT } = require('./config');
 
 // ── spawn → Promise 래퍼 (이벤트 루프 비차단) ────────────────────────────────
 function spawnAsync(cmd, args, opts = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn(cmd, args, {
       cwd: opts.cwd,
+      env: opts.env || process.env, // 계정 라우팅: CLAUDE_CONFIG_DIR 주입용
       windowsHide: opts.windowsHide !== false, // 기본 true; false 명시 시 브라우저 팝업 허용
     });
+    // opts.input 이 있으면 프롬프트를 argv 대신 stdin 으로 전달한다.
+    // (긴 프롬프트를 커맨드라인에 실으면 Windows 길이 한계로 spawn ENAMETOOLONG 발생)
+    if (opts.input != null && child.stdin) {
+      child.stdin.on('error', () => {}); // 자식이 먼저 종료하면 EPIPE — 무시
+      child.stdin.end(opts.input);
+    }
     const stdout = [], stderr = [];
     if (child.stdout) child.stdout.on('data', d => stdout.push(d));
     if (child.stderr) child.stderr.on('data', d => stderr.push(d));
@@ -58,21 +43,24 @@ function spawnAsync(cmd, args, opts = {}) {
   });
 }
 
-// ── Claude 인증 상태 확인 ──────────────────────────────────────────────────────
-async function isClaudeAuthed() {
+// ── Claude 인증 상태 확인 (계정별 env) ─────────────────────────────────────────
+async function isClaudeAuthed(env = process.env) {
   try {
-    const r = await spawnAsync('claude', ['auth', 'status'], { timeout: 10000 });
+    const r = await spawnAsync('claude', ['auth', 'status'], { timeout: 10000, env });
     return JSON.parse(r.stdout || '{}').loggedIn === true;
   } catch { return true; } // 확인 실패 시 인증됨으로 간주
 }
 
-// ── Claude 웹 재인증 (브라우저 팝업) ───────────────────────────────────────────
-async function reAuthClaude() {
-  console.log('[Auth] claude 인증 만료 감지 — 브라우저 인증 시작...');
+// ── Claude 웹 재인증 (브라우저 팝업, 계정별) ───────────────────────────────────
+async function reAuthClaude(account = null) {
+  const label = account?.name || 'default';
+  const email = account?.email || 'yusuke.shikatani@bloomin.world';
+  console.log(`[Auth] claude(${label}) 인증 만료 감지 — 브라우저 인증 시작...`);
   try {
-    const r = await spawnAsync('claude', ['auth', 'login', '--email', 'yusuke.shikatani@bloomin.world'], {
+    const r = await spawnAsync('claude', ['auth', 'login', '--email', email], {
       timeout: 5 * 60 * 1000,
       windowsHide: false, // 브라우저가 열릴 수 있도록
+      env: accounts.envFor(account),
     });
     const ok = r.status === 0;
     console.log(`[Auth] 재인증 ${ok ? '성공' : '실패'} (exit ${r.status})`);
@@ -86,38 +74,78 @@ async function reAuthClaude() {
 // ── claude CLI (비동기 — 이벤트 루프 비차단) ──────────────────────────────────
 async function callClaude(prompt, workDir = BASE_DIR) {
   const agentDir = getAgentDir(workDir);
-  for (let attempt = 0; attempt < 2; attempt++) {
-    let result;
-    try {
-      result = await spawnAsync('claude', [
-        '-p', prompt,
-        '--model', 'claude-opus-4-8',
-        '--add-dir', workDir,        // プロジェクトディレクトリ (サンドボックスに明示追加)
-        '--add-dir', agentDir,       // roles/rules/skills/workflows アクセス
-        '--add-dir', PROJECTS_ROOT,  // 全プロジェクト横断アクセス
-      ], {
-        cwd: workDir,
-        timeout: 20 * 60 * 1000, // 20分
-      });
-    } catch (err) {
-      throw err; // ETIMEDOUT 등
-    }
+  const baseArgs = [
+    '-p', // プロンプトは argv ではなく stdin で渡す（ENAMETOOLONG 回避）→ spawnAsync opts.input
+    // callClaude は Q&A（answerInChannel / handleDM）専用。ファイル変更は
+    // 管理タスク経路（tm.createTaskFile 等）でのみ行う。ここで書込系ツールを
+    // 禁止し、質問に誤分類された作業依頼がサブエージェント経由で番号未発給の
+    // ままファイルを作ってしまう事故を防ぐ。（variadic → 次フラグ --model で停止）
+    '--disallowedTools', 'Write', 'Edit', 'NotebookEdit',
+    // このbotはユーザー指示専用 → Q&A経路も権限プロンプト無しで全ツール素通し
+    // (スクリプト/DB/読取すべて実行可、権限punt廃止)。書込系(Write/Edit/NotebookEdit)
+    // だけは上のdisallowedToolsで無効のまま = 番号未発給のファイル作成事故だけ防ぐ。
+    '--dangerously-skip-permissions',
+    '--add-dir', workDir,        // プロジェクトディレクトリ (サンドボックスに明示追加)
+    '--add-dir', agentDir,       // roles/rules/skills/workflows アクセス
+    '--add-dir', PROJECTS_ROOT,  // 全プロジェクト横断アクセス
+  ];
+  // 우선순위(사용자 지정): MiniMax 먼저 시도 → 실패해야만 Claude 계정 풀로 폴백.
+  let mmExhausted = false;
+  const mm = minimax.resolve();
+  if (mm) {
+    console.log(`[Bot] MiniMax(${mm.model}) 로 실행(Q&A)`);
+    const result = await spawnAsync('claude', [...baseArgs, '--model', mm.model], {
+      cwd: workDir,
+      timeout: 20 * 60 * 1000,
+      env: minimax.envFor(mm),
+      input: prompt,
+    });
+    if (result.status === 0) return (result.stdout || '').trim();
+    const mmOut = `${result.stdout || ''}\n${result.stderr || ''}`;
+    if (minimax.isUsageLimit(mmOut)) minimax.noteUsageLimit();
+    mmExhausted = true;
+    console.log('[Bot] MiniMax 실패 → Claude 폴백으로 전환');
+  }
+
+  // 계정 라우팅: weight 비율대로 계정 선택 → 한도면 다음 계정, 인증 만료면 1회 재인증
+  const maxTries = accounts.count() + 1; // 계정 수 + 인증 재시도 여유분
+  let authRetried = false;
+  for (let attempt = 0; attempt < maxTries; attempt++) {
+    const acct = accounts.pickAccount();
+    if (!acct) break; // 전 계정 쿨다운
+    const env = accounts.envFor(acct);
+    const args = [...baseArgs, '--model', 'claude-opus-4-8'];
+
+    const result = await spawnAsync('claude', args, {
+      cwd: workDir,
+      timeout: 20 * 60 * 1000, // 20分
+      env,
+      input: prompt, // 프롬프트는 stdin 으로 (ENAMETOOLONG 회피)
+    }); // ETIMEDOUT 등은 그대로 throw
+
     if (result.status === 0) return (result.stdout || '').trim();
 
-    // exit 1 — 인증 만료 여부 확인 후 자동 재인증 (1회)
-    if (attempt === 0 && !(await isClaudeAuthed())) {
-      const ok = await reAuthClaude();
-      if (!ok) throw new Error('claude 인증 재시도 실패 — 터미널에서 `claude auth login` 실행 필요');
+    // 사용량 한도 → 해당 계정 쿨다운 후 다음 계정으로
+    // 한도 메시지("You've hit your weekly limit ...")는 stderr가 아니라 stdout에
+    // 찍히는 경우가 있어(giip-759) 두 스트림을 모두 확인한다.
+    const combinedOut = `${result.stdout || ''}\n${result.stderr || ''}`;
+    if (accounts.isUsageLimit(combinedOut)) {
+      accounts.noteUsageLimit(acct, combinedOut);
+      continue;
+    }
+    // 그 외 실패 — 인증 만료 여부 확인 후 자동 재인증 (계정별 1회)
+    if (!authRetried && !(await isClaudeAuthed(env))) {
+      authRetried = true;
+      const ok = await reAuthClaude(acct);
+      if (!ok) throw new Error(`claude(${acct.name}) 인증 재시도 실패 — CLAUDE_CONFIG_DIR=${acct.dir || 'default'} 로 \`claude auth login\` 실행 필요`);
       continue;
     }
     throw new Error(`claude exit ${result.status}: ${(result.stderr || '').slice(0, 200)}`);
   }
+
+  if (mmExhausted) throw new Error('claude 호출 실패 — MiniMax + Claude 전 계정/재시도 소진');
+
+  throw new Error('claude 호출 실패 — 모든 계정/재시도 소진');
 }
 
-module.exports = {
-  spawnAsync,
-  isClaudeAuthed,
-  reAuthClaude,
-  callClaude,
-  gitPullBeforeWork,
-};
+module.exports = { spawnAsync, isClaudeAuthed, reAuthClaude, callClaude };

--- a/slack-bot/config.js
+++ b/slack-bot/config.js
@@ -11,6 +11,8 @@ const path = require('path');
 // ── 設定 ─────────────────────────────────────────────────────────────────────
 const BOT_TOKEN = process.env.SLACK_BOT_TOKEN;
 const CHANNEL_IDS = (process.env.SLACK_CHANNEL_IDS || '').split(',').map(s => s.trim()).filter(Boolean);
+// SLACK_ALLOWED_USERS: Slack user ID whitelist (comma-separated). Empty = allow everyone.
+const ALLOWED_USERS = (process.env.SLACK_ALLOWED_USERS || '').split(',').map(s => s.trim()).filter(Boolean);
 const SLACK_APP_TOKEN = process.env.SLACK_APP_TOKEN;
 
 const BOT_NAME        = process.env.BOT_NAME || 'giipclaude Bot'; // Slack 표시용 봇 이름 (BOT_NAME 환경변수로 변경 가능)
@@ -29,6 +31,12 @@ const CHANNEL_PROJECT_FILE = path.join(__dirname, 'channel-project.json');
 let botUserId = null;
 function getBotUserId() { return botUserId; }
 function setBotUserId(id) { botUserId = id; }
+
+// selfBotId: bot-to-bot conversation support — used to filter out the bot's own
+// messages (by bot_id) so it doesn't reply to itself in an infinite loop.
+let selfBotId = null;
+function getSelfBotId() { return selfBotId; }
+function setSelfBotId(id) { selfBotId = id; }
 
 // ── プロジェクトの .agent ディレクトリを解決 ─────────────────────────────────
 // workDir 内に .agent があればそれを使い、なければ BASE_DIR/.agent にフォールバック
@@ -219,6 +227,7 @@ function deleteChannelProject(channelId) {
 module.exports = {
   BOT_TOKEN,
   CHANNEL_IDS,
+  ALLOWED_USERS,
   SLACK_APP_TOKEN,
   BOT_NAME,
   BASE_DIR,
@@ -229,6 +238,8 @@ module.exports = {
   BOT_THREADS_FILE,
   getBotUserId,
   setBotUserId,
+  getSelfBotId,
+  setSelfBotId,
   getAgentDir,
   parseProjectPrefix,
   resolveProjectCsn,

--- a/slack-bot/dashboard.js
+++ b/slack-bot/dashboard.js
@@ -1,0 +1,289 @@
+/**
+ * dashboard.js
+ * LOWY_ACTION_DASHBOARD.md 의 "slack-bot 요청 처리 현황" 섹션을 봇이 자동 갱신한다.
+ *
+ * 요구사항(사용자 지시):
+ *   - slack-bot 이 처리한 요청(태스크)을 Lowy 가 체크할 수 있게 체크리스트로 유지.
+ *     · 대기/진행(pending/running) → 미체크 `- [ ]`
+ *     · 최근 완료(completed)       → 체크 `- [x]` (검수 후 직접 해제/삭제)
+ *   - 상세 내용은 전부 GitHub 링크(클릭). 완료=PR URL, 대기=태스크 파일 blob(미추적이면 폴더).
+ *   - **이 파일은 온라인에서도 사용자가 수시로 수정하므로, 수정 전 반드시 최신본을 반영한다.**
+ *
+ * 안전 설계 (공유 작업트리에서 다른 세션/봇 작업을 절대 유실시키지 않음):
+ *   - 자동 섹션은 마커(<!-- SLACKBOT-TASKS:START/END -->) 사이만 교체 → 사용자의 수동 내용은 보존.
+ *   - 작업트리가 base 브랜치(master)에 있고 태스크가 점유(bot/task-*)하지 않을 때만 실행.
+ *     (태스크 실행 중에는 skip → 다음 완료 시점(항상 master 복귀)에서 갱신되어 결과적으로 일관.)
+ *   - **최신화는 stash 없이 `fetch` + `merge --ff-only` 로만.** tracked 미커밋 변경이 있으면
+ *     사전 가드(hasTrackedChanges)로 즉시 skip → 다른 세션의 작업을 stash 로 쓸어담지 않는다.
+ *     (`--autostash` 는 유실은 아니어도 남의 tracked 변경을 잠시 stash 로 옮기므로 쓰지 않음.)
+ *   - tasklist.json(런타임, gitignore)을 소스로 하고, 커밋 대상은 대시보드 파일 1개뿐.
+ *   - 예외를 절대 밖으로 던지지 않는다(봇 흐름을 막지 않음).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const tm = require('./task-manager');
+
+const BASE_DIR = path.join(__dirname, '..');
+const DASH_REL = 'LOWY_ACTION_DASHBOARD.md';
+const DASH_FILE = path.join(BASE_DIR, DASH_REL);
+const TASKS_DIR = path.join(BASE_DIR, '.agent', 'tasks');
+
+const MARK_START = '<!-- SLACKBOT-TASKS:START -->';
+const MARK_END = '<!-- SLACKBOT-TASKS:END -->';
+
+const MAX_COMPLETED = 12; // 최근 완료 표시 개수
+
+// 겹치는 갱신 호출을 직렬화(sync spawn 이라 실제 병렬은 없지만 중복 no-op 방지)
+let running = false;
+
+function git(args, opts = {}) {
+  return spawnSync('git', args, { cwd: BASE_DIR, encoding: 'utf8', windowsHide: true, ...opts });
+}
+
+function currentBranch() {
+  const r = git(['rev-parse', '--abbrev-ref', 'HEAD']);
+  return (r.stdout || '').trim() || 'master';
+}
+
+// tracked 미커밋 변경(스테이지/워킹)이 하나라도 있으면 true. untracked(??)는 무시.
+// 다른 세션/봇의 진행 중 작업을 stash 로 건드리지 않기 위한 사전 가드에 쓴다.
+function hasTrackedChanges() {
+  const r = git(['status', '--porcelain', '--untracked-files=no']);
+  return (r.stdout || '').trim().length > 0;
+}
+
+// origin/base 최신을 로컬 base 로 **fast-forward 로만** 반영한다.
+//  - stash/pop 을 절대 쓰지 않는다 → 다른 세션의 tracked 미커밋 작업을 sweep 하지 않음.
+//  - 로컬이 앞서(diverged) 있거나, ff 가 로컬 미커밋을 덮어쓸 상황이면 git 이 스스로 거부 → skip.
+//    (덮어쓰기 대신 "안 함"을 택함 = 데이터 안전 최우선.)
+// 반환: { ok:true } | { ok:false, reason }
+function fastForwardBase(base) {
+  const f = git(['fetch', 'origin', base]);
+  if (f.status !== 0) return { ok: false, reason: 'fetch-failed' };
+  // 이미 최신이면 no-op 성공. 로컬 미커밋이 걸리거나 non-ff 면 status!=0 로 거부됨.
+  const m = git(['merge', '--ff-only', `origin/${base}`]);
+  if (m.status !== 0) return { ok: false, reason: 'not-fast-forwardable' };
+  return { ok: true };
+}
+
+// origin remote → https://github.com/Owner/Repo
+function repoWebBase() {
+  const r = git(['remote', 'get-url', 'origin']);
+  const remote = (r.stdout || '').trim();
+  return remote
+    .replace(/^git@github\.com:/, 'https://github.com/')
+    .replace(/^git@ssh\.github\.com:/, 'https://github.com/')
+    .replace(/\.git$/, '');
+}
+
+function isTracked(relPath) {
+  const r = git(['ls-files', '--error-unmatch', relPath]);
+  return r.status === 0;
+}
+
+// 태스크 파일 GitHub 링크. 추적 중이면 blob URL, 아니면(아직 master 미반영) 태스크 폴더 링크.
+function taskLink(taskId, branch, web) {
+  const candidates = [
+    path.join(TASKS_DIR, `${taskId}.md`),
+    path.join(TASKS_DIR, 'done', `${taskId}.md`),
+    path.join(TASKS_DIR, 'cancel', `${taskId}.md`),
+  ];
+  const found = candidates.find(f => fs.existsSync(f));
+  if (found) {
+    const rel = path.relative(BASE_DIR, found).replace(/\\/g, '/');
+    if (isTracked(rel)) return `${web}/blob/${branch}/${rel}`;
+  }
+  // 미추적이거나 파일 없음 → 태스크 폴더로 폴백(항상 유효)
+  return `${web}/tree/${branch}/.agent/tasks`;
+}
+
+function esc(s) {
+  // 마크다운/링크 라벨 깨짐 방지: 개행 제거, 링크문자 완화, 길이 제한
+  return String(s || '')
+    .replace(/[\r\n]+/g, ' ')
+    .replace(/\|/g, '\\|')
+    .replace(/\[/g, '(')
+    .replace(/\]/g, ')')
+    .trim()
+    .slice(0, 80);
+}
+
+function fmtDate(iso) {
+  if (!iso) return '';
+  const d = String(iso).slice(0, 10);
+  return d;
+}
+
+const EMOJI = { pending: '🕐', running: '⚙️' };
+
+// tasklist 배열 → 자동 섹션 마크다운 문자열(마커 포함)
+function buildSection(list, { branch, web, now }) {
+  const active = list
+    .filter(t => t.status === 'pending' || t.status === 'running')
+    .sort((a, b) => String(b.createdAt || '').localeCompare(String(a.createdAt || '')));
+
+  const completed = list
+    .filter(t => t.status === 'completed')
+    .sort((a, b) => String(b.completedAt || '').localeCompare(String(a.completedAt || '')))
+    .slice(0, MAX_COMPLETED);
+
+  const lines = [];
+  lines.push(MARK_START);
+  lines.push('## 🤖 slack-bot 요청 처리 현황');
+  lines.push('');
+  lines.push(`> 봇 자동 갱신: ${now} · 이 블록은 봇이 관리하므로 직접 수정하지 마세요(마커 밖은 자유).`);
+  lines.push('> 상세는 각 항목의 GitHub 링크(클릭). 완료 항목은 검수 후 체크를 해제하거나 삭제하세요.');
+  lines.push('');
+
+  lines.push('### ✅ 확인 필요 — 대기/진행 중');
+  if (active.length === 0) {
+    lines.push('- _(대기/진행 중인 요청 없음)_');
+  } else {
+    for (const t of active) {
+      const emoji = EMOJI[t.status] || '🕐';
+      const title = esc(t.title || t.summary || t.taskId);
+      const link = taskLink(t.taskId, branch, web);
+      lines.push(`- [ ] ${emoji} \`${t.taskId}\` ${title} — [상세](${link})`);
+    }
+  }
+  lines.push('');
+
+  lines.push(`### 🗂️ 최근 완료 — 검수 후 체크 (최대 ${MAX_COMPLETED}건)`);
+  if (completed.length === 0) {
+    lines.push('- _(완료된 요청 없음)_');
+  } else {
+    for (const t of completed) {
+      const title = esc(t.title || t.summary || t.taskId);
+      const link = t.resultUrl || taskLink(t.taskId, branch, web);
+      const date = fmtDate(t.completedAt);
+      const dateStr = date ? ` _(${date})_` : '';
+      lines.push(`- [x] \`${t.taskId}\` ${title}${dateStr} — [결과](${link})`);
+    }
+  }
+  lines.push('');
+  lines.push(`전체 태스크 이력: [\`.agent/tasks/\`](${web}/tree/${branch}/.agent/tasks)`);
+  lines.push(MARK_END);
+  return lines.join('\n');
+}
+
+// 파일 내용에 섹션을 삽입/교체한다. 마커가 있으면 그 사이만, 없으면 상단 첫 `---` 뒤에 삽입.
+function applySection(content, section) {
+  const s = content.indexOf(MARK_START);
+  const e = content.indexOf(MARK_END);
+  if (s >= 0 && e > s) {
+    const before = content.slice(0, s);
+    const after = content.slice(e + MARK_END.length);
+    return before + section + after;
+  }
+  // 마커 없음 → 최초 삽입: 상단 인트로(첫 '---') 뒤에 넣는다.
+  const hr = content.indexOf('\n---\n');
+  if (hr >= 0) {
+    const cut = hr + '\n---\n'.length;
+    return content.slice(0, cut) + '\n' + section + '\n' + content.slice(cut);
+  }
+  // '---' 도 없으면 상단에 프리펜드
+  return section + '\n\n' + content;
+}
+
+// tasklist 를 읽어 대시보드 파일을 갱신(디스크에만 write). git 은 건드리지 않는다.
+// 반환: { changed, path }
+function writeDashboardFile({ branch, web, now } = {}) {
+  branch = branch || currentBranch();
+  web = web || repoWebBase();
+  now = now || new Date().toISOString();
+
+  const list = tm.getTasklistByStatus(null) || [];
+  const section = buildSection(list, { branch, web, now });
+
+  let content = '';
+  try { content = fs.readFileSync(DASH_FILE, 'utf8'); } catch { content = '# Lowy 확인 필요 안건 대시보드\n\n---\n'; }
+
+  const next = applySection(content, section);
+  if (next === content) return { changed: false, path: DASH_FILE };
+  fs.writeFileSync(DASH_FILE, next);
+  return { changed: true, path: DASH_FILE };
+}
+
+// ── 메인: pull → 섹션 갱신 → 커밋 → push. base 브랜치에서만, 예외를 삼킨다. ──────
+// opts.push=false 면 디스크 갱신만(테스트/시드용).
+function refreshDashboard(reason = '', opts = {}) {
+  const doPush = opts.push !== false;
+  if (running) return { skipped: 'already-running' };
+  running = true;
+  try {
+    // 1) 작업트리가 base 브랜치인지 확인(태스크가 bot/task-* 로 점유 중이면 skip)
+    const base = tm.getBaseBranch(BASE_DIR);
+    const cur = currentBranch();
+    if (doPush && cur !== base) {
+      return { skipped: `not-on-base(${cur})` };
+    }
+
+    // 2) **수정 전 반드시 pull** — 온라인에서 사용자가 수정한 최신본을 먼저 반영
+    if (doPush) {
+      // 사전 가드: tracked 미커밋 변경이 있으면(다른 세션/봇이 작업 중일 수 있음) 이번 회차 skip.
+      //   → 어차피 뒤의 ff-only 도 거부되지만, 여기서 먼저 빠져 남의 작업 근처에서 아무 git 도 안 만짐.
+      if (hasTrackedChanges()) {
+        return { skipped: 'tree-dirty(tracked)' };
+      }
+      // **수정 전 반드시 최신 반영** — 단, stash 없이 fast-forward 로만(남의 작업 안전).
+      const sync = fastForwardBase(base);
+      if (!sync.ok) {
+        console.error(`[Dashboard] base 최신화 skip(${sync.reason}) — 다음 이벤트에서 재시도`);
+        return { skipped: sync.reason };
+      }
+    }
+
+    // 3) 섹션 재생성(디스크)
+    const web = repoWebBase();
+    const { changed } = writeDashboardFile({ branch: base, web });
+    if (!changed) return { skipped: 'no-change' };
+    if (!doPush) return { ok: true, pushed: false };
+
+    // 4) 대시보드 파일만 커밋
+    git(['add', DASH_REL]);
+    const msg = `docs(dashboard): slack-bot 요청 처리 현황 자동 갱신${reason ? ` (${reason})` : ''}\n\nAuto-updated by giipclaude Bot`;
+    const commit = git(['commit', '-m', msg]);
+    if (commit.status !== 0 && !/nothing to commit/.test(commit.stdout || '')) {
+      console.error('[Dashboard] git commit 실패:', (commit.stderr || '').trim().slice(0, 200));
+      return { error: 'commit-failed' };
+    }
+
+    // 5) push (원격이 앞서 거부되면 우리 대시보드 단일 커밋만 rebase 로 얹어 1회 재시도)
+    //   - autostash 미사용. 이 시점 작업트리는 위 사전 가드로 clean 이 보장되므로
+    //     rebase 가 남의 미커밋을 건드릴 일이 없다(더러웠다면 애초에 여기 도달 못 함).
+    let push = git(['push', 'origin', base]);
+    if (push.status !== 0) {
+      git(['fetch', 'origin', base]);
+      const rb = git(['rebase', `origin/${base}`]);
+      if (rb.status !== 0) {
+        git(['rebase', '--abort']); // 충돌 시 우리 커밋은 로컬 보존(유실 없음)
+        console.error('[Dashboard] push 재시도 rebase 실패 → 이번 회차 skip(커밋은 로컬 보존)');
+        return { skipped: 'push-retry-rebase-failed' };
+      }
+      push = git(['push', 'origin', base]);
+    }
+    if (push.status !== 0) {
+      console.error('[Dashboard] git push 실패:', (push.stderr || '').trim().slice(0, 200));
+      return { error: 'push-failed' };
+    }
+    console.log(`[Dashboard] 갱신 완료${reason ? ` (${reason})` : ''} → origin/${base}`);
+    return { ok: true, pushed: true };
+  } catch (e) {
+    console.error('[Dashboard] refreshDashboard 예외:', e.message);
+    return { error: e.message };
+  } finally {
+    running = false;
+  }
+}
+
+module.exports = { refreshDashboard, writeDashboardFile, buildSection, applySection };
+
+// CLI: `node dashboard.js`         → pull+갱신+push (base 브랜치에서)
+//      `node dashboard.js --local` → 디스크만 갱신(테스트/시드용, git 미조작)
+if (require.main === module) {
+  const local = process.argv.includes('--local');
+  const res = refreshDashboard('manual', { push: !local });
+  console.log('[Dashboard]', JSON.stringify(res));
+}

--- a/slack-bot/giip-api.js
+++ b/slack-bot/giip-api.js
@@ -91,7 +91,9 @@ async function issueList(account, { status = '', csn = '' } = {}) {
   return res.body?.issues || [];
 }
 
-async function issueCreate(account, { title, content, status = 'IN_PROGRESS', csn, target_lssn = null, agent_workflow = null }) {
+// 생성 기본값은 PENDING(대기열). '생성'은 착수가 아니라 등록이므로, 무인 처리기(:20/:40, PENDING/READY만 픽업)가
+// 집을 수 있는 상태로 둔다. 착수(IN_PROGRESS)가 필요한 호출자(task 자동연동 등)는 status 를 명시적으로 넘긴다.
+async function issueCreate(account, { title, content, status = 'PENDING', csn, target_lssn = null, agent_workflow = null }) {
   const res = await issueApi(account, 'POST', {
     body: { title, content, status, csn: csn ?? account.csn, target_lssn, agent_workflow },
   });
@@ -130,6 +132,45 @@ async function issueComment(account, isn, content) {
   return res.body;
 }
 
+/**
+ * GET /giipIssueComments?isn= — 이슈의 모든 코멘트를 시간순(regdate ASC)으로 반환한다.
+ * giip issue 재처리 시 로컬 태스크 파일이 done/ 이동·타 클론 처리 등으로 없더라도
+ * DB(SSOT)에서 전체 코멘트 이력을 복원해 처리 맥락으로 쓰기 위한 조회 경로.
+ * 반환: [{ cSn, isn, content, author, issuetype, regdate }, ...]
+ */
+async function issueComments(account, isn) {
+  const base = account.apiBase || accounts.apiBase();
+  let ak = (await getAK(account)).ak;
+  const doGet = (token) =>
+    request('GET', `${base}/giipIssueComments?isn=${encodeURIComponent(isn)}`, {
+      headers: { 'x-api-key': token, 'Content-Type': 'application/json' },
+    });
+  let res = await doGet(ak);
+  if (res.status === 401) { ak = (await getAK(account, { force: true })).ak; res = await doGet(ak); }
+  if (res.status !== 200) throw new Error(`issueComments 실패: ${res.body?.error || res.status}`);
+  return res.body?.comments || [];
+}
+
+/**
+ * 봇 유저(SK→usn)를 @csn 의 멤버로 giip DB(tUserPerCorp)에 멱등 등록한다.
+ * → `giip project set <p> <csn>` 이 로컬 map 저장뿐 아니라 DB 멤버십까지 완결하게 해,
+ *   pApiGiipIssuePutbyAK 의 멤버십 게이트가 홈 CSN(47)으로 클램프하는 문제를 자동 해소한다.
+ * SP: pApiUserPerCorpGrantBotbySk (권한 게이트: 봇 계정 또는 기존 tCorpUserRel 멤버만, 대상=자기 자신).
+ * 호출: giipApiSk2  text="UserPerCorpGrantBot"  jsondata={"csn":<n>}  (ISN-161 auto-append 로 전달).
+ * @returns {{ ok:boolean, rstVal:number|null, already:boolean, msg:string, raw:any }}
+ */
+async function grantBotCsn(account, csn) {
+  const n = Number(csn);
+  if (!Number.isInteger(n)) throw new Error('csn 은 정수여야 합니다.');
+  const raw = await apiCall(account, 'UserPerCorpGrantBot', { csn: n });
+  // giipApiSk2 응답: { data: [ { RstVal, Proc_MSG, usn, csn, already } ], debug } 또는 { error }
+  const row = raw && Array.isArray(raw.data) ? raw.data[0] : null;
+  const rstVal = row && row.RstVal != null ? Number(row.RstVal) : null;
+  const already = !!(row && (row.already === true || row.already === 1));
+  const msg = (row && row.Proc_MSG) || (raw && raw.error) || (raw && raw.message) || '';
+  return { ok: rstVal === 200, rstVal, already, msg, raw };
+}
+
 /** 범용: 임의 giip API 를 giipApi 디스패처로 호출(text=Verb). */
 async function apiCall(account, verb, jsondata = null) {
   const base = account.apiBase || accounts.apiBase();
@@ -150,6 +191,8 @@ module.exports = {
   issueCreate,
   issueUpdate,
   issueComment,
+  issueComments,
   apiCall,
+  grantBotCsn,
   _akCache: akCache,
 };

--- a/slack-bot/giip-commands.js
+++ b/slack-bot/giip-commands.js
@@ -12,6 +12,17 @@ function code(obj, max = 1800) {
   return '```\n' + JSON.stringify(obj, null, 2).slice(0, max) + '\n```';
 }
 
+// Slack이 이메일/URL 같은 토큰을 자동으로 `<mailto:x|y>`/`<url|label>` 형태로 링크화해서
+// 보내는 경우가 있다. 이걸 안 벗기면 login_id 등에 꺾쇠·파이프가 그대로 저장된다.
+function stripSlackAutolink(s) {
+  if (!s) return s;
+  return String(s)
+    .replace(/^<mailto:([^|>]+)\|[^>]*>$/i, '$1')
+    .replace(/^<mailto:([^>]+)>$/i, '$1')
+    .replace(/^<([^|>]+)\|[^>]*>$/, '$1')
+    .replace(/^<([^>]+)>$/, '$1');
+}
+
 /**
  * @returns {Promise<{handled:boolean, text?:string}>}
  */
@@ -27,8 +38,8 @@ async function handleGiipCommand(rawText, channelId) {
     const setM = rest.match(/^set(-default)?\s+(\S+)\s+(\S+)\s*(\d+)?/i);
     if (setM) {
       const asDefault = !!setM[1];
-      const login_id = setM[2];
-      const sk = setM[3];
+      const login_id = stripSlackAutolink(setM[2]);
+      const sk = stripSlackAutolink(setM[3]);
       const csn = setM[4] || null;
       accounts.setAccount(asDefault ? null : channelId, { login_id, sk, csn }, asDefault);
       return {
@@ -62,9 +73,30 @@ async function handleGiipCommand(rawText, channelId) {
         const sm = pargs.match(/^(\S+)\s+(-?\d+)$/);
         if (!sm) return { handled: true, text: USAGE };
         const { name, csn } = config.setProjectCsn(sm[1], sm[2]);
+        // ── DB 멤버십 자동 부여 ──
+        // map 저장만으로는 pApiGiipIssuePutbyAK 의 멤버십 게이트가 홈 CSN(47)으로 클램프한다.
+        // 봇 SK 로 pApiUserPerCorpGrantBotbySk 를 호출해 tUserPerCorp 에 (봇usn, csn) 을 멱등 부여하면
+        // 그 즉시 그 csn 으로 라우팅된다(수동 시드/재배포 불필요). 계정 미설정·실패는 비치명(map 은 저장됨).
+        let grantLine = '';
+        const acctForGrant = accounts.resolve(channelId);
+        if (Number(csn) === 47) {
+          grantLine = '\n(홈 CSN 47 은 항상 허용되므로 멤버십 부여 불필요)';
+        } else if (!acctForGrant) {
+          grantLine = '\n⚠️ giip 계정 미설정이라 DB 멤버십은 부여하지 못했습니다. `giip account set ...` 후 다시 `set` 하세요.';
+        } else {
+          try {
+            const g = await giip.grantBotCsn(acctForGrant, csn);
+            if (g.ok) grantLine = g.already
+              ? `\n🟢 DB 멤버십 이미 존재 (tUserPerCorp usn↔csn ${csn}).`
+              : `\n🟢 DB 멤버십 부여 완료 (tUserPerCorp += csn ${csn}). 다음 등록부터 바로 반영.`;
+            else grantLine = `\n⚠️ DB 멤버십 부여 실패(RstVal=${g.rstVal ?? '?'}): ${g.msg || '알 수 없음'}. map 은 저장됨.`;
+          } catch (e) {
+            grantLine = `\n⚠️ DB 멤버십 부여 호출 오류: ${e.message}. map 은 저장됨.`;
+          }
+        }
         return {
           handled: true,
-          text: `✅ 프로젝트 CSN 매핑 저장: \`${name}\` → csn ${csn}\n이제 \`${name} issue 등록 <내용>\` 은 csn ${csn} 로 등록됩니다(봇 재시작 불필요).`,
+          text: `✅ 프로젝트 CSN 매핑 저장: \`${name}\` → csn ${csn}\n이제 \`${name} issue 등록 <내용>\` 은 csn ${csn} 로 등록됩니다(봇 재시작 불필요).${grantLine}`,
         };
       }
       if (action === 'del' || action === 'delete' || action === 'rm' || action === 'remove') {
@@ -137,6 +169,26 @@ async function handleGiipCommand(rawText, channelId) {
 
   // ── giip issue ... ──
   if (sub === 'issue') {
+    // 자연어 의뢰 감지: `giip issue #604 <자연어 작업 지시>` 형식(에이전트 보고문을 그대로 복붙).
+    //   - 번호만 → get(상세 조회)
+    //   - 번호 뒤에 지시문이 붙으면 → 커맨드로 소비하지 않고(handled:false) 태스크 라우팅으로 넘겨
+    //     에이전트가 "이슈 내용 확인 → 작업 → 코멘트"까지 수행하게 한다.
+    //   (기존엔 '#604 …' 가 알 수 없는 action → list 로 떨어져 rest 전체가 status 필터가 되고,
+    //    존재하지 않는 status 라 목록 0건 → '(이슈 없음)' 오답을 냈다. rule 39/40.)
+    const leadNum = rest.match(/^#?(\d+)\b\s*([\s\S]*)$/);
+    if (leadNum) {
+      const after = (leadNum[2] || '').trim();
+      if (after) return { handled: false }; // 자연어 지시 → 태스크 경로(handleChannelMention 이 이어서 처리)
+      try { const i = await giip.issueGet(acct, Number(leadNum[1])); return { handled: true, text: code(i, 1500) }; }
+      catch (e) { return { handled: true, text: `❌ ${e.message}` }; }
+    }
+    // `giip issue 등록 <내용>` → giipprj 등록 경로와 '동일하게' 위임(handled:false).
+    //   등록/登録/register 는 list status 필터가 아니라 '등록 동사'다. 여기서 소비하면
+    //   im 의 (\w+) 가 한글 '등록'을 못 잡아 action=list, arg='등록 …' 이 되고 status 0건 →
+    //   '(이슈 없음)' 오답을 냈다(rule 39/40). handleChannelMention 의 issueTrigger 가 이어받아
+    //   분석→작업지시서→READY 등록한다. 구분자(공백/콜론/말미) 필수로 '등록됐어?' 질문 오폭 방지
+    //   (JS \b 는 ASCII 전용이라 한글 경계 미검출 → 명시 구분자 요구).
+    if (/^(?:등록|登録|register)(?:\s+|\s*[:：]\s*|$)/i.test(rest)) return { handled: false };
     const im = rest.match(/^(\w+)?\s*([\s\S]*)$/);
     const action = (im && im[1] ? im[1] : 'list').toLowerCase();
     const arg = im ? (im[2] || '').trim() : '';

--- a/slack-bot/giip-task.js
+++ b/slack-bot/giip-task.js
@@ -7,23 +7,51 @@
 const accounts = require('./giip-accounts');
 const giip = require('./giip-api');
 
-/** 태스크 생성 시: 연결되어 있으면 issue 생성(IN_PROGRESS) → isn. 아니면 null(로컬 폴백).
- *  csn: 프로젝트명 기반 매핑(config.resolveProjectCsn) 결과. null 이면 account 기본 csn 로 폴백. */
+/** 타임아웃/네트워크 등 일시적 오류인지 판단(1회 재시도 대상). 권한/데이터 오류는 재시도해도 무의미하므로 제외. */
+function isRetryableIssueError(e) {
+  const msg = String((e && e.message) || e || '');
+  const code = e && e.code;
+  if (['ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'EAI_AGAIN', 'ENOTFOUND'].includes(code)) return true;
+  return /timeout|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN|ENOTFOUND|socket hang up/i.test(msg);
+}
+
+/**
+ * 태스크 생성(=분석) 시: 연결되어 있으면 issue 생성(PENDING) → isn. 아니면 null(로컬 폴백).
+ * 상태는 PENDING 으로 만든다 — 분석만 끝났을 뿐 아직 실행 전(go 대기)이므로. IN_PROGRESS 전이는
+ * 실제 실행 시작(handlers.startTaskExecution → maybeFinish(...,'IN_PROGRESS')) 시점에만 한다.
+ *   (과거: 여기서 IN_PROGRESS 로 만들어 "아무것도 안 움직이는데 IN_PROGRESS·go 요구" 모순 발생)
+ * csn: 프로젝트명 기준 csn(config.resolveProjectCsn). null 이면 issueCreate 가 account.csn 으로 폴백.
+ * 반환: { isn, error }. acct 미연동(csn/계정 미설정)은 정상 경로라 error:null 로 조용히 로컬 폴백.
+ * API 호출이 실제로 실패한 경우만 error 에 사유를 담아 호출측이 "미설정"과 "일시적 오류"를 구분해
+ * 사용자에게 알릴 수 있게 한다(타임아웃 등 일시적 오류로 오인된 채 미설정처럼 보이던 문제 대응).
+ * 일시적 오류(타임아웃/네트워크)는 1회만 재시도 후 그래도 실패하면 포기(무인 봇이 무한 대기하지 않도록).
+ */
 async function maybeCreateIssue(channelId, title, content, csn = null) {
   const acct = accounts.resolve(channelId);
-  if (!acct) return null;
-  try {
-    const r = await giip.issueCreate(acct, {
-      title: (title || '(무제)').slice(0, 200),
-      content: (content || title || '').slice(0, 8000),
-      status: 'IN_PROGRESS',
-      csn,
-    });
-    return r && r.isn ? Number(r.isn) : null;
-  } catch (e) {
-    console.error('[giip-task] issue 생성 실패(로컬 폴백):', e.message);
-    return null;
+  if (!acct) return { isn: null, error: null };
+  const body = {
+    title: (title || '(무제)').slice(0, 200),
+    content: (content || title || '').slice(0, 8000),
+    status: 'PENDING',
+    csn,
+  };
+  let lastErr = null;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const r = await giip.issueCreate(acct, body);
+      return { isn: r && r.isn ? Number(r.isn) : null, error: null };
+    } catch (e) {
+      lastErr = e;
+      if (attempt === 0 && isRetryableIssueError(e)) {
+        console.error(`[giip-task] issue 생성 실패(재시도 1회): ${e.message}`);
+        await new Promise((resolve) => setTimeout(resolve, 1500));
+        continue;
+      }
+      break;
+    }
   }
+  console.error('[giip-task] issue 생성 실패(로컬 폴백):', lastErr.message);
+  return { isn: null, error: lastErr.message };
 }
 
 /** 완료/에러 시: 코멘트 + 상태전이(best-effort, 실패해도 무시). */
@@ -37,5 +65,65 @@ async function maybeFinish(channelId, isn, status, comment) {
   catch (e) { console.error('[giip-task] status 실패:', e.message); }
 }
 
-module.exports = { maybeCreateIssue, maybeFinish };
+/**
+ * 코멘트만 남긴다(상태 전이 없음, best-effort). 작업트리 점유 대기 관계 등
+ * "상태는 그대로 두고 사실만 기록"하는 용도. 실패해도 봇 흐름을 막지 않는다.
+ */
+async function maybeComment(channelId, isn, comment) {
+  if (!isn || !comment) return;
+  const acct = accounts.resolve(channelId);
+  if (!acct) return;
+  try { await giip.issueComment(acct, isn, comment); }
+  catch (e) { console.error('[giip-task] comment(note) 실패:', e.message); }
+}
 
+/** 길이 제한(태스크 파일·프롬프트 폭주 방지). */
+function clip(s, max) {
+  const str = String(s == null ? '' : s);
+  return str.length > max ? `${str.slice(0, max)}\n…(${str.length - max}자 생략)` : str;
+}
+
+/** 이슈 본문 + 코멘트 배열을 사람이·서브에이전트가 읽는 히스토리 다이제스트(마크다운)로 만든다. */
+function formatIssueHistory(isn, issue, comments) {
+  const title  = (issue && (issue.title  || issue.Title))  || '(제목 없음)';
+  const status = (issue && (issue.status || issue.Status)) || '';
+  const body   = (issue && (issue.content || issue.Content)) || '';
+  const lines = [`### giip issue #${isn}${status ? ` [${status}]` : ''}: ${title}`];
+  if (body) lines.push('', '**본문:**', clip(body, 4000));
+  const list = Array.isArray(comments) ? comments : [];
+  if (list.length) {
+    lines.push('', `**코멘트 이력 (${list.length}건, 시간순):**`);
+    list.forEach((c, i) => {
+      const when = c.regdate  || c.Regdate  || '';
+      const who  = c.author   || c.Author   || '?';
+      const type = c.issuetype || c.Issuetype || '';
+      lines.push('', `[${i + 1}] ${when} · ${who}${type ? ` · ${type}` : ''}`,
+        clip(c.content || c.Content || '', 1500));
+    });
+  } else {
+    lines.push('', '(코멘트 없음)');
+  }
+  return clip(lines.join('\n'), 12000); // 전체 상한(대량 코멘트 이슈 대비)
+}
+
+/**
+ * giip issue 의 본문 + 모든 코멘트를 DB(SSOT)에서 가져와 히스토리 다이제스트를 만든다.
+ * 로컬 태스크 파일이 done/ 으로 이동됐거나 타 클론에서 처리돼 없어도, 재처리 요청은
+ * 코멘트 이력을 모두 읽고 맥락을 이어가야 하므로 DB 에서 전체를 복원한다.
+ * best-effort: 계정 미연결/API 실패 시 null(호출자는 기존 폴백 유지).
+ * 반환: { issue, comments, digest } | null
+ */
+async function fetchIssueHistory(channelId, isn) {
+  if (!isn) return null;
+  const acct = accounts.resolve(channelId);
+  if (!acct) return null;
+  let issue = null, comments = [];
+  try { issue = await giip.issueGet(acct, isn); }
+  catch (e) { console.error('[giip-task] issueGet(history) 실패:', e.message); }
+  try { comments = await giip.issueComments(acct, isn); }
+  catch (e) { console.error('[giip-task] issueComments(history) 실패:', e.message); }
+  if (!issue && (!comments || comments.length === 0)) return null;
+  return { issue, comments, digest: formatIssueHistory(isn, issue, comments) };
+}
+
+module.exports = { maybeCreateIssue, maybeFinish, maybeComment, fetchIssueHistory, formatIssueHistory };

--- a/slack-bot/github-issues.js
+++ b/slack-bot/github-issues.js
@@ -7,7 +7,7 @@ const CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
 
 async function fetchFromGitHub() {
   const token = process.env.GITHUB_TOKEN;
-  const repo = process.env.GITHUB_REPO; // owner/repo format, e.g. 'your-org/your-repo'
+  const repo = process.env.GITHUB_REPO; // e.g. 'LowyShin/smartorder-works'
 
   if (!token || !repo) return null;
 
@@ -17,7 +17,7 @@ async function fetchFromGitHub() {
       path: `/repos/${repo}/issues?state=open&per_page=30&sort=updated`,
       headers: {
         'Authorization': `Bearer ${token}`,
-        'User-Agent': 'giip-dev-agent-slack-bot/1.0',
+        'User-Agent': 'smartorder-slack-bot/1.0',
         'Accept': 'application/vnd.github.v3+json',
       },
     }, (res) => {

--- a/slack-bot/handlers.js
+++ b/slack-bot/handlers.js
@@ -1,37 +1,78 @@
-/**
- * handlers.js — Slack メッセージ処理ハンドラ群
- *
- * index.js から behavior-preserving に切り出したモジュール。
- * BOT_USER_ID 参照は config.getBotUserId() に置換済み（挙動は同一）。
- * インラインの require("./giip-commands") / require("./giip-task") は原文どおり維持。
- */
+// handlers.js — メッセージ/DM/チャンネル mention/タスク実行ハンドラ群
+// index.js から behavior-preserving で切り出し（ロジック変更なし）。
+// 内部の giip フック (./giip-commands, ./giip-task) は元コード通りインライン require のまま。
 
-const fs = require("fs");
-const path = require("path");
-const { spawnSync } = require("child_process");
-const config = require("./config");
-const {
-  BOT_NAME, BASE_DIR, AGENT_DIR, TASK_STATE_FILE, HISTORY_FILE,
-  getAgentDir, parseProjectPrefix,
-} = config;
-const { loadJSON, saveJSON, isBotEngagedThread } = require("./state");
-const {
-  postMessage, postLong, fetchThreadTranscript, fetchReferencedThreads,
-} = require("./slack-api");
-const { checkAllRepoStatus, isPushFailureNotice } = require("./repo-status");
-const { callClaude, gitPullBeforeWork } = require("./claude-cli");
-const { isGoCmd, isCancelCmd, isPureGitOp, classifyRequest } = require("./intent");
-const {
-  extractExistingTaskIds, findSimilarPendingTasks,
-  findDuplicatePendingClusters, applyTaskMerge,
-} = require("./task-dedup");
-const tm = require("./task-manager");
-const { searchKLayer } = require("./k-layer");
-const { getIssues, refreshIssues, getCacheAge } = require("./github-issues");
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
 
-// ── チャンネル Q&A (質問と判定されたときのインライン回答) ────────────────────
-// git push / pull のみ（他の作業を含まない）を実行して結果を返す
-// 「A機能を修正して git push して」のような複合指示には反応しない
+const config = require('./config');
+const { BASE_DIR, AGENT_DIR, TASK_STATE_FILE, HISTORY_FILE, getAgentDir, parseProjectPrefix } = config;
+const { loadJSON, saveJSON } = require('./state');
+const { postMessage, postLong, fetchThreadTranscript, resolveUserName, slackGet } = require('./slack-api');
+const { checkAllRepoStatus, isPushFailureNotice } = require('./repo-status');
+const { callClaude } = require('./claude-cli');
+const { isGoCmd, isCancelCmd, isForceTaskCmd, isPureGitOp, classifyRequest } = require('./intent');
+const {
+  extractExistingTaskIds, extractGiipIssueRef, findSimilarPendingTasks, findDuplicatePendingClusters, applyTaskMerge,
+} = require('./task-dedup');
+const tm = require('./task-manager');
+const dashboard = require('./dashboard');
+const { searchKLayer } = require('./k-layer');
+const { getIssues, refreshIssues, getCacheAge } = require('./github-issues');
+
+// LOWY_ACTION_DASHBOARD.md 자동 갱신 훅. tasklist 변화 후 호출한다.
+//  - 예외/블로킹 없이(비동기 defer) 봇 흐름을 막지 않는다.
+//  - base 브랜치가 아니거나(태스크 실행 중) pull 실패면 dashboard 모듈이 알아서 skip.
+function refreshDashboardSafe(reason) {
+  setImmediate(() => {
+    try { dashboard.refreshDashboard(reason); }
+    catch (e) { console.error('[Bot] dashboard refresh 훅 오류:', e.message); }
+  });
+}
+
+// ── allowlist 명령어 — 현재 설정된 허용 user/channel 화이트리스트를 표시 ──────
+const _channelNameCache = new Map();
+async function resolveChannelName(channelId) {
+  if (_channelNameCache.has(channelId)) return _channelNameCache.get(channelId);
+  let name = channelId;
+  try {
+    const res = await slackGet('conversations.info', { channel: channelId });
+    if (res && res.ok && res.channel) name = res.channel.name ? `#${res.channel.name}` : channelId;
+  } catch (e) { /* ignore — fall back to raw ID */ }
+  _channelNameCache.set(channelId, name);
+  return name;
+}
+
+async function buildAllowlistReply() {
+  const users = config.ALLOWED_USERS;
+  const channels = config.CHANNEL_IDS;
+
+  const userLines = users.length
+    ? await Promise.all(users.map(async (id) => {
+        const name = await resolveUserName(id);
+        return name && name !== id ? `• ${name} (${id})` : `• ${id} ⚠️ 조회 실패(존재하지 않는 ID일 수 있음)`;
+      }))
+    : ['(없음 — 화이트리스트 미설정, 전체 유저 허용됨)'];
+
+  const channelLines = channels.length
+    ? await Promise.all(channels.map(async (id) => {
+        const name = await resolveChannelName(id);
+        return name && name !== id ? `• ${name} (${id})` : `• ${id} ⚠️ 조회 실패(존재하지 않는 채널일 수 있음)`;
+      }))
+    : ['(없음 — 채널 제한 미설정)'];
+
+  return [
+    '*🔐 Allowlist 설정 (SLACK_ALLOWED_USERS / SLACK_CHANNEL_IDS)*',
+    '',
+    '*허용된 유저:*',
+    ...userLines,
+    '',
+    '*허용된 채널:*',
+    ...channelLines,
+  ].join('\n');
+}
+
 async function handleSimpleGitOp({ channelId, replyTs, text, workDir = BASE_DIR }) {
   if (!isPureGitOp(text)) return false;
   const t = text.trim();
@@ -54,22 +95,18 @@ async function handleSimpleGitOp({ channelId, replyTs, text, workDir = BASE_DIR 
 async function answerInChannel({ channelId, replyTs, text, workDir = BASE_DIR, threadTs = null }) {
   if (await handleSimpleGitOp({ channelId, replyTs, text, workDir })) return;
 
+  // 即時受付通知: callClaude は最大20分ブロックし、その間ユーザには何も返らないため
+  // 「먹통」に見える。実処理の前に受付メッセージを出して無応答体感を無くす。
+  await postMessage(channelId, '💬 질문을 확인했습니다. 답변을 준비 중입니다…', replyTs);
+
   // スレッド内での質問なら、スレッド全体を取得して文脈として渡す。
   // Bot は mention された1件しか受け取らないため、これをやらないと
-  // 「スレッドを要約して」に対して「会話履歴がない」と誤答してしまう。
+  // 「스레드를 정리해줘」に対して「대화 기록이 없습니다」と誤答してしまう。
   let threadTranscript = '';
   try {
     threadTranscript = await fetchThreadTranscript(channelId, threadTs);
   } catch (e) {
     console.error('[Bot] fetchThreadTranscript error:', e.message);
-  }
-
-  // Slack permalinks pasted in the message → read those threads too (Method 2)
-  let referencedThreads = '';
-  try {
-    referencedThreads = await fetchReferencedThreads(text, channelId, threadTs);
-  } catch (e) {
-    console.error('[Bot] fetchReferencedThreads error:', e.message);
   }
 
   const claims = searchKLayer(text);
@@ -80,7 +117,7 @@ async function answerInChannel({ channelId, replyTs, text, workDir = BASE_DIR, t
 
   const projectName = path.basename(workDir);
   const agentDir = getAgentDir(workDir);
-  let prompt = `You are ${BOT_NAME}, an AI assistant. Respond in the same language as the user's message.
+  let prompt = `You are giipclaude, an AI assistant. Always respond in Korean.
 
 Working project: ${projectName}
 Working directory: ${workDir}
@@ -91,25 +128,36 @@ Agent context directory: ${agentDir}
   - workflows/: workflow definitions
 Read relevant files from the agent context directory as needed to apply the correct role and rules.
 
-IMPORTANT: Answer based on your knowledge of the project directory and K-Layer context below. If you do not know the answer, say so clearly.
+IMPORTANT: Answer based on your knowledge of the project directory and K-Layer context below. If you do not know the answer, say "모르겠습니다" clearly.
 
-MANDATORY RULE — Task Number: If the user's message contains a 14-digit task number (e.g. 20260630170105), you MUST start your response with "[task \`<task_number>\`]" on the very first line. Never omit the task number from your response.`;
+되묻지 말고 실측: 경로·설정·사양 등 조회로 확정 가능한 값은 사용자에게 묻지 말고 직접 찾아라. giip 서비스 설정(SMTP·메일·인증 등)의 정본은 giipdb 사양서(\`giipprj/giipdb/docs/30_Specs/\`)와 DB 다. 예: SMTP 는 \`tEmailServerConfig\` 테이블 + giip API \`EmailServerConfigGetActive\`. 사람에게 묻기 전에 반드시 그곳부터 grep/조회하고, 정말 사람만 아는 값(외부 자격증명 실물)만 질문한다.
+
+**git 커밋·push·PR 생성은 절대 당신이 직접 하지 마세요.** 답변 중 파일을 수정했다면 봇이 응답 후 자동으로 변경분을 감지해 커밋·push·PR 을 생성합니다(당신의 gh/git 계정에는 PR 생성 권한이 없어 시도하면 실패하고, 그 실패를 사용자에게 "수동으로 만들어달라"고 요청하면 안 됩니다 — 그건 봇이 이미 처리하는 일입니다). 파일 변경 사항은 답변 텍스트로 요약만 하세요.
+
+MANDATORY RULE — Task Number: If the user's message contains a 14-digit task number (e.g. 20260630170105), you MUST start your response with "[태스크 \`<task_number>\`]" on the very first line. Never omit the task number from your response.`;
   if (claims.length) prompt += '\n\nK-Layer:\n' + claims.map(c => `• ${c}`).join('\n');
   if (issues.length) prompt += '\n\nOpen Issues:\n' + issues.map(i => `• #${i.number} ${i.title}`).join('\n');
   if (threadTranscript) {
-    prompt += `\n\n── Full current Slack thread (chronological, "speaker: message") ──\n${threadTranscript}\n── end of thread ──\n\nThe thread above is what the user means by "this thread / this conversation / this Slack message". When asked to summarize the thread, explain who said what, or check the surrounding context, you MUST answer based on the content above. Never reply that there is no conversation history.`;
-  }
-  if (referencedThreads) {
-    prompt += `\n\n── Other Slack thread(s) the user referenced by URL ──\n${referencedThreads}\n── end of referenced thread(s) ──\n\nIf the user pasted a Slack link, the block above is that link's thread content. Base any summary, comparison, or answer about it strictly on this content.`;
+    prompt += `\n\n── 현재 Slack 스레드 전체 내용 (시간순, "화자: 발언") ──\n${threadTranscript}\n── 스레드 끝 ──\n\n위 스레드가 사용자가 말하는 "현재 스레드 / 이 대화 / 이 슬랙 메시지"입니다. 스레드 정리·요약·누가 무슨 말을 했는지·전후 확인 요청은 반드시 이 내용을 근거로 답하세요. "대화 기록이 없다"고 답하지 마세요.`;
   }
   prompt += `\n\nQuestion: ${text}\nAnswer:`;
+
+  // ── 安全網: question 経路でも「ファイル変更 = 必ずブランチ+PR」規則を強制する ──
+  // task/question 分類は flaky(LLM)なため、誤って question に落ちた作業依頼でも
+  // callClaude がファイルを書けば作業ツリーに未コミットで取り残される事故が起きる
+  // (giip-629 追加依頼: 未追跡ファイルのまま PR 未生成)。task 経路と同一の
+  // commitAndPRChangedRepos 機械を再利用し、実行「前」に clean だったリポの
+  // タスク由来変更だけを安全に commit·push·PR する(pre-dirty は触らず skip)。
+  let qnaSnapshots = [];
+  try { qnaSnapshots = tm.snapshotCandidateRepos(workDir); }
+  catch (e) { console.error('[Bot] answer snapshot error:', e.message); }
 
   try {
     const reply = await callClaude(prompt, workDir);
     // 코드레벨 강제: 사용자 메시지의 태스크 ID가 응답에 없으면 첫 줄에 삽입
     const missingIds = extractExistingTaskIds(text).filter(id => !reply.includes(id));
     const finalReply = missingIds.length > 0
-      ? `[task \`${missingIds.join('`, `')}\`]\n\n${reply}`
+      ? `[태스크 \`${missingIds.join('`, `')}\`]\n\n${reply}`
       : reply;
     await postLong(channelId, finalReply, replyTs);
   } catch (err) {
@@ -119,6 +167,26 @@ MANDATORY RULE — Task Number: If the user's message contains a 14-digit task n
       : `回答エラー: ${err.message}`;
     await postMessage(channelId, msg2, replyTs);
   }
+
+  // callClaude が(成功/タイムアウト問わず)ファイルを変更していたら、未コミットで
+  // 放置せず自動 PR にする。変更ゼロなら静かに何もしない。
+  try {
+    const stamp = new Date().toISOString().replace(/[^0-9]/g, '').slice(0, 14);
+    const qtitle = String(text).replace(/\s+/g, ' ').trim().slice(0, 60);
+    const multi = tm.commitAndPRChangedRepos(`qna-${stamp}`, qtitle, qnaSnapshots);
+    const prLines = (multi.prs || []).map(p => `🔀 PR (${path.basename(p.repo)}): ${p.url}`);
+    const skipLines = (multi.skipped || []).map(s => `⚠️ 수동 필요: ${path.basename(s.repo)} (${s.reason})`);
+    const blockedLines = (multi.blocked || []).map(b =>
+      `🚧 보류: ${path.basename(b.repo)} — 미머지 PR ${(b.prs || []).map(p => '#' + p.number).join(', ')} 과 같은 파일. 브랜치 \`${b.branch}\` push 됨(선행 PR 머지 후 수동 PR/rebase 필요).`);
+    if (prLines.length || skipLines.length || blockedLines.length) {
+      await postMessage(channelId, [
+        '📝 *답변 중 파일 변경 감지 → 자동 브랜치/PR* (질문 경로 안전망)',
+        ...prLines,
+        ...blockedLines,
+        ...skipLines,
+      ].join('\n'), replyTs);
+    }
+  } catch (e) { console.error('[Bot] answer auto-PR error:', e.message); }
 }
 
 // ── DM 처리 (일반 Q&A) ───────────────────────────────────────────────────────
@@ -150,10 +218,17 @@ async function handleDM({ channelId, ts, threadTs, text, conversations, workDir 
       '• `giip issue new "<title>"` — イシュー新規作成',
       '• `giip issue done|review|progress <isn>` — ステータス変更',
       '• `giip issue comment <isn> <text>` — コメント追加',
+      '• `giip project set <프로젝트명> <csn>` — プロジェクト名→CSN マッピング登録（`<프로젝트> issue 등록` 用）',
+      '• `giip project list` / `giip project del <프로젝트명>` — マッピング一覧 / 削除',
       '• `giip api <Verb> [jsondata]` — 汎用 giip API 呼び出し',
       '',
       'チャンネルで `@ボット名 要求内容` と書くと Task ワークフローが始まります。',
+      '• `allowlist` — 허용된 user/channel 화이트리스트 표시',
     ].join('\n'), replyTs);
+    return;
+  }
+  if (cmd === 'allowlist' || cmd === '!allowlist') {
+    await postMessage(channelId, await buildAllowlistReply(), replyTs);
     return;
   }
   if (cmd === '!reset') {
@@ -176,7 +251,7 @@ async function handleDM({ channelId, ts, threadTs, text, conversations, workDir 
   }
 
   // ── タスク番号による状況照会（DM）────────────────────────────────────────
-  const dmTaskMatch = text.trim().match(/^(?:status\s+)?(\d{14})$/);
+  const dmTaskMatch = text.trim().match(/^(?:status\s+)?(\d{14}|giip-\d{1,6})$/);
   if (dmTaskMatch) {
     const targetId = dmTaskMatch[1];
     const taskFile = path.join(AGENT_DIR, 'tasks', `${targetId}.md`);
@@ -207,7 +282,7 @@ async function handleDM({ channelId, ts, threadTs, text, conversations, workDir 
 
   const projectName = path.basename(workDir);
   const agentDirDM = getAgentDir(workDir);
-  let prompt = `You are ${BOT_NAME}, an AI assistant. Respond in the same language as the user's message.\n\nWorking project: ${projectName}\nWorking directory: ${workDir}\nAgent context directory: ${agentDirDM} (roles/, rules/, skills/, workflows/)\nRead relevant files from the agent context directory to apply the correct role and rules.\n\nIMPORTANT: Answer based on your knowledge of the project and K-Layer context. If you do not know the answer, say so clearly.\n\nMANDATORY RULE — Task Number: If the user's message contains a 14-digit task number (e.g. 20260630170105), you MUST start your response with "[task \`<task_number>\`]" on the very first line. Never omit the task number from your response.`;
+  let prompt = `You are giipclaude, an AI assistant. Always respond in Korean regardless of the language the user writes in.\n\nWorking project: ${projectName}\nWorking directory: ${workDir}\nAgent context directory: ${agentDirDM} (roles/, rules/, skills/, workflows/)\nRead relevant files from the agent context directory to apply the correct role and rules.\n\nIMPORTANT: Answer based on your knowledge of the project and K-Layer context. If you do not know the answer, say "모르겠습니다" clearly.\n\n되묻지 말고 실측: 설정·사양은 직접 조회하라. giip 서비스 설정(SMTP 등)의 정본=giipdb \`docs/30_Specs/\` + DB(예: SMTP=\`tEmailServerConfig\`, API \`EmailServerConfigGetActive\`). 사람만 아는 값만 질문한다.\n\nMANDATORY RULE — Task Number: If the user's message contains a 14-digit task number (e.g. 20260630170105), you MUST start your response with "[태스크 \`<task_number>\`]" on the very first line. Never omit the task number from your response.`;
   if (claims.length) prompt += '\n\nK-Layer:\n' + claims.map(c=>`• ${c}`).join('\n');
   if (issues.length) prompt += '\n\nOpen Issues:\n' + issues.map(i=>`• #${i.number} ${i.title}`).join('\n');
   if (history.length) {
@@ -225,7 +300,7 @@ async function handleDM({ channelId, ts, threadTs, text, conversations, workDir 
     // 코드레벨 강제: 사용자 메시지의 태스크 ID가 응답에 없으면 첫 줄에 삽입
     const missingIdsDM = extractExistingTaskIds(text).filter(id => !reply.includes(id));
     const finalReplyDM = missingIdsDM.length > 0
-      ? `[task \`${missingIdsDM.join('`, `')}\`]\n\n${reply}`
+      ? `[태스크 \`${missingIdsDM.join('`, `')}\`]\n\n${reply}`
       : reply;
     await postLong(channelId, finalReplyDM, replyTs);
   } catch (err) {
@@ -233,46 +308,218 @@ async function handleDM({ channelId, ts, threadTs, text, conversations, workDir 
   }
 }
 
+// ── 작업트리 점유가 풀렸을 때, 대기열의 다음 태스크를 자동 기동한다 ──────────────
+//   busy 로 되돌려진 태스크는 pending 에 `queuedBehind` 마커와 함께 남는다.
+//   태스크 완료(onComplete/onError)로 락이 풀린 직후 이 함수를 호출하면, 마커가 있는
+//   대기 태스크를 FIFO(queuedAt 오름차순) 로 하나 꺼내 실행한다.
+//   ※ 마커 없는 pending(=수동 `go` 대기 중인 분석 완료 태스크)은 자동 실행하지 않는다.
+//   ※ 한 번에 하나만 기동(직렬). 다음 태스크는 그 태스크의 완료 시 다시 드레인된다.
+async function drainNextQueued(reason = 'task-completed') {
+  try {
+    const ts = loadJSON(TASK_STATE_FILE, { pending: {}, running: {} });
+    // 이미 다른 태스크가 실행 중(작업트리 점유)이면 드레인하지 않는다(직렬 보장).
+    if (ts.running && Object.keys(ts.running).length > 0) return;
+    const queued = Object.entries(ts.pending || {})
+      .filter(([, t]) => t && t.queuedBehind)
+      .sort((a, b) => String(a[1].queuedAt || '').localeCompare(String(b[1].queuedAt || '')));
+    if (!queued.length) return;
+    const [key, entry] = queued[0];
+    const ch = entry.channelId;
+    const rt = entry.replyTs || undefined;
+    if (!ch) { console.error('[Bot] drainNextQueued: channelId 없음 → 스킵:', key); return; }
+    console.log(`[Bot] drainNextQueued(${reason}): 대기 태스크 ${entry.taskId} 자동 기동`);
+    await postMessage(ch,
+      `▶️ 작업트리가 비었습니다 — 대기 중이던 \`${entry.taskId}\` 을(를) 자동 기동합니다.`,
+      rt);
+    await startTaskExecution(key, entry, ch, rt, ts, entry.workDir || BASE_DIR);
+  } catch (e) {
+    console.error('[Bot] drainNextQueued error:', e.message);
+  }
+}
+
 // ── Task 実行共通処理 ─────────────────────────────────────────────────────────
 async function startTaskExecution(pendingKey, pendingTask, channelId, replyTs, taskState, workDir = BASE_DIR) {
+  // 保存された workDir を優先（go <id> はプレフィックス無しで来るため handlers 側の
+  // parseProjectPrefix が BASE_DIR に潰してしまう。タスク作成時の workDir を必ず使う）。
+  const effWorkDir = (pendingTask && pendingTask.workDir) || workDir;
+
   delete taskState.pending[pendingKey];
   const startedAt = new Date().toISOString();
   taskState.running[pendingKey] = {
     taskId: pendingTask.taskId,
     taskTitle: pendingTask.taskTitle,
+    isn: pendingTask.isn || null, // 점유 중 대기 태스크가 이 이슈에 대기 코멘트를 남길 수 있게 보존
+    workDir: effWorkDir, // 크래시 후 reconcileTaskState 가 nested repo 를 회수할 때 필요(2026-07-28)
     startedAt,
   };
   saveJSON(TASK_STATE_FILE, taskState);
   tm.updateTasklistEntry(pendingTask.taskId, { status: 'running', startedAt });
 
-  // ── 作業前に対象ディレクトリで git pull ──────────────────────────────────
-  const pull = await gitPullBeforeWork(workDir);
-  if (!pull.skipped) {
-    if (pull.ok) {
-      const alreadyLatest = /already up.to.date/i.test(pull.stdout);
-      const pullMsg = alreadyLatest
-        ? `🔄 git pull \`${pull.branch}\`: 最新状態`
-        : `🔄 git pull \`${pull.branch}\` 完了\n\`\`\`${pull.stdout.slice(0, 300)}\`\`\``;
-      await postMessage(channelId, pullMsg, replyTs);
-    } else {
+  // ── 作業「前」: 候補 nested repo の base を origin 最新へ ff 同期 ──
+  // giipv3 等の nested repo は誰も base を pull せず stale なまま編集され、後段 auto-PR が
+  // 最新 origin/base から切ったブランチへ replay する時に既 merge 済み変更と衝突していた
+  // (= ユーザ指摘「giipv3 は毎回 conflict」の根治)。clean かつ base 上の repo だけ ff 同期。
+  try { tm.syncCandidateReposBase(effWorkDir); }
+  catch (e) { console.error('[Bot] syncCandidateReposBase error:', e.message); }
+
+  // ── 実行「前」: 候補 nested repo を「このタスク専用ブランチ」へ切り替える(スト孤児化の根本予防) ──
+  // prepareTaskBranch が BASE_DIR だけを bot/task-<id> にしていたため、nested repo(giipv3/giipdb)は
+  //   直前タスクのブランチに停留したまま編集され、後段 auto-PR が foreign branch として skip →
+  //   コードが PR されず「REVIEW인데 배포 0」になっていた。ここで clean·on-base の nested repo を
+  //   先に bot/task-<id> へ切り替え、編集が正しい専用ブランチに載るようにする(dirty/foreign は不触)。
+  //   snapshot はこの「後」に撮る(専用ブランチ上の clean 状態を基準にするため順序が重要)。
+  let nestedPrepared = [];
+  try { nestedPrepared = tm.prepareNestedBranches(effWorkDir, pendingTask.taskId, [BASE_DIR]); }
+  catch (e) { console.error('[Bot] prepareNestedBranches error:', e.message); }
+
+  // ── 実行「前」に、タスクが変更しうる候補リポの dirty 状態をスナップショット ──
+  // (effWorkDir を含むリポ + その配下の nested git repo。onComplete/onError で
+  //  「タスクが実際に変更したリポだけ」を安全に判定・PR するための基準。)
+  let repoSnapshots = [];
+  try { repoSnapshots = tm.snapshotCandidateRepos(effWorkDir); }
+  catch (e) { console.error('[Bot] snapshotCandidateRepos error:', e.message); }
+
+  // ── 作業前: 最新 base(origin) から専用ブランチを用意（結果レポート = BASE_DIR）──
+  // 旧: 現在ブランチを git pull --rebase（stale base だと conflict 誘発）→ 廃止。
+  // 新: `git fetch origin <base>` 直後に origin/<base> を起点にブランチを作る。
+  //     常に最新 base 基準なので「ブランチを作るたび merge conflict」を根本回避する。
+  // 注意: 結果レポート/タスクファイルは常に BASE_DIR(lowyworkenv) 配下に生成されるため、
+  //     この既存経路は BASE_DIR を対象にする。effWorkDir 本体や nested repo の
+  //     コード変更は onComplete の commitAndPRChangedRepos が別途担当する。
+  const branchCtx = tm.prepareTaskBranch(pendingTask.taskId, BASE_DIR);
+  if (!branchCtx.ok && !branchCtx.notRepo) {
+    // busy(他タスクが作業ツリー占有) or ブランチ生成失敗 → pending へ戻して中断
+    const ts0 = loadJSON(TASK_STATE_FILE, { pending: {}, running: {} });
+    delete ts0.running[pendingKey];
+
+    if (branchCtx.busy) {
+      // 다른 태스크가 작업트리(git)를 점유 중 → 대기열에 등록만 하고, 점유 태스크가
+      // 끝나면 onComplete/onError 의 drainNextQueued 가 이 태스크를 자동 기동한다.
+      // (직렬 실행은 유지: 사용자가 다시 `go` 하지 않아도 순서대로 실행됨.)
+      const occupying = Object.values(ts0.running || {})[0] || null;
+      const occId = (occupying && occupying.taskId) || '(불명)';
+      ts0.pending[pendingKey] = {
+        ...pendingTask,
+        queuedBehind: occId,                 // 어떤 태스크가 점유 중이었는지(진단·표시용)
+        queuedAt: new Date().toISOString(),  // FIFO 드레인 정렬 키
+        channelId,                           // 자동 기동 시 회신 채널
+        replyTs: replyTs || null,            // 자동 기동 시 회신 스레드
+      };
+      saveJSON(TASK_STATE_FILE, ts0);
+      tm.updateTasklistEntry(pendingTask.taskId, { status: 'pending', startedAt: null });
       await postMessage(channelId,
-        `⚠️ git pull 失敗（作業は続行します）\n\`\`\`${(pull.stderr || pull.stdout).slice(0, 300)}\`\`\``,
+        `⏸️ 지금은 \`${occId}\` 이(가) 작업트리(git)를 점유 중입니다.\n` +
+        `\`${pendingTask.taskId}\` 을(를) *대기열에 등록*했습니다 — 점유 작업이 끝나면 *자동으로 기동*합니다 (다시 \`go\` 하지 않아도 됩니다).`,
         replyTs
       );
+      // 점유 중인 giip 이슈에 대기 관계를 코멘트로 남긴다(best-effort, SSOT-안전한 코멘트 채널).
+      try {
+        if (occupying && occupying.isn) {
+          await require('./giip-task').maybeComment(channelId, occupying.isn,
+            `⏳ 대기 중: \`${pendingTask.taskId}\`${pendingTask.isn ? ` (giip #${pendingTask.isn})` : ''} 이(가) 작업트리 점유 해제를 기다립니다 — 이 작업(#${occupying.isn}) 완료 시 자동 기동됩니다.`);
+        }
+      } catch (e) { console.error('[Bot] 대기 코멘트 훅 오류:', e.message); }
+      return;
     }
+
+    // busy 이외의 브랜치 생성 실패(고아 rebase 등 일시적 git 오류 포함) → 사용자 요청대로
+    // 대기열에 올려 자동 재시도한다(수동 go 불요). clearStaleRebaseState 자가치유로 대개 다음
+    // 시도에 풀리지만, 근본 원인이 남아있는 경우를 대비해 횟수를 제한하고 소진되면 수동 안내로 되돌아간다.
+    const MAX_BRANCH_FAIL_RETRIES = 3;
+    const branchFailRetries = (pendingTask.branchFailRetries || 0) + 1;
+    if (branchFailRetries <= MAX_BRANCH_FAIL_RETRIES) {
+      ts0.pending[pendingKey] = {
+        ...pendingTask,
+        branchFailRetries,
+        queuedBehind: `(git 오류 자동복구 대기 ${branchFailRetries}/${MAX_BRANCH_FAIL_RETRIES})`,
+        queuedAt: new Date().toISOString(),
+        channelId,
+        replyTs: replyTs || null,
+      };
+      saveJSON(TASK_STATE_FILE, ts0);
+      tm.updateTasklistEntry(pendingTask.taskId, { status: 'pending', startedAt: null });
+      await postMessage(channelId,
+        `⏸️ *브랜치 생성 실패* (자동 재시도 ${branchFailRetries}/${MAX_BRANCH_FAIL_RETRIES}): ${branchCtx.error}\n` +
+        `\`${pendingTask.taskId}\` 을(를) *대기열에 등록*했습니다 — 잠시 후 *자동으로 재시도*합니다 (\`go\` 불요).`,
+        replyTs
+      );
+      return;
+    }
+
+    // 재시도 소진 → 수동 재실행 안내(무한 루프 방지).
+    ts0.pending[pendingKey] = { ...pendingTask, branchFailRetries: undefined, queuedBehind: undefined };
+    saveJSON(TASK_STATE_FILE, ts0);
+    tm.updateTasklistEntry(pendingTask.taskId, { status: 'pending', startedAt: null });
+    await postMessage(channelId,
+      `⏸️ *実行できません* (자동 재시도 ${MAX_BRANCH_FAIL_RETRIES}회 소진): ${branchCtx.error}\n\`go ${pendingTask.taskId}\` で後ほど再実行してください。`,
+      replyTs
+    );
+    return;
+  }
+  const execCtx = branchCtx.ok ? branchCtx : null; // notRepo 時は ctx=null (PR 不可、従来通り実行)
+  if (execCtx) {
+    await postMessage(channelId,
+      `🌿 作業ブランチ作成: \`${execCtx.branch}\`\n• base: \`${execCtx.base}\`${execCtx.fetchedBase ? ' (origin 最新 fetch 済)' : ' (⚠️ fetch 失敗 — ローカル base 基準)'}`,
+      replyTs
+    );
   }
 
   await postMessage(channelId,
-    `⚙️ *Task 実行開始*: \`${pendingTask.taskId}\`\n• ${pendingTask.taskTitle}\n\n_サブエージェントが作業中です。完了したら結果 URL をお知らせします。_`,
+    `⚙️ *Task 実行開始*: \`${pendingTask.taskId}\`\n• ${pendingTask.taskTitle}\n\n_サブエージェントが作業中です。完了したら PR URL をお知らせします。_`,
     replyTs
   );
 
-  tm.startExecution(pendingTask.taskId, pendingTask.taskFile, {
-    onComplete: async (resultFile) => {
-      const ts2 = loadJSON(TASK_STATE_FILE, {});
-      delete ts2.running[pendingKey];
-      saveJSON(TASK_STATE_FILE, ts2);
+  // giip issue 연동: 실제 실행이 시작되는 이 시점에 IN_PROGRESS 로 전이한다.
+  //   분석 단계에서 미리 IN_PROGRESS 를 찍지 않으므로 「issue 는 IN_PROGRESS 인데
+  //   실제로는 아무것도 안 도는」 모순 상태가 생기지 않는다(사용자 지적 대응).
+  if (pendingTask && pendingTask.isn) {
+    try { await require('./giip-task').maybeFinish(channelId, pendingTask.isn, 'IN_PROGRESS', null); }
+    catch (e) { console.error('[Bot] giip IN_PROGRESS 전이 오류:', e.message); }
+  }
 
+  // effWorkDir/nested repo の PR を Slack へ整形するヘルパ（onComplete/onError 共用）
+  const renderRepoLines = (reportUrl, multi) => {
+    const prLines = [];
+    if (reportUrl) prLines.push(`🔀 PR: ${reportUrl}`);
+    for (const p of (multi.prs || [])) prLines.push(`🔀 PR (${path.basename(p.repo)}): ${p.url}`);
+    const skipLines = (multi.skipped || []).map(s => {
+      const files = (s.files || []).slice(0, 6).map(f => path.basename(f)).join(', ');
+      const more = (s.files || []).length > 6 ? ' 외' : '';
+      return `⚠️ 수동 필요: ${path.basename(s.repo)}${files ? ` [${files}${more}]` : ''} — ${s.reason}`;
+    });
+    // PR 충돌 게이트로 보류된 저장소: 어떤 미머지 PR 과 어느 파일이 겹쳤는지 알린다.
+    const blockedLines = [];
+    for (const b of (multi.blocked || [])) {
+      const prTxt = (b.prs || []).map(p => `#${p.number}`).join(', ');
+      const fileTxt = (b.files || []).slice(0, 5).map(f => path.basename(f)).join(', ') + ((b.files || []).length > 5 ? ' 외' : '');
+      blockedLines.push(`🚧 보류: ${path.basename(b.repo)} — 파일 [${fileTxt}] 이(가) 미머지 PR ${prTxt} 대상이라 새 PR 을 만들지 않았습니다(브랜치 \`${b.branch}\` 는 push 됨).`);
+      for (const p of (b.prs || [])) blockedLines.push(`   ↳ ${p.url}`);
+    }
+    return { prLines, skipLines, blockedLines };
+  };
+
+  // ── 자가 치유: giip issue 태스크인데 로컬 태스크 파일이 없으면 DB 이력으로 재생성 ──
+  //   giip issue 재처리 요청은 done/ 이동·타 클론 처리·워킹트리 churn 으로 로컬
+  //   .agent/tasks/{giip-isn}.md 가 사라졌을 수 있다(#660 "タスクファイルが見つかりません"의 원인).
+  //   이 경우 DB(SSOT)에서 이슈 본문 + 전체 코멘트를 가져와 태스크 파일을 복원해, 서브에이전트가
+  //   코멘트 이력을 모두 읽고 이어서 처리하도록 한다. isn 이 있는 태스크에만 적용(best-effort).
+  if (pendingTask.isn && (!pendingTask.taskFile || !fs.existsSync(pendingTask.taskFile))) {
+    try {
+      const hist = await require('./giip-task').fetchIssueHistory(channelId, pendingTask.isn);
+      const rebuilt = tm.rebuildTaskFileFromIssue(
+        pendingTask.taskId, pendingTask.isn, pendingTask.requestText || '', hist && hist.digest);
+      pendingTask.taskFile = rebuilt;
+      await postMessage(channelId,
+        `🗄️ 로컬 태스크 파일이 없어 giip issue #${pendingTask.isn} 의 DB 이력(본문+코멘트${hist && hist.comments ? ` ${hist.comments.length}건` : ''})으로 복원해 처리합니다.`,
+        replyTs);
+    } catch (e) {
+      console.error('[Bot] giip 태스크 파일 DB 복원 실패:', e.message);
+    }
+  }
+
+  tm.startExecution(pendingTask.taskId, pendingTask.taskFile, {
+    isn: pendingTask.isn || null, // giip 연동 시 서브에이전트가 진행 코멘트를 남기도록 isn 전달
+    onComplete: async (resultFile) => {
       // 결과 내용을 태스크 파일에 추가하고 done/ 폴더로 이동
       let doneTaskFile = null;
       try {
@@ -282,54 +529,143 @@ async function startTaskExecution(pendingKey, pendingTask, channelId, replyTs, t
         console.error('[Bot] completeTaskFile error:', e.message);
       }
 
-      const githubUrl = tm.gitPushResult(pendingTask.taskId, pendingTask.taskTitle, resultFile, doneTaskFile);
-      tm.updateTasklistEntry(pendingTask.taskId, {
-        status: 'completed',
-        completedAt: new Date().toISOString(),
-        resultUrl: githubUrl || null,
-      });
-      if (githubUrl) {
-        await postMessage(channelId,
-          `✅ *작업 완료*: \`${pendingTask.taskId}\`\n• ${pendingTask.taskTitle}\n\n📋 태스크 결과 보고서: ${githubUrl}`,
-          replyTs
-        );
-      } else {
-        await postMessage(channelId,
-          `✅ *작업 완료* (⚠️ git push 실패 — 원격 미반영이라 GitHub URL 미생성)\n• \`${pendingTask.taskId}\`: ${pendingTask.taskTitle}\n결과 파일: \`.agent/tasks/done/${pendingTask.taskId}.md\`\n봇 로그의 git push 오류를 확인하세요.`,
-          replyTs
-        );
-        await postLong(channelId, checkAllRepoStatus(), replyTs);
-      }
-
-      // ── giip issue 통일(rule 40): 완료 시 코멘트 + REVIEW 전이(best-effort). ──
-      try {
-        const gt = require('./giip-task');
-        const cmt = githubUrl ? `✅ 작업 완료\n결과: ${githubUrl}` : '✅ 작업 완료(로컬, git push 실패)';
-        await gt.maybeFinish(channelId, pendingTask.isn, 'REVIEW', cmt);
-      } catch (e) { console.error('[Bot] giip finish 훅 오류:', e.message); }
-    },
-    onError: async (err, resultFile) => {
+      // ① 결과 보고서/기본 리포(BASE_DIR): 기존 경로 유지 (report + BASE_DIR 코드 변경).
+      // ⚠️ gitPushResultAndPR 내부에서 restoreTaskBranch 를 호출해 gitTreeBusy 락을 해제한다.
+      //   running 상태 삭제는 반드시 이 호출 *이후* 에 해야 한다 — 먼저 지우면 gitTreeBusy=true 인데
+      //   running 은 이미 비어 있는 창(레이스 윈도우)이 생겨, 그 사이 새 태스크가 busy 로 걸리면
+      //   점유자를 찾지 못해 '(불명)' 으로 표시된다(실제로는 이 태스크가 push/PR 처리 중이었음).
+      const reportUrl = tm.gitPushResultAndPR(pendingTask.taskId, pendingTask.taskTitle, resultFile, doneTaskFile, execCtx, BASE_DIR);
       const ts2 = loadJSON(TASK_STATE_FILE, {});
       delete ts2.running[pendingKey];
       saveJSON(TASK_STATE_FILE, ts2);
-      const githubUrl = resultFile ? tm.gitPushResult(pendingTask.taskId, pendingTask.taskTitle + ' (error)', resultFile, null) : null;
+      // ② 그 외 실제로 바뀐 저장소(effWorkDir 본체 + nested repo) 각각 커밋·push·PR.
+      let multi = { prs: [], skipped: [] };
+      try {
+        multi = tm.commitAndPRChangedRepos(pendingTask.taskId, pendingTask.taskTitle, repoSnapshots, { excludeRoots: [BASE_DIR] });
+      } catch (e) { console.error('[Bot] commitAndPRChangedRepos error:', e.message); }
+      // prepareNestedBranches 로 전환한 nested repo 를 base 로 복원(드리프트 누적 차단).
+      try { tm.restoreNestedBranches(nestedPrepared); }
+      catch (e) { console.error('[Bot] restoreNestedBranches error:', e.message); }
+
+      const allUrls = [reportUrl, ...multi.prs.map(p => p.url)].filter(Boolean);
+      const blocked = multi.blocked || [];
+      // unlanded = このタスクが変更したのに PR にできなかった repo(兄弟 giipv3 が別ブランチに停留 等)。
+      //   これがあるのに素直に「완료」と言うと、コードが未反映のまま完了扱いになる(giip-720 の再発)。
+      const unlanded = multi.skipped || [];
+      tm.updateTasklistEntry(pendingTask.taskId, {
+        // 일부 저장소가 미머지 PR 과 충돌해 PR 보류되면 'blocked' — "머지완료 <taskid>" 로 재개.
+        // unlanded(이 태스크가 바꿨는데 PR 못한 repo)도 '완료'가 아니다 → 'blocked' 로 묶어
+        //   대시보드/집계에서 '완료'로 세지 않게 한다(= 거짓 완료 방지).
+        status: (blocked.length || unlanded.length) ? 'blocked' : 'completed',
+        completedAt: new Date().toISOString(),
+        resultUrl: allUrls[0] || null,
+        blocked: blocked.length ? blocked : undefined,
+        unlanded: unlanded.length ? unlanded.map(s => ({ repo: s.repo, files: s.files || [], reason: s.reason })) : undefined,
+      });
+      refreshDashboardSafe('task-completed'); // 완료 후 작업트리는 master 복귀 상태 → 갱신 가능
+      // giip issue 통일: 완료 → 코멘트 + REVIEW.
+      // ⚠️ 근본수정: REVIEW 는 「이 태스크가 바꾼 코드가 전부 PR 로 반영됐을 때만」 찍는다.
+      //   blocked(선행 PR 충돌 보류) 뿐 아니라 unlanded(foreign branch 등으로 PR 못한 변경)가
+      //   하나라도 있으면 REVIEW 로 넘기지 않는다 → IN_PROGRESS 유지 + 미반영 사유 명시.
+      //   (과거: unlanded 여도 REVIEW 로 전이해 「REVIEW인데 배포 0」 거짓 완료가 양산됐다.)
+      try {
+        if (pendingTask.isn) {
+          const gt = require('./giip-task');
+          if (blocked.length) {
+            const prTxt = blocked.map(b => (b.prs || []).map(p => '#' + p.number).join(',')).join(' ');
+            await gt.maybeFinish(channelId, pendingTask.isn, 'IN_PROGRESS',
+              `⏸️ 작업 산출물은 브랜치에 push 됐으나, 선행 미머지 PR(${prTxt})과 같은 파일이라 PR 을 보류했습니다. 선행 PR 머지 후 재개합니다.`);
+          } else if (unlanded.length) {
+            const unlandedTxt = unlanded.map(s => {
+              const files = (s.files || []).slice(0, 6).map(f => path.basename(f)).join(', ');
+              return `${path.basename(s.repo)}${files ? ` [${files}]` : ''} — ${s.reason}`;
+            }).join(' / ');
+            const prTxt = allUrls.length ? `\n부분 PR: ${allUrls.join(' , ')}` : '';
+            await gt.maybeFinish(channelId, pendingTask.isn, 'IN_PROGRESS',
+              `⚠️ 아직 완료 아님(REVIEW 보류). 이 태스크가 바꾼 다음 저장소 변경분이 PR 로 반영되지 않았습니다(수동 PR 필요): ${unlandedTxt}${prTxt}`);
+          } else {
+            const cmt = allUrls.length
+              ? `✅ 작업 완료. PR: ${allUrls.join(' , ')}`
+              : `✅ 작업 완료(push/PR 실패). 결과: .agent/tasks/done/${pendingTask.taskId}.md`;
+            await gt.maybeFinish(channelId, pendingTask.isn, 'REVIEW', cmt);
+          }
+        }
+      } catch (e) { console.error('[Bot] giip finish 훅 오류:', e.message); }
+
+      const { prLines, skipLines, blockedLines } = renderRepoLines(reportUrl, multi);
+      const resumeGuide = blocked.length
+        ? ['', `⏸️ 선행 PR 머지 후 \`머지완료 ${pendingTask.taskId}\` 라고 알려주면 base 를 pull→rebase 후 PR 을 만듭니다.`]
+        : [];
+      // 헤드라인: 보류(blocked) > 미반영(unlanded) > 완료 の優先で正直に表示する。
+      const headline = blocked.length
+        ? '⏸️ *작업 완료 (일부 PR 보류)*'
+        : (unlanded.length ? '⚠️ *작업 완료 — 일부 저장소 PR 미생성(수동 필요)*' : '✅ *작업 완료*');
+      if (prLines.length || blockedLines.length) {
+        await postMessage(channelId, [
+          `${headline}: \`${pendingTask.taskId}\`${pendingTask.isn ? ` / giip #${pendingTask.isn}${(blocked.length || unlanded.length) ? '' : '→REVIEW'}` : ''}`,
+          `• ${pendingTask.taskTitle}`,
+          '',
+          ...prLines,
+          ...(blockedLines.length ? ['', ...blockedLines] : []),
+          ...(skipLines.length ? ['', ...skipLines] : []),
+          ...resumeGuide,
+        ].join('\n'), replyTs);
+      } else {
+        await postMessage(channelId, [
+          `${unlanded.length ? '⚠️ *작업 완료 — 일부 저장소 PR 미생성(수동 필요)*' : '✅ *작업 완료*'} (⚠️ 원격 반영된 PR 없음)`,
+          `• \`${pendingTask.taskId}\`: ${pendingTask.taskTitle}`,
+          `결과 파일: \`.agent/tasks/done/${pendingTask.taskId}.md\``,
+          ...(skipLines.length
+            ? ['', ...skipLines]
+            : ['변경된 저장소가 없거나 push/PR 생성에 실패했습니다. 봇 로그의 git/gh 오류를 확인하세요.']),
+        ].join('\n'), replyTs);
+        if (!skipLines.length) await postLong(channelId, checkAllRepoStatus(), replyTs);
+      }
+
+      // 작업트리 락이 해제된 시점 → 대기열에 쌓인 다음 태스크를 자동 기동.
+      await drainNextQueued('task-completed');
+    },
+    onError: async (err, resultFile) => {
+      // エラー時も部分成果を push+PR し、必ず作業ツリーを原状復帰(ブランチ復元)する。
+      // ⚠️ onComplete 와 동일한 이유로 running 삭제는 gitPushResultAndPR(restoreTaskBranch 포함) 이후.
+      const reportUrl = tm.gitPushResultAndPR(pendingTask.taskId, pendingTask.taskTitle + ' (error)', resultFile, null, execCtx, BASE_DIR);
+      const ts2 = loadJSON(TASK_STATE_FILE, {});
+      delete ts2.running[pendingKey];
+      saveJSON(TASK_STATE_FILE, ts2);
+      let multi = { prs: [], skipped: [] };
+      try {
+        multi = tm.commitAndPRChangedRepos(pendingTask.taskId, pendingTask.taskTitle + ' (error)', repoSnapshots, { excludeRoots: [BASE_DIR] });
+      } catch (e) { console.error('[Bot] commitAndPRChangedRepos(error) 오류:', e.message); }
+      try { tm.restoreNestedBranches(nestedPrepared); }
+      catch (e) { console.error('[Bot] restoreNestedBranches(error) error:', e.message); }
+
+      const allUrls = [reportUrl, ...multi.prs.map(p => p.url)].filter(Boolean);
       tm.updateTasklistEntry(pendingTask.taskId, {
         status: 'cancelled',
         completedAt: new Date().toISOString(),
-        resultUrl: githubUrl || null,
+        resultUrl: allUrls[0] || null,
       });
-      await postMessage(channelId,
-        `❌ *작업 에러* (\`${pendingTask.taskId}\`): ${err.message}${githubUrl ? `\n📄 에러 로그: ${githubUrl}` : ''}`,
-        replyTs
-      );
-
-      // ── giip issue 통일(rule 40): 에러 시 코멘트 + REVIEW 전이(best-effort). ──
+      refreshDashboardSafe('task-error'); // 에러 후에도 작업트리는 master 복귀 상태
+      // giip issue 통일: 에러 → 코멘트 + REVIEW(사람 판단 대기)
       try {
-        const gt = require('./giip-task');
-        await gt.maybeFinish(channelId, pendingTask.isn, 'REVIEW', `❌ 작업 에러: ${err.message}${githubUrl ? `\n로그: ${githubUrl}` : ''}`);
-      } catch (e) { console.error('[Bot] giip finish 훅 오류:', e.message); }
+        if (pendingTask.isn) {
+          const gt = require('./giip-task');
+          await gt.maybeFinish(channelId, pendingTask.isn, 'REVIEW', `❌ 작업 에러: ${err.message}${allUrls.length ? `\nPR(부분): ${allUrls.join(' , ')}` : ''}`);
+        }
+      } catch (e) { console.error('[Bot] giip finish(error) 훅 오류:', e.message); }
+
+      const { prLines, skipLines, blockedLines } = renderRepoLines(reportUrl, multi);
+      await postMessage(channelId, [
+        `❌ *작업 에러* (\`${pendingTask.taskId}\`)${pendingTask.isn ? ` / giip #${pendingTask.isn}→REVIEW` : ''}: ${err.message}`,
+        ...(prLines.length ? ['', '🔀 부분 결과:', ...prLines] : []),
+        ...(blockedLines.length ? ['', ...blockedLines] : []),
+        ...(skipLines.length ? ['', ...skipLines] : []),
+      ].join('\n'), replyTs);
+
+      // 에러여도 작업트리 락은 해제됨 → 대기열의 다음 태스크를 자동 기동.
+      await drainNextQueued('task-error');
     },
-  }, workDir);
+  }, effWorkDir, execCtx);
 }
 
 // ── チャンネル Mention 処理 (Task ワークフロー) ───────────────────────────────
@@ -342,7 +678,7 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
   const cmd = text.trim().replace(/`/g, '').replace(/\s+/g, ' ').toLowerCase();
   console.log(`[Bot] handleChannelMention cmd="${cmd}" convKey="${convKey}"`);
 
-  // ── giip 커맨드 (giip api|issue|account|project) ──
+  // ── giip 커맨드 (giip api|issue|account) — giip issue 통일 (rule 39/40) ──
   try {
     const { handleGiipCommand } = require('./giip-commands');
     const gc = await handleGiipCommand(text.trim(), channelId);
@@ -350,14 +686,21 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
   } catch (e) { console.error('[Bot] giip command error:', e.message); }
 
   // ── "issue 등록 <내용>" — 分類器を通さず明示的に giip issue として登録 ──────
-  //   利用形: `<プロジェクト名> issue 등록 <内容>` / `issue 등록 <内容>`
-  //   (プロジェクト名は parseProjectPrefix で workDir/projectName に解決済み → text は接頭辞除去済み)
-  //   csn は project-csn.json のマッピング(projectName)で決定。未登録なら account 既定 csn にフォールバック。
+  //   利用形: `<プロジェクト名> issue 등록 <内容>` / `이슈 등록 <内容>`
+  //   （プロジェクト名は parseProjectPrefix で workDir に解決済み → text は接頭辞除去済み）
+  //   既存の task 自動連携(giip-task.maybeCreateIssue)は変更せず、明示登録の即時経路のみ追加。
   //   区切り(空白 / コロン / 文字列末)を必須にして「issue 등록됐어?」等の質問誤爆を防ぐ
-  //   (JS の \b は ASCII 専用でハングル境界を検出できないため明示的に区切りを要求)。
-  const issueTrigger = /^(?:issue|이슈|イシュー)\s*(?:등록|登録|register)(?:\s+|\s*[:：]\s*|$)/i;
+  //   （JS の \b は ASCII 専用でハングル境界を検出できないため明示的に区切りを要求）。
+  //   선두 `giip ` 도 허용: `giip issue 등록 …` == `giipprj issue 등록 …` (사용자 요청).
+  //   'giip' 는 projects/ 실폴더가 아니라 parseProjectPrefix 가 못 벗겨 workDir=BASE_DIR 로 남으므로
+  //   아래에서 이 형태만 workDir 을 giipprj 로 고정해 분석(작업지시서) 경로를 동일하게 탄다.
+  const issueTrigger = /^(?:giip\s+)?(?:issue|이슈|イシュー)\s*(?:등록|登録|register)(?:\s+|\s*[:：]\s*|$)/i;
   if (issueTrigger.test(text.trim())) {
     const body = text.trim().replace(issueTrigger, '').trim();
+    // `giip issue 등록 …`(선두 giip) → giipprj 프로젝트 등록과 동일 처리하도록 workDir 고정.
+    const effWorkDir = /^giip\s+/i.test(text.trim())
+      ? path.join(config.PROJECTS_ROOT, 'giipprj')
+      : workDir;
     if (!body) {
       await postMessage(channelId, '사용법: `<프로젝트> issue 등록 <내용>` — 내용을 그대로 giip issue 로 등록합니다.', replyTs);
       return;
@@ -373,12 +716,47 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
           replyTs);
         return;
       }
-      const csn = config.resolveProjectCsn(projectName || workDir);
-      const r = await giip.issueCreate(acct, { title, content: body.slice(0, 8000), status: 'PENDING', csn });
+      // giipprj(giipprj 폴더) 는 의뢰를 그대로 넣지 않고, 분석해 '작업지시서' 수준으로 등록한다.
+      //   무인 처리기(run-gissue-claude)의 refine([B]) 를 등록 시점에 앞당겨 수행하는 셈:
+      //   raw 본문은 content 로, 분석된 작업지시서는 코멘트로 붙이고 status=READY 로 두면
+      //   처리기 [C](READY + 지시서 코멘트)가 다음 :20/:40 에 바로 착수한다.
+      const isGiipprj = /(^|[\\/])giipprj$/i.test(String(effWorkDir).replace(/[\\/]+$/, ''));
+      if (isGiipprj) {
+        await postMessage(channelId, '🔍 의뢰 내용을 분석해 작업지시서로 정리 중입니다... (수십 초 소요)', replyTs);
+        let planContent = null;
+        try { ({ planContent } = tm.analyzeRequest(body, null, effWorkDir)); }
+        catch (e) { console.error('[Bot] issue 등록 분석 실패:', e.message); }
+
+        const specTitle = ((planContent && tm.extractTitle(planContent)) || title).slice(0, 200);
+        // create 는 항상 PENDING 으로(유실 방지). 분석 성공 시에만 작업지시서 코멘트 + READY 로 승격.
+        const r = await giip.issueCreate(acct, { title: specTitle, content: body.slice(0, 8000), status: 'PENDING', csn: config.resolveProjectCsn(projectName || effWorkDir) });
+        const isn = r && r.isn ? Number(r.isn) : null;
+        let promoted = false;
+        if (isn && planContent) {
+          try {
+            await giip.issueComment(acct, isn, `📋 작업지시서 (봇 자동 분석)\n\n${planContent}`.slice(0, 8000));
+            await giip.issueUpdate(acct, { isn, status: 'READY' }); // read-modify-write(제목·본문 보존)
+            promoted = true;
+          } catch (e) { console.error('[Bot] issue 작업지시서 첨부 실패:', e.message); }
+        }
+        await postMessage(channelId,
+          isn
+            ? [
+                `✅ giip issue #${isn} 등록 완료 (${promoted ? 'READY · 작업지시서 첨부 → 자동 처리 대기' : 'PENDING · 무인 refine 대기'})`,
+                `• 제목: ${specTitle}`,
+                ...(promoted ? ['', '```', planContent.slice(0, 1200), '```'] : []),
+              ].join('\n')
+            : '⚠️ issue 등록 응답에 isn 이 없습니다. 계정/CSN 설정을 확인하세요.',
+          replyTs);
+        return;
+      }
+      // 그 외 프로젝트: 의뢰를 그대로 PENDING 으로 등록(무인 처리기가 refine 부터 수행).
+      //   IN_PROGRESS 로 만들면 PENDING/READY 만 집는 처리기의 사각지대에 빠져 '먹통'이 된다.
+      const r = await giip.issueCreate(acct, { title, content: body.slice(0, 8000), status: 'PENDING', csn: config.resolveProjectCsn(projectName || effWorkDir) });
       const isn = r && r.isn ? Number(r.isn) : null;
       await postMessage(channelId,
         isn
-          ? `✅ giip issue #${isn} 등록 완료 (PENDING · csn=${csn ?? acct.csn ?? '-'})\n• 제목: ${title}`
+          ? `✅ giip issue #${isn} 등록 완료 (PENDING · 대기열 등록 → 자동 처리 대기)\n• 제목: ${title}`
           : '⚠️ issue 등록 응답에 isn 이 없습니다. 계정/CSN 설정을 확인하세요.',
         replyTs);
     } catch (e) {
@@ -395,6 +773,7 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
       '`@ボット名 <質問>` → その場で回答（曖昧な内容も質問扱い）',
       '`@ボット名 <作業依頼>` → Task 分析 → 確認 → 実行 → GitHub 結果 URL',
       '`@ボット名 タスク登録: <内容>` → 強制的に Task として登録',
+      '`@ボット名 <プロジェクト名> task <内容>` / `<プロジェクト名> 태스크등록 <内容>` → 先頭が task/태스크등록 なら強制 Task 登録',
       '',
       '*Task 管理:*',
       '• `tasklist` — 待機中 Task 一覧',
@@ -404,7 +783,8 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
       '• `go <Task番号>` — 指定した Task を実行',
       '• `cancel` — 待機中 Task の一覧を表示',
       '• `cancel <Task番号>` — 指定した Task をキャンセル',
-      '• `taskmerge` — 未完了の重複タスクを検出（プレビュー）',
+      '• `머지완료 <Task番号>` — 선행 PR 머지 후, 보류(⏸️)된 Task 를 rebase→PR 로 재개',
+      '• `taskmerge` — 未完了の重複タスクを検出（プレビュー） *別名: 중복 정리 / dedup / マージ*',
       '• `taskmerge go` — 重複タスクを統合（代表1件に集約し残りを取消）',
       '',
       '*ワークフロー:*',
@@ -425,13 +805,20 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
       '• `giip issue new "<title>"` — イシュー新規作成',
       '• `giip issue done|review|progress <isn>` — ステータス変更',
       '• `giip issue comment <isn> <text>` — コメント追加',
+      '• `giip project set <프로젝트명> <csn>` — プロジェクト名→CSN マッピング登録（`<프로젝트> issue 등록` 用）',
+      '• `giip project list` / `giip project del <프로젝트명>` — マッピング一覧 / 削除',
       '• `giip api <Verb> [jsondata]` — 汎用 giip API 呼び出し',
       '',
       '*情報:*',
       '• `!issues` — GitHub Issue 一覧',
       '• `!klayer <キーワード>` — K-Layer 検索',
+      '• `allowlist` — 허용된 user/channel 화이트리스트 표시',
       '• `!help` — ヘルプ',
     ].join('\n'), replyTs);
+    return;
+  }
+  if (cmd === 'allowlist' || cmd === '!allowlist') {
+    await postMessage(channelId, await buildAllowlistReply(), replyTs);
     return;
   }
   if (cmd === '!issues' || cmd === '!issues refresh') {
@@ -490,7 +877,7 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
   //     ゆるい形（name-first / 単語のみ）— 一般質問の誤爆を防ぐため .agent/workflows に
   //     完全一致する時だけ実行:
   //       `<プロジェクト> <名> 실행[해/해줘]` / `<名> 워크플로우 실행` / `<名> run|start` / `<名>`
-  //   例: `giipprj wf errorproc` / `giipprj errorproc 실행` / `giipprj /errorproc` → errorproc.md を実行。
+  //   例: `giipprj errorproc 실행` / `giipprj /errorproc` → giipprj/.agent/workflows/errorproc.md を実行。
   //   なぜ必須か: DB照会等の .ps1 を含むワークフローは、この実行経路（権限スキップ）
   //   でしか非対話 Slack セッションの権限ポリシーを越えられない。Q&A経路(callClaude)は
   //   skip 権限が無いため必ずブロックされる。ワークフローは必ずここへ載せること。
@@ -565,7 +952,7 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
       const taskFile = tm.createTaskFile(taskId, `[wfrun] ${projName}/${wfName}`, planContent, [wfPath]);
       const taskTitle = tm.extractTitle(planContent);
       const taskSummary = tm.extractSummary(planContent);
-      taskState.pending[convKey] = { taskId, taskTitle, taskFile, requestText: `wfrun ${wfName}` };
+      taskState.pending[convKey] = { taskId, taskTitle, taskFile, requestText: `wfrun ${wfName}`, workDir };
       saveJSON(TASK_STATE_FILE, taskState);
       tm.addToTasklist(taskId, taskTitle, taskSummary, `wfrun ${wfName}`);
       await postMessage(channelId,
@@ -645,7 +1032,7 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
   // ── taskmerge — 未完了の重複タスクを検出・統合 ─────────────────────────────
   //   `taskmerge`           → プレビュー（何を統合するか表示のみ、変更なし）
   //   `taskmerge go/실행/apply` → 実際に統合（重複を survivor に集約し残りを取消）
-  const mergeCmd = cmd.match(/^(?:taskmerge|task\s*merge|dedupe|중복\s*통합|타스크\s*통합|머지)(?:\s+(go|실행|확정|apply|yes|はい|실시))?$/);
+  const mergeCmd = cmd.match(/^(?:taskmerge|task\s*merge|merge\s*tasks|dedupe?|dupes|duplicates|consolidate|중복\s*통합|중복\s*정리|중복\s*제거|중복\s*태스크|태스크\s*정리|중복\s*찾기|타스크\s*통합|머지|タスク統合|重複統合|重複整理|マージ)(?:\s+(go|실행|실행해|확정|apply|yes|ok|はい|実行|실시))?$/);
   if (mergeCmd) {
     const doApply = !!mergeCmd[1];
     const clusters = findDuplicatePendingClusters();
@@ -682,8 +1069,45 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
     return;
   }
 
+  // ── 머지완료 <Task番号> — 선행 PR 머지 알림 → 보류했던 저장소를 rebase 후 PR ──────
+  //   PR 충돌 게이트(commitAndPRChangedRepos)로 'blocked' 된 태스크를 재개한다.
+  const mergedDone = cmd.match(/^(?:머지완료|머지됨|merge완료|merged)\s+(\d{14}|giip-\d{1,6})$/);
+  if (mergedDone) {
+    const targetId = mergedDone[1];
+    const entry = tm.getTasklistByStatus(null).find(t => t.taskId === targetId);
+    if (!entry || !Array.isArray(entry.blocked) || entry.blocked.length === 0) {
+      await postMessage(channelId, `⚠️ \`${targetId}\` 는 보류(blocked) 상태가 아닙니다. \`tasklist all\` 로 상태를 확인하세요.`, replyTs);
+      return;
+    }
+    await postMessage(channelId, `🔄 \`${targetId}\` 재개: 선행 PR 머지 반영(base pull→rebase) 후 PR 생성 중...`, replyTs);
+    let res;
+    try { res = tm.resumeBlockedTask(targetId, entry.title || targetId, entry.blocked); }
+    catch (e) { await postMessage(channelId, `❌ 재개 실패: ${e.message}`, replyTs); return; }
+
+    const lines = [];
+    for (const p of (res.prs || [])) lines.push(`🔀 PR (${path.basename(p.repo)}): ${p.url}`);
+    for (const s of (res.stillBlocked || [])) lines.push(`🚧 여전히 보류: ${path.basename(s.repo)} — ${s.reason}`);
+    for (const f of (res.failed || [])) lines.push(`⚠️ 실패: ${path.basename(f.repo)} — ${f.reason}`);
+
+    // 아직 해소 안 된 저장소(재-conflict/실패)만 blocked 로 남긴다.
+    const unresolved = new Set([...(res.stillBlocked || []).map(s => s.repo), ...(res.failed || []).map(f => f.repo)]);
+    const remainingBlocked = entry.blocked.filter(b => unresolved.has(b.repo));
+    tm.updateTasklistEntry(targetId, {
+      status: remainingBlocked.length ? 'blocked' : 'completed',
+      completedAt: new Date().toISOString(),
+      blocked: remainingBlocked.length ? remainingBlocked : undefined,
+    });
+    refreshDashboardSafe('task-resumed');
+    await postMessage(channelId, [
+      remainingBlocked.length ? `⏸️ *\`${targetId}\` 일부 재개*` : `✅ *\`${targetId}\` 재개 완료*`,
+      ...(lines.length ? lines : ['(변경 없음)']),
+      ...(remainingBlocked.length ? ['', '여전히 conflict/실패인 저장소는 수동 해소가 필요합니다. 해소 후 다시 `머지완료 ' + targetId + '`.'] : []),
+    ].join('\n'), replyTs);
+    return;
+  }
+
   // ── cancel <Task番号> — スレッド不問でどこからでもキャンセル ──────────────
-  const cancelWithId = cmd.match(/^(?:cancel|취소|キャンセル|中断)\s+(\d{14})$/);
+  const cancelWithId = cmd.match(/^(?:cancel|취소|キャンセル|中断)\s+(\d{14}|giip-\d{1,6})$/);
   if (cancelWithId) {
     const targetId = cancelWithId[1];
     const entry = Object.entries(taskState.pending || {}).find(([, t]) => t.taskId === targetId);
@@ -693,6 +1117,7 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
       saveJSON(TASK_STATE_FILE, taskState);
       tm.updateTasklistEntry(targetId, { status: 'cancelled', completedAt: new Date().toISOString() });
       try { tm.cancelTaskFile(targetId); } catch {}
+      refreshDashboardSafe('task-cancelled');
       await postMessage(channelId, `🚫 Task \`${targetId}\` をキャンセルしました。\n• ${task.taskTitle}`, replyTs);
     } else {
       const runEntry = Object.entries(taskState.running || {}).find(([, t]) => t.taskId === targetId);
@@ -705,6 +1130,7 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
           try {
             const dest = tm.cancelTaskFile(targetId);
             tm.updateTasklistEntry(targetId, { status: 'cancelled', completedAt: new Date().toISOString() });
+            refreshDashboardSafe('task-cancelled');
             await postMessage(channelId, `🚫 Task \`${targetId}\` をキャンセルしました。\n📁 移動先: \`${dest}\``, replyTs);
           } catch (err) {
             await postMessage(channelId, `⚠️ キャンセル失敗: ${err.message}`, replyTs);
@@ -738,13 +1164,13 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
   // ── go <Task番号> [追加指示] — スレッド不問で指定 Task を実行 ──────────────
   //   末尾に $ を張らず、`go <番号>` の後ろに続くテキストを「追加指示」として許容する。
   //   （旧: $ 固定 → コメント行を付けると bare go に落ちて Task 一覧が出るバグ）
-  const goWithId = cmd.match(/^(?:go|start|실행|시작|진행|実行|開始)\s+(\d{14})\b/);
+  const goWithId = cmd.match(/^(?:go|start|실행|시작|진행|実行|開始)\s+(\d{14}|giip-\d{1,6})\b/);
   if (goWithId) {
     const targetId = goWithId[1];
     // go <番号> の後ろに続くテキスト = その Task への「追加指示」。原文 text から抽出し
     //   (大小文字/改行/한글 保持)、Task ファイルへの追記は tm.appendTaskNote に委譲する。
     const extraNote = text.trim()
-      .replace(/^(?:go|start|실행|시작|진행|実行|開始)\s+\d{14}[ \t]*/i, '')
+      .replace(/^(?:go|start|실행|시작|진행|実行|開始)\s+(?:\d{14}|giip-\d{1,6})[ \t]*/i, '')
       .trim();
     const entry = Object.entries(taskState.pending || {}).find(([, t]) => t.taskId === targetId);
     if (!entry) {
@@ -760,7 +1186,7 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
         const titleMatch = fc.match(/^# TASK:\s*(.+)$/m);
         const taskTitle = titleMatch ? titleMatch[1].trim() : `タスク ${targetId}`;
         const pendingKeyNew = `${channelId}:${replyTs}`;
-        taskState.pending[pendingKeyNew] = { taskId: targetId, taskTitle, taskFile: taskFileFallback, requestText: '' };
+        taskState.pending[pendingKeyNew] = { taskId: targetId, taskTitle, taskFile: taskFileFallback, requestText: '', workDir };
         saveJSON(TASK_STATE_FILE, taskState);
         if (extraNote && tm.appendTaskNote(targetId, extraNote)) {
           await postMessage(channelId, `📎 追加指示 (${extraNote.length}字) を Task \`${targetId}\` に反映しました。`, replyTs);
@@ -806,7 +1232,7 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
   }
 
   // ── タスク番号による状況照会（14桁数字のみ or "status <14桁>"） ──────────
-  const taskStatusMatch = text.trim().replace(/`/g, '').match(/^(?:status\s+)?(\d{14})$/);
+  const taskStatusMatch = text.trim().replace(/`/g, '').match(/^(?:status\s+)?(\d{14}|giip-\d{1,6})$/);
   if (taskStatusMatch) {
     const targetId = taskStatusMatch[1];
     const taskFile = path.join(AGENT_DIR, 'tasks', `${targetId}.md`);
@@ -838,6 +1264,8 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
   //   注意: ここでの分類結果は下流の intent 判定でも再利用し、二重の classifyRequest 呼び出しを避ける。
   let preIntent = null;        // この分岐で確定した意図（下流で再分類しないため）
   let refTaskContext = '';     // 修正依頼時に本文へ付加する親タスク文脈
+  let reuseTaskId = null;      // 既存タスクID言及の修正依頼 → 新規発給せずこのIDを更新する
+  let linkedIsn = null;        // 既存 giip issue 番号への言及 → 新規 task/issue を作らず #NNN に紐付ける
   const mentionedIds = extractExistingTaskIds(text);
   if (mentionedIds.length > 0) {
     const targetId = mentionedIds[0];
@@ -848,7 +1276,7 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
     ].find(f => fs.existsSync(f));
 
     // テキストがタスクID単独（些末な語のみ）か、指示を含むかを判定
-    const isOnlyId = text.trim().replace(/`/g, '').match(/^(\d{14}|\d{8}_[\w-]+)$/);
+    const isOnlyId = text.trim().replace(/`/g, '').match(/^(\d{14}|\d{8}_[\w-]+|giip-\d{1,6})$/);
     if (isOnlyId) {
       // ① ID単独 → 状態表示のみ（新規タスクは作らない）
       if (activeFile) {
@@ -868,7 +1296,7 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
     }
 
     // ID以外の指示を含む → 意図を判定（下流と共有するため preIntent に保持）
-    preIntent = await classifyRequest(text, workDir);
+    preIntent = isForceTaskCmd(text) ? 'task' : await classifyRequest(text, workDir);
     if (preIntent === 'question') {
       // ② 質問 → その場で回答（タスクファイルのパスをコンテキストとして付加）
       const taskContext = activeFile
@@ -878,15 +1306,53 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
       return;
     }
 
-    // ③ 修正・再実行依頼（task）→ 拒否せず、親タスクを文脈に付けて通常のタスク生成フローへ流す
+    // ③ 修正・再実行依頼（task）→ 新規タスクは作らず、参照された既存タスクIDを更新する。
+    //    （ユーザ指摘: タスク番号を指定した返信は、その番号のファイルに追記すべきで、
+    //      別番号の新規ファイルを量産してはならない）
     if (activeFile) {
+      reuseTaskId = targetId;
       refTaskContext = `\n\n[修正対象] このリクエストは既存タスク ${targetId}（${activeFile}）に対する修正/再実行依頼です。元タスクの内容・成果物を踏まえて対応してください。`;
       await postMessage(channelId,
-        `🔧 タスク \`${targetId}\` への修正依頼として受け付けました。内容を分析して新しいタスクを作成します。`,
+        `🔧 タスク \`${targetId}\` への修正依頼として受け付けました。新規タスクは作らず、このタスクを更新します。`,
         replyTs
       );
     }
-    // ここで return せず、下流の「タスク確定 → 分析 → 作成」フローへ落とす
+    // ここで return せず、下流の「タスク確定 → 分析 → 更新/作成」フローへ落とす
+  }
+
+  // ── 既存 giip issue 番号への言及 → 新規 task 番号/新規 issue を作らず #NNN に紐付けて処理 ──
+  //   ユーザ指摘(D): issue 番号を指定して処理を頼んだのに新規 task 番号が発給され、さらに #610 のような
+  //   二重 issue まで作られた。既存 issue があるなら実行単位を giip-<isn> に固定(冪等)し、下流の
+  //   reuseTaskId 経路に載せて maybeCreateIssue(新規 issue 作成)をスキップ、#NNN へ紐付け・状態遷移する。
+  //   `admin/giip-issues/609 처리해줘` / `giip issue #609 …` 等の URL・自然文経路を拾う(番号のみ get は giip-commands 側)。
+  if (!reuseTaskId) {
+    const isn = extractGiipIssueRef(text);
+    if (isn) {
+      const forcedGiip = isForceTaskCmd(text);
+      const gIntent = forcedGiip ? 'task' : (preIntent || await classifyRequest(text, workDir));
+      preIntent = gIntent; // 下流の再分類を避けるため確定意図を共有
+      if (gIntent === 'task') {
+        linkedIsn = isn;
+        reuseTaskId = `giip-${isn}`;
+        // DB(SSOT)에서 이슈 본문 + 전체 코멘트 이력을 가져와 재처리 컨텍스트로 주입한다.
+        //   재처리 시점엔 로컬 태스크 파일이 done/ 이동·타 클론 처리로 없을 수 있으나, 코멘트 이력은
+        //   DB 에 남아 있으므로 전체를 읽어 맥락을 이어가야 한다(사용자 지적). best-effort.
+        let giipHistoryBlock = '';
+        try {
+          const hist = await require('./giip-task').fetchIssueHistory(channelId, isn);
+          if (hist && hist.digest) giipHistoryBlock =
+            `\n\n[DB에서 복원한 이슈 이력 — 아래 코멘트 히스토리를 시간순으로 모두 읽고 맥락을 반영해 처리하라]\n${hist.digest}`;
+        } catch (e) { console.error('[Bot] giip 이슈 이력 조회 실패(비치명):', e.message); }
+        refTaskContext = `\n\n[対象 giip issue] このリクエストは既存 giip issue #${isn} の処理依頼です。まず #${isn} の内容を確認し(giip issue get ${isn} 相当)、作業後は結果を #${isn} にコメントして状態遷移してください。新しい issue は作成しないこと。${giipHistoryBlock}`;
+        await postMessage(channelId,
+          forcedGiip
+            // 「처리해줘」等の明示的命令形 = go と等価 → 分析後そのまま自動実行（go 不要）。
+            ? `🔗 giip issue #${isn} の処理依頼として受け付けました。新規 issue/タスク番号は作らず、この issue に紐付けて *そのまま実行* します（\`go\` 不要）。`
+            : `🔗 giip issue #${isn} への処理依頼として受け付けました。新規 issue/タスク番号は作らず、この issue に紐付けて実行します(実行: \`go giip-${isn}\`)。`,
+          replyTs
+        );
+      }
+    }
   }
 
   // ── 実行中チェック ────────────────────────────────────────────────────────
@@ -900,9 +1366,12 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
   }
 
   // ── 意図を分類してルーティング ──────────────────────────────────────────────
+  // 明示的タスク作成キーワードがあれば分類器をバイパスして強制 task 化する。
+  // （質問形で始まる複合文の question 誤分類 → 番号未発給を防ぐ）
+  const forcedTask = isForceTaskCmd(text);
   // preIntent（既存タスクID分岐で確定済み）があれば再分類せず流用する
-  const intent = preIntent || await classifyRequest(text, workDir);
-  console.log(`[Bot] intent="${intent}"${preIntent ? ' (reused)' : ''} text="${text.slice(0, 60)}"`);
+  const intent = forcedTask ? 'task' : (preIntent || await classifyRequest(text, workDir));
+  console.log(`[Bot] intent="${intent}"${forcedTask ? ' (forced)' : preIntent ? ' (reused)' : ''} text="${text.slice(0, 60)}"`);
 
   if (intent === 'question') {
     // 質問・曖昧 → その場で回答（スレッド内なら全文脈を渡す）
@@ -911,8 +1380,8 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
   }
 
   // ── タスク確定 → 類似タスク自動クローズ → Task 分析 ──────────────────────
-  // 同一内容の旧タスクを自動検出してクローズ
-  const similarTasks = findSimilarPendingTasks(text);
+  // 同一内容の旧タスクを自動検出してクローズ（既存タスクID更新時はクローズしない）
+  const similarTasks = reuseTaskId ? [] : findSimilarPendingTasks(text);
   let closedNotice = '';
   if (similarTasks.length > 0) {
     const closedLines = [];
@@ -941,29 +1410,68 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
     return;
   }
 
-  const taskId = tm.getTimestampId();
-  const taskFile = tm.createTaskFile(taskId, taskRequestText, planContent, filesRead);
   const taskTitle = tm.extractTitle(planContent);
   const taskSummary = tm.extractSummary(planContent);
 
-  taskState.pending[convKey] = { taskId, taskTitle, taskFile, requestText: taskRequestText };
-  saveJSON(TASK_STATE_FILE, taskState);
-  tm.addToTasklist(taskId, taskTitle, taskSummary, taskRequestText);
-
-  // ── giip issue 통일(rule 40): 연결 시 issue 우선 등록(IN_PROGRESS). 실패/미연결 시 로컬 태스크만. ──
+  // ── giip issue 통일(rule 40): 연결돼 있으면 issue 를 "먼저" 등록(PENDING)하고 그 번호(giip-<isn>)를
+  //   태스크 ID 로 삼는다 → 한 작업 = ID 하나. 미연결/실패 시에만 로컬 타임스탬프로 폴백한다.
+  //   (과거: 타임스탬프를 항상 먼저 발급하고 issue 를 그 위에 덧붙여 ID 두 개[타임스탬프+isn]가 생겼다)
+  //   상태전이(IN_PROGRESS)는 분석이 아니라 실행 시작(startTaskExecution)에서만 한다.
   let giipIsn = null;
-  try {
-    const gt = require('./giip-task');
-    // csn 은 처음 언급한 프로젝트명(projectName, 폴더 없어도 해석) 기준(project-csn.json). 없으면 account.csn 폴백.
-    giipIsn = await gt.maybeCreateIssue(channelId, taskTitle, planContent, config.resolveProjectCsn(projectName || workDir));
-    if (giipIsn) { taskState.pending[convKey].isn = giipIsn; saveJSON(TASK_STATE_FILE, taskState); }
-  } catch (e) { console.error('[Bot] giip issue 등록 훅 오류:', e.message); }
-  const isnLine = giipIsn ? `\n🔗 giip issue #${giipIsn} (IN_PROGRESS)` : '';
+  let giipIssueError = null; // API 호출 자체가 실패한 경우의 사유(csn/계정 미설정과 구분해 사용자에게 알리기 위함)
+  if (linkedIsn) {
+    // 既存 issue 참조: 新規作成せず #linkedIsn を再利用(reuseTaskId は既に giip-<isn>)。
+    giipIsn = linkedIsn;
+  } else if (!reuseTaskId) {
+    try {
+      const gt = require('./giip-task');
+      // csn 은 처음 언급한 프로젝트명(projectName, 폴더 없어도 해석) 기준(project-csn.json). 없으면 account.csn 폴백.
+      const res = await gt.maybeCreateIssue(channelId, taskTitle, planContent, config.resolveProjectCsn(projectName || workDir));
+      giipIsn = res.isn;
+      giipIssueError = res.error;
+    } catch (e) { console.error('[Bot] giip issue 등록 훅 오류:', e.message); }
+  }
 
+  // ID 통일: 기존 태스크 갱신이면 그 ID, 신규+issue 등록 성공이면 giip-<isn>, 그 외엔 타임스탬프.
+  const taskId = reuseTaskId || (giipIsn ? `giip-${giipIsn}` : tm.getTimestampId());
+  const taskFile = reuseTaskId
+    ? tm.updateTaskFile(taskId, taskRequestText, planContent, filesRead)
+    : tm.createTaskFile(taskId, taskRequestText, planContent, filesRead);
+
+  taskState.pending[convKey] = { taskId, taskTitle, taskFile, requestText: taskRequestText, workDir };
+  if (giipIsn) taskState.pending[convKey].isn = giipIsn;
+  saveJSON(TASK_STATE_FILE, taskState);
+  if (reuseTaskId) {
+    tm.updateTasklistEntry(taskId, { title: taskTitle, summary: taskSummary, status: 'pending', updatedAt: new Date().toISOString() });
+  } else {
+    tm.addToTasklist(taskId, taskTitle, taskSummary, taskRequestText);
+  }
+  refreshDashboardSafe('task-created'); // 대기 항목이 바로 대시보드에 뜨도록
+  // giipIssueError 가 있으면 "csn/계정 미설정으로 조용히 로컬 폴백"이 아니라 API 호출이 실제로 실패한
+  //   것이므로 사유를 노출한다(과거: 둘 다 같은 타임스탬프 ID 로만 보여 원인을 구분할 수 없었다).
+  const isnLine = giipIsn
+    ? `\n🔗 giip issue #${giipIsn}`
+    : (giipIssueError ? `\n⚠️ giip issue 연동 실패(${giipIssueError}) — 로컬 태스크 번호로 진행합니다` : '');
+
+  // 明示的命令形(처리/수정/구현…해줘 = isForceTaskCmd)は「実行の意思確定」= go と等価。
+  //   分析後そのまま実行し、redundant な二度目の `go` を要求しない(ユーザ指摘の恒久対応)。
+  //   曖昧・LLM 分類による task は従来どおり plan+go ゲートを維持する。
+  const autoExec = forcedTask;
+  const footer = autoExec
+    ? `*🚀 明示的な依頼のため自動実行します（\`go\` 不要）。中断: \`cancel ${taskId}\`*`
+    : `*実行: \`go ${taskId}\` / キャンセル: \`cancel ${taskId}\`*`;
+
+  const headline = (reuseTaskId && !linkedIsn) ? 'Task 更新完了' : 'Task 分析完了';
   await postLong(channelId,
-    `📋 *Task 分析完了* (\`${taskId}\`)${isnLine}${closedNotice}\n\n${planContent}\n\n---\n*実行: \`go ${taskId}\` / キャンセル: \`cancel ${taskId}\`*`,
+    `📋 *${headline}* (\`${taskId}\`)${isnLine}${closedNotice}\n\n${planContent}\n\n---\n${footer}`,
     replyTs
   );
+
+  if (autoExec) {
+    // pending → running へ即遷移して実行(go <id> と等価)。作業ツリー busy 時は
+    //   startTaskExecution が pending に戻し「go で後ほど再実行」を案内する(直列実行は維持)。
+    await startTaskExecution(convKey, taskState.pending[convKey], channelId, replyTs, taskState, workDir);
+  }
 }
 
 // pending/running task があるスレッドかどうかを確認
@@ -979,7 +1487,12 @@ async function processMessage({ channelId, msg, isDM, conversations, threadTs })
   const effectiveThreadTs = threadTs || msg.thread_ts || null;
   const mentionsBot = config.getBotUserId() && msg.text.includes(`<@${config.getBotUserId()}>`);
   const isTaskReply = isActiveTaskThread(channelId, effectiveThreadTs);
-  const isEngagedThread = isBotEngagedThread(channelId, effectiveThreadTs);
+  // giip-773: other-bot mention also qualifies — bot間对话対応
+  const mentionsOtherBot = !mentionsBot && /<@[A-Z0-9]+>/.test(msg.text);
+  // giip-729: 채널에서는 "명시 멘션 + 활성 태스크 스레드"만 응답한다.
+  // 과거의 isBotEngagedThread(7일간 봇이 한 번이라도 말한 스레드) 자동응답은
+  // 봇이 참여했던 스레드의 사람들끼리의 일반 대화(무멘션)까지 개입하게 만들어 제거.
+  // 활성 태스크(pending/running)의 후속 입력은 isTaskReply 로 계속 허용된다.
 
   const rawCleanText = msg.text
     .replace(/<@[A-Z0-9]+>/g, '')
@@ -997,14 +1510,14 @@ async function processMessage({ channelId, msg, isDM, conversations, threadTs })
 
   // プロジェクトプレフィックス検出: "giipprj 何か" → giipprj フォルダに切り替え
   //   さらにチャンネル固定マッピング(channel-project.json)を適用: 明示接頭辞が無ければ
-  //   このチャンネルの既定プロジェクトへ workDir/projectName を固定する。
+  //   このチャンネルの既定プロジェクトへ workDir/projectName を固定する（task giip-724）。
   //   優先順位: 明示接頭辞(Rule 32) > チャンネル固定。cleanText は不変。
   const { workDir, cleanText, projectName } =
     config.applyChannelPin(channelId, parseProjectPrefix(rawCleanText));
 
   const hasFiles = msg.files && msg.files.length > 0;
   if (hasFiles && !cleanText) {
-    if (mentionsBot || isEngagedThread) {
+    if (mentionsBot || mentionsOtherBot || isTaskReply) {
       await postMessage(channelId, '画像やファイルのみのメッセージは処理できません。テキストで質問してください。', effectiveThreadTs || msg.ts);
     }
     return;
@@ -1013,14 +1526,15 @@ async function processMessage({ channelId, msg, isDM, conversations, threadTs })
 
   if (isDM) {
     await handleDM({ channelId, ts: msg.ts, threadTs: effectiveThreadTs, text: cleanText, conversations, workDir });
-  } else if (mentionsBot || isTaskReply || isEngagedThread) {
+  } else if (mentionsBot || mentionsOtherBot || isTaskReply) {
     await handleChannelMention({ channelId, ts: msg.ts, threadTs: effectiveThreadTs, text: cleanText, workDir, projectName });
   }
 }
 
 // ── Socket Mode イベントハンドラ ─────────────────────────────────────────────
 async function onSlackMessage(event, conversations) {
-  if (event.bot_id || event.subtype || !event.text) return;
+  // 다른 봇과는 대화 가능(giip-773 후속 지시, 2026-07-26) — 자기 자신이 보낸 메시지만 걸러 무한루프 방지.
+  if ((event.bot_id && event.bot_id === config.getSelfBotId()) || event.subtype || !event.text) return;
   const isDM = event.channel_type === 'im';
   try {
     await processMessage({ channelId: event.channel, msg: event, isDM, conversations });
@@ -1035,6 +1549,7 @@ module.exports = {
   answerInChannel,
   handleDM,
   startTaskExecution,
+  drainNextQueued,     // index.js の起動/定期リカバリが凍結キューを解凍するために使う
   handleChannelMention,
   isActiveTaskThread,
   processMessage,

--- a/slack-bot/index.js
+++ b/slack-bot/index.js
@@ -22,7 +22,7 @@ const { SocketModeClient } = require('@slack/socket-mode');
 // ── 機能別モジュール (index.js から behavior-preserving で切り出し) ───────────
 const config = require('./config');
 const { BOT_TOKEN, CHANNEL_IDS, SLACK_APP_TOKEN, AGENT_DIR, HISTORY_FILE, TASK_STATE_FILE } = config;
-const { loadJSON, saveJSON } = require('./state');
+const { loadJSON, saveJSON, isBotEngagedThread } = require('./state');
 const { slackGet } = require('./slack-api');
 const { onSlackMessage, drainNextQueued } = require('./handlers');
 
@@ -292,23 +292,39 @@ async function main() {
     return config.ALLOWED_USERS.includes(userId);
   };
 
+  // 채널 화이트리스트: 설정된 경우 등록되지 않은 채널의 입력은 무시(DM은 항상 허용, CHANNEL_IDS 무관).
+  const isAllowedChannel = (channelId) => {
+    if (config.CHANNEL_IDS.length === 0) return true;
+    return config.CHANNEL_IDS.includes(channelId);
+  };
+
   // チャンネルでの @mention (app_mention イベント)
   socketClient.on('app_mention', async ({ event, ack }) => {
     await safeAck(ack);
     if (!isAllowedUser(event.user)) return; // 발신자 검증
+    if (!isAllowedChannel(event.channel)) return; // 채널 검증
     console.log('[Bot] app_mention:', event.channel, (event.text || '').slice(0, 60));
     await onSlackMessage(event, conversations);
   });
 
   // DM・スレッド返信 (message イベント — message.im / message.channels 購読時)
   // @mention を含むチャンネルメッセージは app_mention で処理済みのためスキップ
-  // giip-773: 他のボットへの @mention 也有効 — 自分宛のみ app_mention で重複スキップ
+  // giip-773 の意図は「自分が(他ボットと並んで)メンションされたら答える」であって
+  // 「自分宛でなくても(他ボット宛/無メンションの雑談でも)反応する」ことではない。
+  // 元の実装は「自分宛メンションでなければ全部処理」になっており、同一チャンネルに同居する
+  // 別ボット宛のメッセージにまで反応して誤ったタスクを実行する事故につながる。
+  // 修正: 自分宛メンション(app_mention 側で処理済み)以外は、自分が既に関与したスレッドの
+  // 続きだけを処理する。
   socketClient.on('message', async ({ event, ack }) => {
     await safeAck(ack);
     if (!isAllowedUser(event.user)) return; // 발신자 검증
+    if (!isAllowedChannel(event.channel)) return; // 채널 검증
     const isDM = event.channel_type === 'im';
     const mentionsBot = config.getBotUserId() && (event.text || '').includes(`<@${config.getBotUserId()}>`);
-    if (!isDM && mentionsBot) return; // app_mention ハンドラで処理済み — 重複スキップ
+    if (!isDM) {
+      if (mentionsBot) return; // app_mention ハンドラで処理済み — 重複スキップ
+      if (!isBotEngagedThread(event.channel, event.thread_ts)) return; // 미관여 채널 발화는 무시
+    }
     console.log('[Bot] message:', event.channel_type, (event.text || '').slice(0, 60));
     await onSlackMessage(event, conversations);
   });

--- a/slack-bot/index.js
+++ b/slack-bot/index.js
@@ -16,14 +16,15 @@ const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
 const tm = require('./task-manager');
+const minimax = require('./minimax-accounts');
 const { SocketModeClient } = require('@slack/socket-mode');
 
-// ── 機能別モジュール (index.js から切り出し) ─────────────────────────────────
+// ── 機能別モジュール (index.js から behavior-preserving で切り出し) ───────────
 const config = require('./config');
 const { BOT_TOKEN, CHANNEL_IDS, SLACK_APP_TOKEN, AGENT_DIR, HISTORY_FILE, TASK_STATE_FILE } = config;
 const { loadJSON, saveJSON } = require('./state');
 const { slackGet } = require('./slack-api');
-const { onSlackMessage } = require('./handlers');
+const { onSlackMessage, drainNextQueued } = require('./handlers');
 
 // ── 重複プロセス検出・自己終了 ───────────────────────────────────────────────
 function killDuplicateBots() {
@@ -49,57 +50,151 @@ function killDuplicateBots() {
 }
 
 // ── stale タスク状態のクリーンアップ（起動時 + 定期実行） ─────────────────────
-// ボットが再起動した際・稼働中定期的に、残存タスク状態を reconcile する。
-// - running: done/·cancel/ にファイルあれば除去(完了/取消)。tasks/ にも無い＝行方不明は
-//   起動時(staleMinutes=0)は即除去、定期実行は staleMinutes 経過分のみ(生存実行を保護)。
-// - pending(신규): done/·cancel/ で既に해소된 orphan pending を掃除。
-//   (従来 reconcile は running のみ触り pending が無限累積した — Lowyworkenv 라이브본과 동일 보완.)
-//   ※ tasks/ 直下に残る＝未着手 backlog は触らない(手動処理待ちを尊重)。
+// running のまま滞留したタスクを実ファイルの位置と経過時間で最終化する。
+// 判定ソース = tasklist.json の running + .task-state.json の running（ライブロック）。
+//   - done/   にファイルあり → completed（resultUrl 付与）
+//   - cancel/ にファイルあり → cancelled（resultUrl 付与）
+//   - どちらでもない（tasks/ 直下に残る or 消失）＝ 中断された未完了タスク:
+//       経過が staleMinutes 以上なら pending へ復帰（再実行待ち）、未満なら実行中の可能性ありとして触らない。
+//
+// staleMinutes:
+//   0  … 起動時。再起動直後の running は全て孤児（サブプロセスは死んでいる）→ 即 reconcile。
+//   30 … 定期実行。生きている実行を巻き込まないよう 30 分以上経過したものだけ pending 復帰。
 function reconcileTaskState({ staleMinutes = 0 } = {}) {
   const taskState = loadJSON(TASK_STATE_FILE, { pending: {}, running: {} });
   const TASKS_DIR = path.join(AGENT_DIR, 'tasks');
   const nowMs = Date.now();
-  let changed = false;
+  let stateChanged = false;
 
-  // ── pending 스윕 ──
+  // ── pending 스윕(신규) ────────────────────────────────────────────────────
+  // reconcile 은 원래 running 만 청소해 pending 은 무한 누적됐다(orphan). 세션·수동
+  // 처리 등 다른 경로로 이미 해소돼 task 파일이 done/·cancel/ 로 이동된 pending 항목을
+  // 여기서 정리한다. 파일이 tasks/ 직하에 남은 = 진짜 미착수 backlog 는 건드리지 않는다
+  // (마커 없는 pending = 수동 `go` 대기라는 drainNextQueued 설계를 존중).
   const isResolved = (tid) =>
     fs.existsSync(path.join(TASKS_DIR, 'done', `${tid}.md`)) ||
     fs.existsSync(path.join(TASKS_DIR, 'cancel', `${tid}.md`));
   for (const [key, entry] of Object.entries(taskState.pending || {})) {
     if (entry && entry.taskId && isResolved(entry.taskId)) {
       delete taskState.pending[key];
-      changed = true;
+      stateChanged = true;
       console.log(`[Bot] reconcile: stale pending ${entry.taskId} 제거 (done/cancel 로 이미 해소)`);
     }
   }
 
-  // ── running reconcile ──
+  // taskId → .task-state.running のキー（ライブロック除去用）
+  const runningKeyByTaskId = {};
   for (const [key, entry] of Object.entries(taskState.running || {})) {
-    const taskId = entry.taskId;
-    const inDone   = fs.existsSync(path.join(TASKS_DIR, 'done',   `${taskId}.md`));
-    const inCancel = fs.existsSync(path.join(TASKS_DIR, 'cancel', `${taskId}.md`));
-    const inPending = fs.existsSync(path.join(TASKS_DIR, `${taskId}.md`));
-
-    if (inDone || inCancel) {
-      const reason = inDone ? 'done' : 'cancelled';
-      console.log(`[Bot] reconcile: task ${taskId} (${reason}) — removing from running`);
-      delete taskState.running[key];
-      tm.updateTasklistEntry(taskId, { status: inDone ? 'completed' : 'cancelled' });
-      changed = true;
-    } else if (!inPending) {
-      // tasks/·done/·cancel/ 어디에도 없음 = 행방불명. 재시작 직후엔 서브프로세스가 죽어
-      // 즉시 정리, 정기 실행 땐 staleMinutes 경과분만(생존 실행 보호).
-      const started = entry.startedAt ? Date.parse(entry.startedAt) : NaN;
-      const ageMin = isNaN(started) ? Infinity : (nowMs - started) / 60000;
-      if (ageMin < staleMinutes) continue;
-      console.log(`[Bot] reconcile: task ${taskId} (missing) — removing from running`);
-      delete taskState.running[key];
-      tm.updateTasklistEntry(taskId, { status: 'cancelled' });
-      changed = true;
-    }
+    if (entry && entry.taskId) runningKeyByTaskId[entry.taskId] = key;
   }
 
-  if (changed) saveJSON(TASK_STATE_FILE, taskState);
+  // 対象 = tasklist.json の running ∪ .task-state.json の running（片方漏れ対策）
+  const runningList = tm.getTasklistByStatus('running');
+  const startedAtByTaskId = {};
+  const runningTaskIds = new Set();
+  for (const t of runningList) {
+    runningTaskIds.add(t.taskId);
+    startedAtByTaskId[t.taskId] = t.startedAt || null;
+  }
+  for (const [taskId, key] of Object.entries(runningKeyByTaskId)) {
+    runningTaskIds.add(taskId);
+    if (!(taskId in startedAtByTaskId)) {
+      const e = taskState.running[key];
+      startedAtByTaskId[taskId] = (e && e.startedAt) || null;
+    }
+  }
+  if (!runningTaskIds.size) { if (stateChanged) saveJSON(TASK_STATE_FILE, taskState); return; }
+
+  for (const taskId of runningTaskIds) {
+    const inDone   = fs.existsSync(path.join(TASKS_DIR, 'done',   `${taskId}.md`));
+    const inCancel = fs.existsSync(path.join(TASKS_DIR, 'cancel', `${taskId}.md`));
+
+    let resolution;
+    if (inDone) {
+      resolution = 'completed';
+    } else if (inCancel) {
+      resolution = 'cancelled';
+    } else {
+      // tasks/ 直下に残る or 消失 = 中断された未完了。経過時間で pending 復帰を判断。
+      const started = startedAtByTaskId[taskId] ? Date.parse(startedAtByTaskId[taskId]) : NaN;
+      const ageMin = isNaN(started) ? Infinity : (nowMs - started) / 60000;
+      if (ageMin < staleMinutes) continue; // まだ実行中の可能性 → 触らない
+      resolution = 'pending';
+    }
+
+    if (resolution === 'completed' || resolution === 'cancelled') {
+      tm.updateTasklistEntry(taskId, {
+        status: resolution,
+        completedAt: new Date().toISOString(),
+        resultUrl: tm.getTaskFileUrl(taskId) || null,
+      });
+    } else { // pending 復帰
+      tm.updateTasklistEntry(taskId, { status: 'pending', startedAt: null, completedAt: null });
+    }
+
+    const key = runningKeyByTaskId[taskId];
+    // 크래시(소켓 self-heal exit 등) 후 pending 복귀 시점에, 실행이 실제로 시작됐었다면
+    // (prepareNestedBranches 로 nested repo 가 bot/task-<id> 에 남아있을 수 있음) 안전하게
+    // 회수를 시도하고, 연관 giip issue 가 있으면 무슨 일이 있었는지 note 코멘트로 남긴다
+    // (2026-07-28: "IN_PROGRESS 전이 전 크래시 → 아무 흔적도 안 남는" 갭 메움).
+    if (resolution === 'pending' && key) {
+      const entry = taskState.running[key];
+      const isn = entry && entry.isn;
+      const entryWorkDir = entry && entry.workDir;
+      if (entryWorkDir) {
+        try {
+          const { restored, stranded } = tm.reclaimCrashedTaskBranches(entryWorkDir, taskId);
+          if (restored.length || stranded.length) {
+            console.log(`[Bot] reconcile: ${taskId} 크래시 회수 — 자동복원 ${restored.length}건, stranded ${stranded.length}건`);
+          }
+          if (isn) {
+            const channelId = key.split(':')[0];
+            const lines = [
+              `[WARN] 이전 처리 시도가 봇 재시작(소켓 끊김 등 self-heal exit)으로 중단되어 PENDING으로 복귀했습니다.`,
+              `실행이 시작된 뒤 완료되지 못해 이 issue 는 IN_PROGRESS 로 전이되지 못했습니다(정상 — 실행 안 되는데 IN_PROGRESS로 보이는 모순 방지).`,
+            ];
+            if (restored.length) lines.push(`자동 복원된 저장소(취소분 정리): ${restored.map(r => path.basename(r)).join(', ')}`);
+            if (stranded.length) lines.push(`⚠️ 미커밋 변경이 남아 자동 복원하지 못한 저장소(확인 필요): ${stranded.map(r => path.basename(r)).join(', ')}`);
+            lines.push(`재개하려면: \`go ${taskId}\``);
+            require('./giip-task').maybeComment(channelId, isn, lines.join('\n')).catch(() => {});
+          }
+        } catch (e) {
+          console.error(`[Bot] reconcile: ${taskId} 크래시 회수 오류:`, e.message);
+        }
+      }
+    }
+    if (key && taskState.running[key]) {
+      delete taskState.running[key];
+      stateChanged = true;
+    }
+    console.log(
+      `[Bot] reconcile: task ${taskId} → ${resolution}` +
+      (resolution === 'pending' ? ` (running ${staleMinutes}m+ 정체 → 재실행 대기)` : '')
+    );
+  }
+
+  if (stateChanged) saveJSON(TASK_STATE_FILE, taskState);
+}
+
+// ── 凍結キューのリカバリ（ghost-occupier freeze 対策） ────────────────────────
+// 直列実行のため、他タスクが作業ツリーを占有中に来たタスクは pending に
+// `queuedBehind` マーカ付きで積まれ、占有タスクの onComplete/onError が
+// drainNextQueued を呼んで初めて自動起動する。ところが占有タスク実行中にボットが
+// 再起動すると、そのサブプロセスは死に onComplete が永遠に発火しない＝
+// queuedBehind の待機タスクは誰にも起動されず「凍結」する（ユーザ報告の“멈춤”の主因）。
+// running が空なのに queuedBehind 待機タスクがある＝この凍結状態なので、ここで一度
+// drainNextQueued を叩いて直列キューを解凍する。running が生きていれば通常経路に任せる。
+async function recoverQueuedOnStartup(reason = 'startup-recovery') {
+  try {
+    const ts = loadJSON(TASK_STATE_FILE, { pending: {}, running: {} });
+    if (Object.keys(ts.running || {}).length > 0) return; // 実行中 → 通常の drain 経路が処理
+    const queued = Object.values(ts.pending || {}).filter(t => t && t.queuedBehind);
+    if (!queued.length) return;
+    console.log(`[Bot] ${reason}: 凍結された待機タスク ${queued.length}件 감지 → drain 시도`);
+    await drainNextQueued(reason);
+  } catch (e) {
+    console.error('[Bot] recoverQueuedOnStartup error:', e.message);
+  }
 }
 
 // ── 起動 ──────────────────────────────────────────────────────────────────────
@@ -113,21 +208,33 @@ async function main() {
   const auth = await slackGet('auth.test');
   if (!auth.ok) { console.error('[Bot] SLACK_BOT_TOKEN 無効:', auth.error); process.exit(1); }
   config.setBotUserId(auth.user_id);
+  config.setSelfBotId(auth.bot_id || null);
 
   console.log('[giipclaude Bot] 起動 — Socket Mode');
   console.log(`[Bot] ID: ${config.getBotUserId()} (${auth.user}) PID: ${process.pid}`);
   console.log(`[Bot] 監視チャンネル: ${CHANNEL_IDS.join(', ') || '(DM のみ)'}`);
+  // 実行エンジン優先順位を起動時に明示する。MINIMAX_API_KEY 未設定だと MiniMax は
+  // 黙って skip され全部 Claude に流れるため（設定漏れが無症状になる）、ここで可視化する。
+  const mmBoot = minimax.resolve();
+  console.log(mmBoot
+    ? `[Bot] 実行エンジン: MiniMax(${mmBoot.model}) 優先 → 失敗時 Claude フォールバック`
+    : '[Bot] 実行エンジン: Claude のみ (MINIMAX_API_KEY 未設定 → MiniMax スキップ)');
 
   killDuplicateBots();
-  // 起動時: 再起動で孤児化した running を即 reconcile + orphan pending 스윕
+  // 起動時: 再起動で孤児化した running を即 reconcile（サブプロセスは既に死亡）
   reconcileTaskState({ staleMinutes: 0 });
+  // 起動時: 占有タスクの死で凍結した queuedBehind 待機タスクを解凍（ghost-occupier freeze）
+  await recoverQueuedOnStartup('startup-recovery');
 
-  // 定期 reconcile: 30分以上 running 滞留(異常終了 등)を最終化 + pending 누적 정리。
+  // 定期 reconcile: 30分以上 running のまま滞留したタスクを最終化 or pending 復帰。
+  // reconcileTaskState() が「루트에 남은 running」を拾えず再起動しても自動復旧しなかった空白を埋める。
   const RECONCILE_INTERVAL_MS = 10 * 60 * 1000; // 10分ごと
-  const RECONCILE_STALE_MIN = 30;               // 30分以上経過した missing running が対象
+  const RECONCILE_STALE_MIN = 30;               // 30分以上経過した running が対象
   setInterval(() => {
     try {
       reconcileTaskState({ staleMinutes: RECONCILE_STALE_MIN });
+      // reconcile で running が空になった直後にも凍結キューが残りうるので続けて解凍を試みる。
+      recoverQueuedOnStartup('periodic-recovery').catch(() => {});
     } catch (e) {
       console.error('[Bot] periodic reconcile error:', e.message);
     }
@@ -141,21 +248,64 @@ async function main() {
     serverPingTimeout: 60000,  // 1min
   });
 
+  // ---- Self-healing watchdog (event-driven, zero polling) -----------------
+  // The process can stay "online" while the Slack WebSocket silently dies
+  // (ping/pong timeouts -> "no active connection"); pm2 cannot detect that
+  // because the process itself is alive. We exit(1) on a confirmed dead/stuck
+  // socket so pm2 restarts us with a fresh connection.
+  const RECONNECT_GRACE_MS = 120 * 1000; // must recover within 2min of losing the socket
+  const ACK_FAIL_LIMIT = 6;              // consecutive ack failures => socket is stuck
+  let ackFailStreak = 0;
+  let reconnectTimer = null;
+  const dieAndRestart = (why) => {
+    console.error(`[Bot] self-heal: ${why}. Exiting so pm2 restarts.`);
+    process.exit(1);
+  };
+  const markAlive = () => {
+    ackFailStreak = 0;
+    if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
+  };
+  const armReconnectWatch = (evt) => {
+    if (reconnectTimer) return;
+    console.warn(`[Bot] socket '${evt}' — must recover within ${RECONNECT_GRACE_MS / 1000}s...`);
+    reconnectTimer = setTimeout(() => dieAndRestart(`no reconnect after '${evt}'`), RECONNECT_GRACE_MS);
+  };
+  // Losing the socket arms a grace timer; recovering (or any inbound frame) clears it.
+  ['disconnecting', 'disconnected', 'reconnecting'].forEach(ev => socketClient.on(ev, () => armReconnectWatch(ev)));
+  ['connected', 'authenticated'].forEach(ev => socketClient.on(ev, markAlive));
+
   const safeAck = async (ack) => {
-    try { await ack(); } catch (e) { console.warn('[Bot] ack failed (reconnecting?):', e.message); }
+    try {
+      await ack();
+      markAlive();
+    } catch (e) {
+      ackFailStreak++;
+      console.warn(`[Bot] ack failed (${ackFailStreak}/${ACK_FAIL_LIMIT}):`, e.message);
+      if (ackFailStreak >= ACK_FAIL_LIMIT) dieAndRestart('too many consecutive ack failures (socket stuck)');
+    }
+  };
+
+  // 화이트리스트 접근 제어: 설정된 경우 등록되지 않은 사용자의 입력은 무시(Silent Drop)
+  const isAllowedUser = (userId) => {
+    if (!userId) return false;
+    if (config.ALLOWED_USERS.length === 0) return true;
+    return config.ALLOWED_USERS.includes(userId);
   };
 
   // チャンネルでの @mention (app_mention イベント)
   socketClient.on('app_mention', async ({ event, ack }) => {
     await safeAck(ack);
+    if (!isAllowedUser(event.user)) return; // 발신자 검증
     console.log('[Bot] app_mention:', event.channel, (event.text || '').slice(0, 60));
     await onSlackMessage(event, conversations);
   });
 
   // DM・スレッド返信 (message イベント — message.im / message.channels 購読時)
   // @mention を含むチャンネルメッセージは app_mention で処理済みのためスキップ
+  // giip-773: 他のボットへの @mention 也有効 — 自分宛のみ app_mention で重複スキップ
   socketClient.on('message', async ({ event, ack }) => {
     await safeAck(ack);
+    if (!isAllowedUser(event.user)) return; // 발신자 검증
     const isDM = event.channel_type === 'im';
     const mentionsBot = config.getBotUserId() && (event.text || '').includes(`<@${config.getBotUserId()}>`);
     if (!isDM && mentionsBot) return; // app_mention ハンドラで処理済み — 重複スキップ
@@ -165,6 +315,9 @@ async function main() {
 
   // 全WebSocketメッセージをデバッグログ
   socketClient.on('ws_message', (data) => {
+    // NOTE: do NOT markAlive() here. Inbound frames only prove we can RECEIVE.
+    // The failure mode is a half-open socket that receives but cannot SEND (ack),
+    // so liveness must be confirmed by a successful ack or a 'connected' event only.
     try {
       const p = JSON.parse(data.toString());
       if (p.type !== 'hello' && p.type !== 'disconnect') {

--- a/slack-bot/intent.js
+++ b/slack-bot/intent.js
@@ -1,10 +1,8 @@
-/**
- * intent.js — コマンド判定と意図分類
- *
- * index.js から behavior-preserving に切り出したモジュール。
- */
+// intent.js — コマンド判定 + 意図分類（task / question）
+// index.js から behavior-preserving で切り出し（ロジック変更なし）。
 
 const { spawnAsync } = require('./claude-cli');
+const accounts = require('./claude-accounts');
 const { BASE_DIR } = require('./config');
 
 // ── 確認コマンド判定 ──────────────────────────────────────────────────────────
@@ -13,23 +11,76 @@ const CANCEL_WORDS = ['cancel', '취소', 'no', '아니', '중단', 'stop', 'キ
 
 function isGoCmd(text) {
   const t = text.trim().toLowerCase();
-  return GO_WORDS.some(w => t === w || t.startsWith(w + ' ') || t.includes('시작') || t.includes('진행'));
+  // 完全一致 or 「<go語> 」で始まる場合のみ。以前は .includes('시작'/'진행') で
+  // 部分一致していたため「…태스크 파일 만들어서 진행해줘」等の作業依頼文が
+  // 誤って bare go コマンド扱いされていた（番号未発給の原因）。
+  return GO_WORDS.some(w => t === w || t.startsWith(w + ' '));
 }
 function isCancelCmd(text) {
   const t = text.trim().toLowerCase();
   return CANCEL_WORDS.some(w => t === w || t.startsWith(w + ' '));
 }
 
-// git push / pull のみ（他の作業を含まない）を実行して結果を返す
-// 「A機能を修正して git push して」のような複合指示には反応しない
-function isPureGitOp(text) {
-  // Korean/Chinese/全角を除去し、残ったテキストが git コマンドとその助詞のみか確認
-  const stripped = text
-    .replace(/<[^>]+>/g, '')          // Slack mrkdwn タグ除去
-    .replace(/[^\x00-\x7Fぁ-ん亜-熙ー]/g, ' ')  // Korean等を空白に
-    .trim();
-  // "git push [して/する/お願い/etc]" のみで構成されているか
-  return /^git\s+(push|pull)(\s+(して|する|してください|お願い|please|원|해줘|해주세요))?$/i.test(stripped);
+// ── 明示的タスク作成キーワード → 分類器をバイパスして強制 task 化 ──────────────
+// 質問形で始まる複合文（「…맞아? … 태스크 파일 만들어」等）が classifyRequest で
+// question に誤分類され、書込権限を持つ Q&A サブエージェントが番号を発給せずに
+// ファイルを作ってしまう事故を防ぐ。これらの語があれば必ず管理タスク経路へ。
+const FORCE_TASK_PATTERNS = [
+  /태스크\s*등록/,
+  /태스크\s*파일\s*(을|를)?\s*(만들|생성|작성)/,
+  /태스크\s*(을|를)?\s*(만들|생성|작성)/,
+  /작업\s*의뢰/,
+  /タスク\s*(登録|作成|化)/,
+  /task\s*(등록|추가|생성|作成|登録)/i,
+  // 先頭が「태스크등록 …」または「task …」で始まる場合は強制タスク化。
+  //   利用形: `<プロジェクト名> 태스크등록 <内容>` / `<プロジェクト名> task <内容>`
+  //   （プロジェクト名は parseProjectPrefix で workDir に解決済み → ここでは cleanText の先頭）
+  //   tasklist / taskmerge / task7days 等の管理コマンドや「task list」誤爆は否定先読みで除外。
+  /^\s*(?:태스크\s*등록|task)\s+(?!list\b|리스트|목록|一覧|일람|merge\b|병합|7)\S/i,
+  // 実行形(命令形)の指示 — 実装/修正/解決 等ディスク変更を伴う命令は task。
+  //   命令形終結(…해줘/…해라/…해 주세요/…해봐)だけを対象にし、質問形(…돼 있어?/…했어?)と区別する。
+  //   例: "…해결을 해라" / "구현해줘" / "수정해라" / "반영해 주세요"
+  //   업데이트/갱신/번역/현행화 系(ディスク書込を伴う)も追加 — "…일본어로 업데이트 해줘"が
+  //   決定的 fast-path を素通りして flaky LLM classifier で question に誤分類され、質問経路で
+  //   ファイルが未コミットのまま残り PR 未生成になった事故(giip-629 追加依頼)を恒久修正する。
+  /(구현|수정|해결|반영|적용|배포|개선|보완|생성|작성|처리|점검|리팩터링?|리팩토링|업데이트|업뎃|갱신|번역|현행화|일본어화)\s*(을|를|이|가)?\s*(해\s*줘|해라|하라|해\s*주세요|하세요|해봐|해다오|해\s*주라)/,
+  //   고치다/만들다 系の命令形。
+  /고쳐\s*(줘|라|주세요|주라)/,
+  /만들어\s*(줘|라|주세요|주라)/,
+  // 「計算/集計/推定 …(해서) 보여줘/표시/출력/노출」= ページに計算結果を描画する ⇒ コード変更(task)。
+  //   「보여줘」単体は読み取り質問(例: "로그 보여줘" / "비용 보여줘")なので拾わず、計算系動詞との
+  //   共起時のみ task 化して誤爆を防ぐ。恒久修正の契機: "이번 달 예상 금액을 계산해서 보여줘" が
+  //   LLM classifier で question に誤分類され(実測 flaky: 프롬프트 예시조차 4/4 question)、giip issue
+  //   未登録・PR 未生成のまま質問経路で直接編集される事故が起きた。決定的 fast-path で恒久化する。
+  /(계산|집계|합산|추정|산출)\s*(을|를)?\s*(해서|하여|해\s*서|해|한|하도록)?\s*(보여|표시|노출|출력)\s*(해\s*)?(줘|주세요|주라|줄래|달라|다오|주세여)/,
+];
+function isForceTaskCmd(text) {
+  const t = text.replace(/`/g, '');
+  return FORCE_TASK_PATTERNS.some(re => re.test(t));
+}
+
+// ── 決定的 question fast-path: 純粋な「確認/照会」依頼 ─────────────────────────
+// ユーザ指摘: 「…확인 가능해?」「…확인해줘」のような読み取り専用の確認依頼が
+// LLM classifier(flaky)で task に誤分類され、不要な giip issue が発給された(#622)。
+// ディスク書込を伴う動詞(구현/수정/저장/파일… force-task 相当)を一切含まず、
+// 確認/照会マーカー(확인 가능/확인해줘/알려줘/뭐였는지/뭐야 等)のみで構成される
+// メッセージは、LLM を呼ばず決定的に question として即答経路へ回す。
+// 安全順序: 呼び出し側は必ず isForceTaskCmd を先に評価するため、書込を伴う命令形は
+// ここに到達しない。加えて WRITE_INTENT_MARKERS で二重に除外し誤爆を防ぐ。
+const CONFIRM_QUERY_MARKERS = [
+  /확인\s*(가능|할\s*수\s*있|해\s*줄|해\s*줘|해\s*주세요|해\s*주라|좀|부탁|돼|되나|되니|가능해|가능한가|가능할까)/,
+  /알려\s*(줘|주세요|주라|줄래|다오)/,
+  /뭐(였|야|예요|냐|니|지)/,
+  /뭔지|무엇\s*(인지|이야|인가)/,
+  /어떻게\s*(돼|되나|됐|되었)/,
+];
+// これらが含まれると「単なる確認」ではない(書込/実装/計算を伴う) → fast-path 対象外。
+const WRITE_INTENT_MARKERS = /(저장|파일|폴더|구현|수정|해결|반영|적용|배포|개선|보완|생성|작성|계산|집계|합산|추정|산출|만들|고쳐|고치|등록|추가|처리|점검|리팩터|리팩토|커밋|푸시|push|업데이트|업뎃|갱신|번역|현행화|일본어화)/;
+
+function isConfirmationQuery(text) {
+  const t = text.replace(/`/g, '');
+  if (WRITE_INTENT_MARKERS.test(t)) return false;
+  return CONFIRM_QUERY_MARKERS.some(re => re.test(t));
 }
 
 // ── 意図分類 (task / question) ────────────────────────────────────────────────
@@ -40,6 +91,9 @@ async function classifyRequest(text, workDir = BASE_DIR) {
   if (/^\s*(git\s+(push|pull|stash|fetch|merge|rebase|status|log|diff)|タスク(?:一覧|リスト|確認|状況)|tasklist|task7d)/i.test(text.replace(/[^\x00-\x7Fぁ-ん亜-熙ー]/g, ' '))) {
     return 'question';
   }
+
+  // 純粋な確認/照会依頼は LLM を呼ばず決定的に question へ（#622: 확인 요청が task 誤分類）。
+  if (isConfirmationQuery(text)) return 'question';
 
   const prompt = `You are an assistant that classifies the intent of Slack messages.
 
@@ -53,6 +107,12 @@ Classify using the following rules:
   4. Document/spec creation and saving: "사양서 만들어 저장", "문서로 저장", "파일로 저장해줘", "작성해서 저장", "만들어서 저장"
   5. Any request that ends with saving/writing output to a file or folder on disk
 
+  6. Imperative requests to implement, fix, solve, add, change, or "calculate and show" a
+     page / feature / behavior — even when phrased as "…보여줘", "…체크하고 해결해라",
+     "…고쳐줘", "구현해줘" — because fulfilling them requires modifying code or config.
+     A request that reports something is missing/broken/unimplemented and then asks to fix
+     or realize it ("아직 구현이 안된 거 같아 … 계산해서 보여줘") is "task".
+
 - "question": applies when NO file needs to be created or modified:
   1. Question, information inquiry, explanation request (no file output expected)
   2. Status check, deployment check, environment check, log review
@@ -61,15 +121,31 @@ Classify using the following rules:
   5. Message consisting only of "git push" or "git pull" (no other work instructions)
 
 Key principle: If the request involves writing, saving, or creating ANY file on disk — classify as "task".
+A read-only phrasing like "보여줘/확인해줘" does NOT make it a question when satisfying it
+requires implementing or changing code.
+
+Examples:
+- "azure-cost 페이지에 이번 달 예상 금액을 계산해서 보여줘" → task (needs a code change to add the calculation)
+- "csn 2 에 등록된 logical machine 이 사라진 원인 체크하고 문제 해결을 해라" → task (fix requires code/query change)
+- "지금 배포 상태 어때?" → question
+- "azure-cost 페이지 URL 이 뭐야?" → question
 
 Reply with only one word: "task" or "question". No explanation needed.`;
 
   try {
-    const result = await spawnAsync('claude', ['-p', prompt, '--model', 'claude-opus-4-8'], {
+    const acct = accounts.pickAccount();
+    const result = await spawnAsync('claude', ['-p', '--model', 'claude-opus-4-8'], {
       cwd: workDir,
       timeout: 60000,
+      env: accounts.envFor(acct),
+      input: prompt, // 프롬프트는 stdin 으로 (ENAMETOOLONG 회피)
     });
-    if (result.status !== 0) return 'question';
+    if (result.status !== 0) {
+      // 한도 메시지가 stdout에 찍히는 경우가 있어(giip-759) 두 스트림 모두 확인한다.
+      const combinedOut = `${result.stdout || ''}\n${result.stderr || ''}`;
+      if (accounts.isUsageLimit(combinedOut)) accounts.noteUsageLimit(acct, combinedOut);
+      return 'question';
+    }
     const out = (result.stdout || '').trim().toLowerCase();
     return out.startsWith('task') ? 'task' : 'question';
   } catch {
@@ -77,9 +153,17 @@ Reply with only one word: "task" or "question". No explanation needed.`;
   }
 }
 
-module.exports = {
-  isGoCmd,
-  isCancelCmd,
-  isPureGitOp,
-  classifyRequest,
-};
+// ── チャンネル Q&A (質問と判定されたときのインライン回答) ────────────────────
+// git push / pull のみ（他の作業を含まない）を実行して結果を返す
+// 「A機能を修正して git push して」のような複合指示には反応しない
+function isPureGitOp(text) {
+  // Korean/Chinese/全角を除去し、残ったテキストが git コマンドとその助詞のみか確認
+  const stripped = text
+    .replace(/<[^>]+>/g, '')          // Slack mrkdwn タグ除去
+    .replace(/[^\x00-\x7Fぁ-ん亜-熙ー]/g, ' ')  // Korean等を空白に
+    .trim();
+  // "git push [して/する/お願い/etc]" のみで構成されているか
+  return /^git\s+(push|pull)(\s+(して|する|してください|お願い|please|원|해줘|해주세요))?$/i.test(stripped);
+}
+
+module.exports = { isGoCmd, isCancelCmd, isForceTaskCmd, isConfirmationQuery, isPureGitOp, classifyRequest };

--- a/slack-bot/minimax-accounts.js
+++ b/slack-bot/minimax-accounts.js
@@ -1,0 +1,72 @@
+/**
+ * minimax-accounts.js — MiniMax Token Plan을 1순위 실행 엔진으로 쓰기 위한 pseudo-account.
+ *
+ * 우선순위(사용자 지정, giip-780대 후속): MiniMax 먼저 쓰고, MiniMax 한도 소진 시에만 Claude로 폴백.
+ * (claude-accounts.js 의 실제 Claude 구독 계정 로테이션이 최종 폴백 — 그쪽은 건드리지 않는다.)
+ *
+ * MiniMax는 Anthropic Messages API 호환 엔드포인트(https://api.minimax.io/anthropic)를 제공한다
+ * (실측: curl POST /anthropic/v1/messages 200, tool_use 블록 정상 반환 — 2026-07-27).
+ * 그래서 `claude` CLI 자체를 그대로 spawn하되 ANTHROPIC_BASE_URL/ANTHROPIC_API_KEY 만 바꿔치기하면
+ * 새 에이전트 루프를 만들 필요 없이 기존 파일편집/Bash/PR 흐름을 그대로 재사용할 수 있다.
+ *
+ * 키 종류 주의: MiniMax는 종량제 API Key 와 Token Plan 전용 Subscription Key(sk-cp- 접두)가
+ * 서로 호환되지 않는다. MINIMAX_API_KEY 에는 반드시 sk-cp- 로 시작하는 구독 키를 넣는다.
+ */
+
+const DEFAULT_MODEL = 'MiniMax-M2.7';
+const ANTHROPIC_BASE_URL = 'https://api.minimax.io/anthropic';
+const DEFAULT_COOLDOWN_MS = 60 * 60 * 1000; // 1h — MiniMax 쪽 리셋 주기를 모르므로 보수적 기본값
+
+let cooldownUntil = 0; // 단일 계정(구독 키 1개)이라 claude-accounts.js처럼 배열 대신 모듈 전역 상태로 충분
+
+/** 설정 여부 + 쿨다운 확인 후 pseudo-account 반환. 키 없음/쿨다운 중이면 null(호출측은 Claude로 폴백). */
+function resolve() {
+  const apiKey = process.env.MINIMAX_API_KEY;
+  if (!apiKey) return null;
+  if (cooldownUntil && cooldownUntil > Date.now()) return null;
+  return {
+    name: 'minimax',
+    provider: 'minimax',
+    model: process.env.MINIMAX_MODEL || DEFAULT_MODEL,
+    apiKey,
+  };
+}
+
+/** claude CLI spawn 용 env. CLAUDE_CONFIG_DIR(실 계정 OAuth 세션)은 반드시 제거 — 남아있으면
+ *  claude CLI 가 ANTHROPIC_API_KEY 대신 그 세션을 쓰려 해 혼선이 생길 수 있다. */
+function envFor(account) {
+  const env = { ...process.env };
+  delete env.CLAUDE_CONFIG_DIR;
+  env.ANTHROPIC_BASE_URL = ANTHROPIC_BASE_URL;
+  env.ANTHROPIC_API_KEY = account.apiKey;
+  env.ANTHROPIC_MODEL = account.model;
+  return env;
+}
+
+/** claude CLI args 의 기존 `--model <v>` 지정을 걷어내고 MiniMax 모델로 갈아 끼운다.
+ *  MiniMax 엔드포인트는 claude-* 모델명을 모르므로, 호출측이 이미 --model 을 넣어둔 경로
+ *  (task-manager.runClaude 등)를 그대로 태우면 실패한다. */
+function argsFor(args, account) {
+  const out = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--model') { i++; continue; } // 플래그 + 값 같이 제거
+    out.push(args[i]);
+  }
+  return [...out, '--model', account.model];
+}
+
+// MiniMax/일반 API 한도 표현(429, quota, insufficient balance 등) 휴리스틱 탐지.
+// 정확한 문구를 아직 실측하지 못했으므로 넓게 잡는다 — 오탐 시에도 Claude 폴백일 뿐 안전.
+const USAGE_LIMIT_RE = /\b429\b|rate limit|quota|insufficient balance|insufficient.{0,10}credit|too many requests/i;
+function isUsageLimit(text) {
+  return USAGE_LIMIT_RE.test(text || '');
+}
+
+/** 한도 감지 시 쿨다운 설정(기본 1h, MINIMAX_COOLDOWN_MS 로 조정 가능) — 그동안은 resolve()가 null. */
+function noteUsageLimit() {
+  const ms = Number(process.env.MINIMAX_COOLDOWN_MS) || DEFAULT_COOLDOWN_MS;
+  cooldownUntil = Date.now() + ms;
+  console.log(`[minimax-accounts] usage limit 감지 → cooldown ${Math.round(ms / 60000)}분 (Claude로 폴백)`);
+}
+
+module.exports = { resolve, envFor, argsFor, isUsageLimit, noteUsageLimit, DEFAULT_MODEL, ANTHROPIC_BASE_URL };

--- a/slack-bot/repo-lock.js
+++ b/slack-bot/repo-lock.js
@@ -1,0 +1,86 @@
+// repo-lock.js — lowyworkenv 저장소 루트에 대한 프로세스 간 git 작업 상호배제 락.
+// scripts/repo-lock.ps1(PowerShell 쪽 정본)과 같은 락 파일(.agent/locks/lowyworkenv-repo.lock,
+// 같은 JSON 스키마: {pid, holder, purpose, startedAt})을 공유해 언어와 무관하게 동일한 락으로
+// 취급된다. 이 모듈은 slack-bot(Node, pm2 상시 데몬) 쪽에서 쓰기 위한 동기(sync) 구현이다.
+//
+// task-manager.js의 gitPushResult()가 기존에 이미 spawnSync로 완전 동기 실행되므로 스타일을
+// 맞췄다. 다만 slack-bot은 단일 이벤트 루프에서 다른 Slack 요청도 같이 처리해야 하므로,
+// PowerShell 쪽(push_with_auth.ps1, 기본 15분 대기)보다 훨씬 짧은 기본 대기 예산을 쓰고,
+// 예산을 넘기면 "실패로 막지 않고 경고만 남긴 채 진행"한다(fail-open) — gitPushResult 자체가
+// 이미 pull --rebase --autostash + push 실패 시 재시도를 갖추고 있어 락 없이도 어느 정도
+// 회복력이 있고, 몇 분씩 봇 전체를 얼리는 것이 더 나쁘기 때문이다.
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const LOCK_DIR = path.join(REPO_ROOT, '.agent', 'locks');
+const LOCK_PATH = path.join(LOCK_DIR, 'lowyworkenv-repo.lock');
+
+function readLock() {
+  try {
+    return JSON.parse(fs.readFileSync(LOCK_PATH, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function writeLock(holder, purpose) {
+  if (!fs.existsSync(LOCK_DIR)) fs.mkdirSync(LOCK_DIR, { recursive: true });
+  const obj = { pid: process.pid, holder, purpose, startedAt: new Date().toISOString() };
+  fs.writeFileSync(LOCK_PATH, JSON.stringify(obj, null, 4), 'utf8');
+}
+
+function isPidAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isStale(lock, staleMinutes) {
+  if (!lock) return true;
+  if (!isPidAlive(lock.pid)) return true;
+  const ageMs = Date.now() - new Date(lock.startedAt).getTime();
+  return ageMs >= staleMinutes * 60 * 1000;
+}
+
+/**
+ * 락 획득을 시도한다. 이미 내가 쥔 락이면 즉시 성공, 죽었거나 오래된 락이면 회수 후 성공.
+ * 남이 쥔 살아있는 락이면 waitMs 예산 안에서 pollMs 간격으로 재확인하다가, 예산을 넘기면
+ * false를 반환한다(예외를 던지지 않는다 — 호출자가 fail-open 판단).
+ * @returns {boolean} 락을 실제로 획득했는지
+ */
+function acquireRepoLock(holder, purpose, { waitMs = 120000, staleMinutes = 120, pollMs = 3000 } = {}) {
+  const deadline = Date.now() + waitMs;
+  for (;;) {
+    const lock = readLock();
+    if (!lock || lock.holder === holder || isStale(lock, staleMinutes)) {
+      writeLock(holder, purpose);
+      return true;
+    }
+    if (Date.now() >= deadline) {
+      console.warn(`[repo-lock] 대기 시간 초과(${waitMs}ms) — holder=${lock.holder}, purpose=${lock.purpose}. 락 없이 진행합니다.`);
+      return false;
+    }
+    // task-manager.js와 동일하게 완전 동기 방식을 유지한다(spawnSync 기반 git 파이프라인 중간
+    // 삽입이라 async로 바꾸려면 호출부 전체를 리팩터링해야 함). execSync 기반 짧은 sleep.
+    try {
+      execSync(process.platform === 'win32'
+        ? `powershell -NoProfile -Command "Start-Sleep -Milliseconds ${pollMs}"`
+        : `sleep ${pollMs / 1000}`);
+    } catch { /* ignore */ }
+  }
+}
+
+/** 내가 쥔 락만 해제한다(남의 락은 절대 건드리지 않음). */
+function releaseRepoLock(holder) {
+  const lock = readLock();
+  if (!lock) return;
+  if (lock.holder !== holder) return;
+  try { fs.unlinkSync(LOCK_PATH); } catch { /* ignore */ }
+}
+
+module.exports = { acquireRepoLock, releaseRepoLock, LOCK_PATH };

--- a/slack-bot/repo-status.js
+++ b/slack-bot/repo-status.js
@@ -1,8 +1,5 @@
-/**
- * repo-status.js — git リポジトリの探索と push 状況チェック
- *
- * index.js から behavior-preserving に切り出したモジュール。
- */
+// repo-status.js — git リポジトリスキャン + push 状況チェック
+// index.js から behavior-preserving で切り出し（ロジック変更なし）。
 
 const fs = require('fs');
 const path = require('path');
@@ -76,8 +73,4 @@ function isPushFailureNotice(text) {
     || /作業完了[^\n]*git\s*push\s*失敗/i.test(text);
 }
 
-module.exports = {
-  discoverGitRepos,
-  checkAllRepoStatus,
-  isPushFailureNotice,
-};
+module.exports = { discoverGitRepos, checkAllRepoStatus, isPushFailureNotice };

--- a/slack-bot/slack-api.js
+++ b/slack-bot/slack-api.js
@@ -1,13 +1,9 @@
-/**
- * slack-api.js — Slack API 呼び出しとスレッド読み取り
- *
- * index.js から behavior-preserving に切り出したモジュール。
- * BOT_USER_ID 参照は config.getBotUserId() に置換済み（挙動は同一）。
- */
+// slack-api.js — Slack Web API 呼び出し + メッセージ整形/スレッド取得
+// index.js から behavior-preserving で切り出し（ロジック変更なし）。
 
 const https = require('https');
 const config = require('./config');
-const { BOT_TOKEN, BOT_NAME } = config;
+const { BOT_TOKEN } = config;
 const { markThreadEngaged } = require('./state');
 
 // ── Slack API ─────────────────────────────────────────────────────────────────
@@ -75,13 +71,12 @@ async function postLong(channel, text, thread_ts) {
 // ── スレッド全体を読み取る (conversations.replies) ───────────────────────────
 // Bot は mention された1件のメッセージしか event で受け取らないため、スレッドの
 // 前後文脈は Slack API で明示的に取得しないと Claude からは全く見えない。
-// これを行わないと「이전 대화 기록이 없습니다 / no prior conversation」等の誤答になる。
-// 必要スコープ: channels:history / groups:history（本文）, users:read（話者の実名解決/任意）。
+// これを行わないと「이전 대화 기록이 없습니다」等の誤答になる（本 fix の主眼）。
 const _userNameCache = new Map();
 let _usersReadMissing = false; // users:read スコープ無し → users.info 呼び出しを打ち切る
 async function resolveUserName(userId) {
   if (!userId) return null;
-  if (config.getBotUserId() && userId === config.getBotUserId()) return BOT_NAME;
+  if (config.getBotUserId() && userId === config.getBotUserId()) return 'giipclaude';
   if (_userNameCache.has(userId)) return _userNameCache.get(userId);
   // users:read が無い環境では users.info が missing_scope になる。一度失敗したら
   // 以降は API を叩かず ID をそのまま話者ラベルにフォールバック（同一話者は同一IDで一貫）。
@@ -98,7 +93,7 @@ async function resolveUserName(userId) {
 // Slack メッセージ本文を人間可読テキストへ整形（mention/tel/url/装飾記号を除去）
 function cleanThreadText(t) {
   return (t || '')
-    .replace(/<@[A-Z0-9]+>/g, '@mention')
+    .replace(/<@[A-Z0-9]+>/g, '@멘션')
     .replace(/<tel:(\d+)\|[^>]*>/g, '$1')
     .replace(/<tel:(\d+)>/g, '$1')
     .replace(/<(https?:\/\/[^|>]+)\|[^>]*>/g, '$1')
@@ -108,7 +103,7 @@ function cleanThreadText(t) {
 }
 
 // threadTs のスレッド全体を「話者: 発言」形式のテキストで返す。取得不可なら ''。
-// 他の bot/app の発言も username 付きで含める。
+// 他の bot/app（giipgravity, Manus 등）の発言も username 付きで含める。
 async function fetchThreadTranscript(channelId, threadTs) {
   if (!threadTs) return '';
   const res = await slackGet('conversations.replies', {
@@ -124,7 +119,7 @@ async function fetchThreadTranscript(channelId, threadTs) {
     if (!name && m.user) name = await resolveUserName(m.user);
     if (!name) name = m.bot_id ? 'bot' : 'unknown';
     let body = cleanThreadText(m.text);
-    if (!body && m.files && m.files.length) body = `(attachment x${m.files.length})`;
+    if (!body && m.files && m.files.length) body = `(첨부파일 ${m.files.length}건)`;
     if (!body && m.attachments && m.attachments.length) {
       body = cleanThreadText(m.attachments.map(a => a.text || a.fallback || '').join(' '));
     }
@@ -133,57 +128,8 @@ async function fetchThreadTranscript(channelId, threadTs) {
   }
   let transcript = lines.join('\n');
   const MAX = 12000; // プロンプト肥大を防ぐ上限（超過分は古い側を切る）
-  if (transcript.length > MAX) transcript = '…(older messages truncated)\n' + transcript.slice(-MAX);
+  if (transcript.length > MAX) transcript = '…(앞부분 생략)\n' + transcript.slice(-MAX);
   return transcript;
-}
-
-// ── Read other threads referenced by URL (Method 2) ──────────────────────────
-// Detect Slack permalinks pasted in the message → read that channel/thread via
-// conversations.replies and inject it into the prompt. This is what lets a single
-// line "summarize this URL thread" pull in another thread (same or other channel).
-//   https://<workspace>.slack.com/archives/<channel>/p<16-digit ts>[?thread_ts=..]
-//     channel   = <channel>
-//     thread_ts = the ?thread_ts= value if present (thread root), else p<ts> → 10digits.6digits
-// Requires: the bot is a member of that channel AND has channels:history (public) /
-// groups:history (private) scope; otherwise the read fails gracefully.
-const SLACK_ARCHIVE_RE = /https?:\/\/[a-z0-9][a-z0-9.-]*\.slack\.com\/archives\/([A-Z0-9]+)\/p(\d{10})(\d{6})(?:\?\S*?thread_ts=(\d+\.\d+))?/gi;
-
-function parseSlackArchiveUrls(text) {
-  const out = [];
-  const seen = new Set();
-  SLACK_ARCHIVE_RE.lastIndex = 0;
-  let m;
-  while ((m = SLACK_ARCHIVE_RE.exec(text)) !== null) {
-    const channel = m[1];
-    // Reply link (?thread_ts=..) → use the root ts; otherwise use p<ts>.
-    const ts = m[4] ? m[4] : `${m[2]}.${m[3]}`;
-    const key = `${channel}:${ts}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    out.push({ channel, ts, url: m[0] });
-  }
-  return out;
-}
-
-// Read every referenced URL and return a "▼ Referenced thread …" block string, or ''.
-// Skips the very thread being answered (already provided as current-thread context).
-async function fetchReferencedThreads(text, currentChannelId, currentThreadTs) {
-  const refs = parseSlackArchiveUrls(text);
-  if (!refs.length) return '';
-  const blocks = [];
-  for (const ref of refs) {
-    if (ref.channel === currentChannelId && currentThreadTs && ref.ts === currentThreadTs) continue;
-    let transcript = '';
-    try {
-      transcript = await fetchThreadTranscript(ref.channel, ref.ts);
-    } catch (e) {
-      console.error('[Bot] fetchReferencedThreads error:', e.message);
-    }
-    blocks.push(transcript
-      ? `▼ Referenced thread (${ref.url})\n${transcript}`
-      : `▼ Referenced thread (${ref.url})\n(could not read — the bot may not be a member of that channel, or lacks channels:history/groups:history scope.)`);
-  }
-  return blocks.join('\n\n');
 }
 
 module.exports = {
@@ -194,6 +140,4 @@ module.exports = {
   resolveUserName,
   cleanThreadText,
   fetchThreadTranscript,
-  parseSlackArchiveUrls,
-  fetchReferencedThreads,
 };

--- a/slack-bot/state.js
+++ b/slack-bot/state.js
@@ -1,8 +1,5 @@
-/**
- * state.js — JSON I/O とボット関与スレッド追跡
- *
- * index.js から behavior-preserving に切り出したモジュール。
- */
+// state.js — JSON I/O + ボット関与スレッド追跡
+// index.js から behavior-preserving で切り出し（ロジック変更なし）。
 
 const fs = require('fs');
 const { BOT_THREADS_FILE } = require('./config');
@@ -35,9 +32,4 @@ function isBotEngagedThread(channelId, threadTs) {
   return !!threads[`${channelId}:${threadTs}`];
 }
 
-module.exports = {
-  loadJSON,
-  saveJSON,
-  markThreadEngaged,
-  isBotEngagedThread,
-};
+module.exports = { loadJSON, saveJSON, markThreadEngaged, isBotEngagedThread };

--- a/slack-bot/task-dedup.js
+++ b/slack-bot/task-dedup.js
@@ -1,8 +1,5 @@
-/**
- * task-dedup.js — タスクID抽出・類似判定・重複統合
- *
- * index.js から behavior-preserving に切り出したモジュール。
- */
+// task-dedup.js — 既存タスクID抽出 + 類似/重複タスク検出・統合
+// index.js から behavior-preserving で切り出し（ロジック変更なし）。
 
 const fs = require('fs');
 const path = require('path');
@@ -22,6 +19,25 @@ function extractExistingTaskIds(text) {
       path.join(AGENT_DIR, 'tasks', 'cancel', `${id}.md`),
     ].some(f => fs.existsSync(f));
   });
+}
+
+// ── 既存 giip issue 番号をメッセージから抽出 ─────────────────────────────────
+//   `admin/giip-issues/609`, `giip issue #609`, `issue 609`, `이슈 #609` 等から ISN を得る。
+//   ユーザ指摘(D): issue 番号が既にあるなら task 番号を新規発給せず、二重 issue(#610 等)も作らない。
+//   ISN は小さい整数(1〜6桁)に限定し、14桁タスクIDや電話番号等の誤検知を防ぐ。無ければ null。
+function extractGiipIssueRef(text) {
+  const t = String(text || '').replace(/`/g, '');
+  // issue/이슈/giip の明示的な文脈を必須にする(bare `#609` は `PR #123` 等の誤検知源なので拾わない)。
+  const patterns = [
+    /giip[-\s]?issues?\s*[/#]?\s*(\d{1,6})\b/i, // giip-issues/609, giip issue #609, giip issue 609
+    /\bissues?\s*#?\s*(\d{1,6})\b/i,            // issue #609, issue 609
+    /이슈\s*#?\s*(\d{1,6})\b/,                  // 이슈 609, 이슈 #609
+  ];
+  for (const re of patterns) {
+    const m = t.match(re);
+    if (m) return Number(m[1]);
+  }
+  return null;
 }
 
 // ── 類似 pending タスクを検索 ──────────────────────────────────────────────
@@ -104,7 +120,7 @@ function loadPendingTaskMeta() {
 }
 
 // ── 2つのタスクmetaが重複（類似）かを判定 ────────────────────────────────────
-// ブラケットキー一致 or 共有語 >= 2（generic な1語だけの誤マッチ防止）かつ 重なり率 >= 50%。
+// findSimilarPendingTasks と同じ発想: ブラケットキー一致 or 単語集合の重なり >= 50%。
 function tasksAreSimilar(a, b) {
   if (a.bracketKey && b.bracketKey && a.bracketKey === b.bracketKey) return true;
   const smaller = a.words.size <= b.words.size ? a.words : b.words;
@@ -112,6 +128,7 @@ function tasksAreSimilar(a, b) {
   if (smaller.size < 2) return false;
   let hits = 0;
   for (const w of smaller) if (larger.has(w)) hits++;
+  // 共有語 >= 2（generic な1語だけの誤マッチ防止）かつ 重なり率 >= 50%
   return hits >= 2 && hits / smaller.size >= 0.5;
 }
 
@@ -194,6 +211,7 @@ function applyTaskMerge(clusters, taskState) {
 
 module.exports = {
   extractExistingTaskIds,
+  extractGiipIssueRef,
   findSimilarPendingTasks,
   loadPendingTaskMeta,
   tasksAreSimilar,

--- a/slack-bot/task-manager.js
+++ b/slack-bot/task-manager.js
@@ -7,6 +7,9 @@ const fs = require('fs');
 const path = require('path');
 const { spawnSync, spawn } = require('child_process');
 const { searchKLayer } = require('./k-layer');
+const accounts = require('./claude-accounts');
+const minimax = require('./minimax-accounts');
+const { acquireRepoLock, releaseRepoLock } = require('./repo-lock');
 
 const BASE_DIR = path.join(__dirname, '..');
 const TASKS_DIR = path.join(BASE_DIR, '.agent', 'tasks');
@@ -26,7 +29,7 @@ function getTimestampId() {
   return `${now.getFullYear()}${p(now.getMonth()+1)}${p(now.getDate())}${p(now.getHours())}${p(now.getMinutes())}${p(now.getSeconds())}`;
 }
 
-// baseDir 配下の .agent/roles/ を読む。なければ BASE_DIR の roles にフォールバック
+// baseDir 配下の .agent/roles/ を読む。なければ Lowyworkenv の roles にフォールバック
 // filesRead に読んだファイルの絶対パスを push する
 function readRolesContext(baseDir = BASE_DIR, filesRead = []) {
   const dirs = [
@@ -48,80 +51,199 @@ function readRolesContext(baseDir = BASE_DIR, filesRead = []) {
   return '';
 }
 
-// .agent/rules/ 配下のルールファイル一覧を収集（内容はプロンプトに含めず、ファイル名のみ記録）
-function collectRulesFiles(baseDir = BASE_DIR, filesRead = []) {
-  const dirs = [
-    path.join(baseDir, '.agent', 'rules'),
-    path.join(BASE_DIR, '.agent', 'rules'),
-  ];
-  const seen = new Set();
-  for (const dir of dirs) {
-    try {
-      const files = fs.readdirSync(dir).filter(f => f.endsWith('.md'));
-      for (const f of files) {
-        const fullPath = path.join(dir, f);
-        if (!seen.has(fullPath)) {
-          seen.add(fullPath);
-          filesRead.push(fullPath);
-        }
-      }
-    } catch {}
-  }
-}
-
-// .agent/skills/ 配下のスキルファイル一覧を収集
-function collectSkillsFiles(baseDir = BASE_DIR, filesRead = []) {
-  const dirs = [
-    path.join(baseDir, '.agent', 'skills'),
-    path.join(BASE_DIR, '.agent', 'skills'),
-  ];
-  const seen = new Set();
-  for (const dir of dirs) {
-    try {
-      const entries = fs.readdirSync(dir, { withFileTypes: true });
-      for (const e of entries) {
-        const skillMd = e.isDirectory()
-          ? path.join(dir, e.name, 'SKILL.md')
-          : path.join(dir, e.name);
-        if (fs.existsSync(skillMd) && !seen.has(skillMd)) {
-          seen.add(skillMd);
-          filesRead.push(skillMd);
-        }
-      }
-    } catch {}
-  }
-}
-
 function getCurrentBranch(cwd = BASE_DIR) {
   const res = spawnSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd, encoding: 'utf8', windowsHide: true });
   return (res.stdout || '').trim() || 'master';
 }
 
-function runClaude(args, cwd = BASE_DIR) {
-  const result = spawnSync('claude', args, {
+// リポジトリの base ブランチ (PR の向き先) を判定。origin/HEAD → master/main 等。
+function getBaseBranch(cwd = BASE_DIR) {
+  const res = spawnSync('git', ['symbolic-ref', 'refs/remotes/origin/HEAD'], { cwd, encoding: 'utf8', windowsHide: true });
+  const m = (res.stdout || '').trim().match(/refs\/remotes\/origin\/(.+)$/);
+  if (m) return m[1];
+  // origin/HEAD 未設定時のフォールバック: main → master の順で存在する方
+  for (const b of ['main', 'master']) {
+    const chk = spawnSync('git', ['show-ref', '--verify', '--quiet', `refs/remotes/origin/${b}`], { cwd, windowsHide: true });
+    if (chk.status === 0) return b;
+  }
+  return 'master';
+}
+
+// 単一 bot プロセス内で作業ツリー(共有)を同時に切り替えないための簡易ガード。
+// prepareTaskBranch が成功時に true、restoreTaskBranch で false に戻す。
+let gitTreeBusy = false;
+
+// 자가 치유: 봇 재시작·타임아웃 등으로 `git rebase`/`pull --rebase`가 중간에 끊기면
+// .git/rebase-merge(또는 rebase-apply/MERGE_HEAD)가 고아 상태로 남고, 이후 모든
+// `checkout -B` 가 "you need to resolve your current index first" 로 영구 실패한다
+// (작업트리 자체는 clean 인데도 — giip-792 실사례: giipv3 가 5일 전 끊긴 rebase 흔적으로 막혀 있었음).
+// porcelain 이 clean(충돌/미커밋 0)일 때만 안전하게 지운다 — 실제 진행 중인 rebase/merge 라면
+// 반드시 뭔가 unstaged/unmerged 로 잡히므로 그 경우는 손대지 않고 그대로 실패시킨다.
+function clearStaleRebaseState(cwd = BASE_DIR) {
+  const git = (args) => spawnSync('git', args, { cwd, encoding: 'utf8', windowsHide: true });
+  const gitDirRes = git(['rev-parse', '--git-dir']);
+  if (gitDirRes.status !== 0) return false;
+  const gitDirRaw = (gitDirRes.stdout || '').trim();
+  const gitDir = path.isAbsolute(gitDirRaw) ? gitDirRaw : path.join(cwd, gitDirRaw);
+  const stuckPaths = ['rebase-merge', 'rebase-apply', 'MERGE_HEAD', 'CHERRY_PICK_HEAD']
+    .map(p => path.join(gitDir, p))
+    .filter(p => fs.existsSync(p));
+  if (!stuckPaths.length) return false;
+  const porcelain = git(['status', '--porcelain']);
+  if ((porcelain.stdout || '').trim()) {
+    console.error(`[TaskManager] clearStaleRebaseState: ${cwd} 에 중단된 rebase/merge 흔적 있으나 dirty — 자동 정리 skip(수동 확인 필요)`);
+    return false;
+  }
+  for (const p of stuckPaths) { try { fs.rmSync(p, { recursive: true, force: true }); } catch {} }
+  console.error(`[TaskManager] clearStaleRebaseState: ${cwd} 의 고아 rebase/merge 상태 제거함(clean tree 확인 후) — ${stuckPaths.map(p => path.basename(p)).join(', ')}`);
+  return true;
+}
+
+function runClaude(args, cwd = BASE_DIR, input = null) {
+  const spawnOpts = {
     cwd,
     encoding: 'utf8',
     maxBuffer: 10 * 1024 * 1024,
     timeout: 20 * 60 * 1000, // 20分
     windowsHide: true,
+    // 프롬프트는 argv 대신 stdin 으로 전달(ENAMETOOLONG 회피). null 이면 미전달.
+    ...(input != null ? { input } : {}),
+  };
+
+  // 우선순위(사용자 지정): MiniMax 먼저 → 실패해야만 Claude 계정 풀로 폴백.
+  // runTask/callClaude 와 같은 정책. 여기(분석·계획 생성)만 Claude 전용으로 남으면
+  // MiniMax 1순위가 반쪽이 되고 Claude 한도를 계속 태운다.
+  const mm = minimax.resolve();
+  if (mm) {
+    console.log(`[TaskManager] runClaude: MiniMax(${mm.model}) 로 실행`);
+    const r = spawnSync('claude', minimax.argsFor(args, mm), { ...spawnOpts, env: minimax.envFor(mm) });
+    if (!r.error && r.status === 0) return (r.stdout || '').trim();
+    const mmOut = `${r?.stdout || ''}\n${r?.stderr || ''}`;
+    if (minimax.isUsageLimit(mmOut)) minimax.noteUsageLimit();
+    console.log('[TaskManager] runClaude: MiniMax 실패 → Claude 폴백으로 전환');
+  }
+
+  // 계정 라우팅: weight 비율대로 계정 선택 → 한도면 다음 계정으로 재시도
+  const maxTries = accounts.count();
+  let result;
+  for (let i = 0; i < maxTries; i++) {
+    const acct = accounts.pickAccount();
+    if (!acct) throw new Error('claude 전 계정 사용량 한도 소진 — 잠시 후 재시도 필요');
+    result = spawnSync('claude', args, { ...spawnOpts, env: accounts.envFor(acct) });
+    if (result.error) throw result.error;
+    if (result.status === 0) return (result.stdout || '').trim();
+    // 한도 메시지가 stdout에 찍히는 경우가 있어(giip-759) 두 스트림 모두 확인한다.
+    const combinedOut = `${result.stdout || ''}\n${result.stderr || ''}`;
+    if (accounts.isUsageLimit(combinedOut)) { accounts.noteUsageLimit(acct, combinedOut); continue; }
+    break; // 한도 외 실패 — 기존 관대한 동작(부분 출력 반환) 유지
+  }
+  return (result?.stdout || '').trim();
+}
+
+// ── Rule 43: 컨텍스트 파일 provenance (경로 + 로드 사유) ──────────────────────
+// 전량 무선별 주입(readRolesContext) 대신, 요청 관련 role/rule/skill 만 사유와 함께 선별 로드한다.
+
+// .agent/roles·rules·skills 의 파일 카탈로그(경로 + 짧은 설명). skills 는 dir(SKILL.md) 또는 *.md.
+function buildContextCatalog(baseDir = BASE_DIR) {
+  const out = [];
+  const firstDesc = (text) => {
+    const fm = text.match(/description:\s*(.+)/i);
+    if (fm) return fm[1].trim().replace(/^["']|["']$/g, '').slice(0, 140);
+    const line = text.split(/\r?\n/).map(l => l.trim()).find(l => l && l !== '---');
+    return (line || '').replace(/^#+\s*/, '').slice(0, 140);
+  };
+  const addFile = (type, absPath) => {
+    try {
+      const rel = path.relative(baseDir, absPath).replace(/\\/g, '/');
+      out.push({ type, path: rel, desc: firstDesc(fs.readFileSync(absPath, 'utf8')) });
+    } catch {}
+  };
+  // roles/rules: project baseDir 우선, 없으면 Lowyworkenv(.agent) 로 폴백
+  for (const [type, sub] of [['role', 'roles'], ['rule', 'rules']]) {
+    let dir = path.join(baseDir, '.agent', sub);
+    try { if (!fs.readdirSync(dir).some(f => f.endsWith('.md'))) dir = path.join(BASE_DIR, '.agent', sub); }
+    catch { dir = path.join(BASE_DIR, '.agent', sub); }
+    try { fs.readdirSync(dir).filter(f => f.endsWith('.md')).forEach(f => addFile(type, path.join(dir, f))); } catch {}
+  }
+  // skills: dir 안 SKILL.md, 또는 top-level *.md
+  let skillsDir = path.join(baseDir, '.agent', 'skills');
+  if (!fs.existsSync(skillsDir)) skillsDir = path.join(BASE_DIR, '.agent', 'skills');
+  try {
+    for (const e of fs.readdirSync(skillsDir, { withFileTypes: true })) {
+      if (e.isDirectory()) {
+        const sk = path.join(skillsDir, e.name, 'SKILL.md');
+        if (fs.existsSync(sk)) addFile('skill', sk);
+      } else if (e.name.endsWith('.md')) {
+        addFile('skill', path.join(skillsDir, e.name));
+      }
+    }
+  } catch {}
+  return out;
+}
+
+// 요청에 관련된 컨텍스트 파일을 LLM 으로 선별하고 각 파일의 로드 사유를 받는다. → [{path, reason}]
+function selectContextFiles(requestText, catalog, baseDir = BASE_DIR) {
+  if (!catalog.length) return [];
+  const catalogText = catalog.map((c, i) => `${i + 1}. [${c.type}] ${c.path} — ${c.desc}`).join('\n');
+  const prompt = `너는 아래 Slack 요청을 분석·수행하기 위해 참조해야 할 컨텍스트 파일(role/rule/skill)을 고르는 큐레이터다.
+
+요청:
+"${requestText}"
+
+사용 가능한 컨텍스트 파일:
+${catalogText}
+
+이 요청 처리에 "실제로 관련 있는" 파일만 골라라(무관한 것은 넣지 말 것, 보통 2~8개). 각 파일에 대해
+"이 태스크에서 그 파일의 무엇을 참조/적용하려는지"를 한국어 한 줄 사유로 적어라.
+아래 JSON 배열만 출력한다(코드펜스·설명 금지):
+[{"path":"<위 목록의 정확한 경로>","reason":"<한 줄 사유>"}]`;
+  const raw = runClaude(['-p', '--model', 'claude-opus-4-8'], baseDir, prompt);
+  let parsed = [];
+  try { const m = raw.match(/\[[\s\S]*\]/); parsed = m ? JSON.parse(m[0]) : []; } catch { parsed = []; }
+  const valid = new Set(catalog.map(c => c.path));   // 카탈로그에 없는(할루시네이션) 경로 차단
+  const seen = new Set();
+  return parsed
+    .filter(x => x && typeof x.path === 'string' && valid.has(x.path) && !seen.has(x.path) && seen.add(x.path))
+    .map(x => ({ path: x.path, reason: (String(x.reason || '').trim().slice(0, 200)) || '(사유 미기재)' }));
+}
+
+// 선별된 파일 내용을 읽어 분석 프롬프트용 컨텍스트 문자열과 filesRead([{path,reason}]) 를 만든다.
+function readSelectedContext(selected, baseDir = BASE_DIR) {
+  const parts = [], filesRead = [];
+  for (const s of selected) {
+    try {
+      const content = fs.readFileSync(path.join(baseDir, s.path), 'utf8');
+      parts.push(`### ${s.path} (로드 사유: ${s.reason})\n${content.slice(0, 800)}`);
+      filesRead.push({ path: s.path, reason: s.reason });
+    } catch {}
+  }
+  return { context: parts.join('\n\n---\n\n'), filesRead };
+}
+
+// filesRead 항목을 {path, reason} 로 정규화(문자열/절대경로 입력 후방호환 — 예: wfrun 의 [wfPath]).
+function normalizeFilesRead(filesRead) {
+  return (filesRead || []).map(f => {
+    if (typeof f === 'string') {
+      const rel = path.isAbsolute(f) ? path.relative(BASE_DIR, f).replace(/\\/g, '/') : f.replace(/\\/g, '/');
+      return { path: rel, reason: '(직접 지정)' };
+    }
+    return { path: String(f.path || '').replace(/\\/g, '/'), reason: f.reason || '(사유 미기재)' };
   });
-  if (result.error) throw result.error;
-  return (result.stdout || '').trim();
 }
 
 // ── Phase 1: 요청 분석 → TASK 파일 생성 ─────────────────────────────────────
-// returns { planContent, filesRead }
+// returns { planContent, filesRead: [{path, reason}] }
 function analyzeRequest(requestText, taskId, baseDir = BASE_DIR) {
   ensureDirs();
-  const filesRead = [];
 
   const claims = searchKLayer(requestText);
   const projectName = path.basename(baseDir);
-  const rolesContext = readRolesContext(baseDir, filesRead);
-  collectRulesFiles(baseDir, filesRead);
-  collectSkillsFiles(baseDir, filesRead);
+  // Rule 43: 요청 관련 role/rule/skill 만 사유와 함께 선별 로드하고, 그 사유를 태스크 파일에 남긴다.
+  const catalog = buildContextCatalog(baseDir);
+  const selected = selectContextFiles(requestText, catalog, baseDir);
+  const { context: rolesContext, filesRead } = readSelectedContext(selected, baseDir);
 
-  const analysisPrompt = `You are a senior software architect. Respond in the same language as the task/request.
+  const analysisPrompt = `You are a senior software architect. Always respond in Korean.
 
 Working project: ${projectName}
 Working directory: ${baseDir}
@@ -150,15 +272,16 @@ Analyze the request and output a task specification in this EXACT format (in Kor
 
 Output ONLY the task specification, no extra commentary.`;
 
-  const planContent = runClaude(['-p', analysisPrompt, '--model', 'claude-opus-4-8'], baseDir);
+  const planContent = runClaude(['-p', '--model', 'claude-opus-4-8'], baseDir, analysisPrompt);
   return { planContent, filesRead };
 }
 
 function createTaskFile(taskId, requestText, planContent, filesRead = []) {
   ensureDirs();
 
-  const fileList = filesRead.length > 0
-    ? '\n' + filesRead.map(f => `#   - ${path.relative(BASE_DIR, f).replace(/\\/g, '/')}`).join('\n')
+  const norm = normalizeFilesRead(filesRead);   // Rule 43: 경로 + 로드 사유
+  const fileList = norm.length > 0
+    ? '\n' + norm.map(f => `#   - ${f.path} — ${f.reason}`).join('\n')
     : '\n#   (없음)';
 
   const header = `---
@@ -166,7 +289,7 @@ task_id: ${taskId}
 status: pending
 requested_at: ${new Date().toISOString()}
 request: "${requestText.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"
-# 분석 시 참조한 파일 목록 (roles / rules / skills):${fileList}
+# 분석에 로드된 컨텍스트 파일 (role/rule/skill — 경로 — 로드 사유):${fileList}
 ---
 
 `;
@@ -175,13 +298,73 @@ request: "${requestText.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"
   return taskFile;
 }
 
+// 既存タスクファイルを「更新」する（新規IDを発給しない）。
+// 参照されたタスク番号に改訂を追記し、done/cancel にあれば tasks/ に戻して pending に再オープンする。
+// 見つからなければ createTaskFile にフォールバック。返り値は tasks/{taskId}.md の絶対パス。
+function updateTaskFile(taskId, requestText, planContent, filesRead = []) {
+  ensureDirs();
+  const activePath = path.join(TASKS_DIR, `${taskId}.md`);
+  const existing = [
+    activePath,
+    path.join(TASKS_DIR, 'done', `${taskId}.md`),
+    path.join(TASKS_DIR, 'cancel', `${taskId}.md`),
+  ].find(f => fs.existsSync(f));
+
+  // 元ファイルが見つからない場合のみ新規作成（実質 createTaskFile と同じ挙動）
+  if (!existing) return createTaskFile(taskId, requestText, planContent, filesRead);
+
+  let content = fs.readFileSync(existing, 'utf8');
+
+  // status を pending に戻して再オープン
+  content = /status:\s*.+/i.test(content)
+    ? content.replace(/status:\s*.+/i, 'status: pending')
+    : `status: pending\n${content}`;
+
+  // 改訂を追記（元タスクの内容・成果物は保持したまま）
+  const now = new Date().toISOString();
+  const norm = normalizeFilesRead(filesRead);   // Rule 43: 경로 + 로드 사유
+  const fileList = norm.length > 0
+    ? '\n' + norm.map(f => `-   ${f.path} — ${f.reason}`).join('\n')
+    : '\n-   (없음)';
+  content = `${content.trimEnd()}\n\n---\n\n## 개정 (${now})\n\n### 추가 요청\n${requestText}\n\n### 갱신된 계획\n${planContent}\n\n### 로드된 컨텍스트 파일 (role/rule/skill — 경로 — 사유)${fileList}\n`;
+
+  // done/cancel にあった場合は tasks/ 直下へ戻す
+  fs.writeFileSync(activePath, content);
+  if (existing !== activePath) {
+    try { fs.rmSync(existing); } catch {}
+  }
+  return activePath;
+}
+
+// giip issue 재처리용: 로컬 태스크 파일이 없을 때 DB 이력(본문+전체 코멘트)으로 태스크 파일을 재생성한다.
+//   done/ 이동·타 클론 처리·워킹트리 churn 등으로 .agent/tasks/{giip-isn}.md 가 사라져도, DB(SSOT)에서
+//   복원한 히스토리 다이제스트를 계획 본문으로 삼아 서브에이전트가 코멘트 이력 전체를 읽고 이어서 처리하게 한다.
+//   (이 파일이 없어서 startExecution 이 "タスクファイルが見つかりません" 로 실패하던 문제의 항구 대책.)
+function rebuildTaskFileFromIssue(taskId, isn, requestText, historyDigest) {
+  ensureDirs();
+  const plan = [
+    `# TASK: giip issue #${isn} 재처리`,
+    '',
+    '## 원 요청',
+    (requestText && requestText.trim()) || `(giip issue #${isn} 처리 요청)`,
+    '',
+    '## DB에서 복원한 이슈 이력 (본문 + 전체 코멘트 — 반드시 시간순으로 모두 읽고 맥락을 반영)',
+    historyDigest || '(이력 없음 — DB 조회 실패. giip issue get 로 직접 확인하라)',
+    '',
+    '## 지시',
+    '- 위 코멘트 이력을 모두 읽고, 아직 처리되지 않았거나 새로 추가된 요청을 파악해 처리하라.',
+    `- 새 issue/task 번호를 만들지 말고 #${isn} 에 결과를 코멘트하고 상태를 전이하라.`,
+  ].join('\n');
+  return createTaskFile(taskId, (requestText && requestText.trim()) || `giip issue #${isn} 재처리`, plan, []);
+}
+
 function extractTitle(planContent) {
   const match = planContent.match(/^#\s*TASK:\s*(.+)$/m);
   return match ? match[1].trim() : '作業';
 }
 
 // ── Phase 2: subagent 실행 (비동기) ─────────────────────────────────────────
-function startExecution(taskId, taskFilePath, { onComplete, onError }, baseDir = BASE_DIR) {
+function startExecution(taskId, taskFilePath, { onComplete, onError, isn = null }, baseDir = BASE_DIR, ctx = null) {
   ensureDirs();
 
   // taskFilePath が未指定 or 存在しない場合は TASKS_DIR/{taskId}.md にフォールバック
@@ -201,10 +384,38 @@ function startExecution(taskId, taskFilePath, { onComplete, onError }, baseDir =
   const rolesContext = readRolesContext(baseDir);
   const claims = searchKLayer(taskContent);
 
-  const currentBranch = getCurrentBranch(baseDir);
-  const executionPrompt = `You are a senior software engineer working in the current workspace. Respond in the same language as the task.
+  // ctx が渡されていれば prepareTaskBranch 済みの専用ブランチ。無ければ現在ブランチ(後方互換)。
+  const currentBranch = (ctx && ctx.branch) || getCurrentBranch(baseDir);
+  const baseBranch = (ctx && ctx.base) || getBaseBranch(baseDir);
+
+  // 進捗コメント・プロトコル(PROTOCOL_PROGRESS_COMMENT.md): giip issue に連携済み(isn あり)の時だけ
+  // 注入する。isn が無ければ giip 未連携なのでブロック全体を省く(条件「giip issue api 접근 가능한 환경이면」)。
+  const addCommentScript = path.join(BASE_DIR, '..', 'giipprj', 'giipdb', 'mgmt', 'addIssueComment.ps1');
+  const progressBlock = isn ? `
+
+=== 진행 코멘트 프로토콜 (정본 .agent/rules/PROTOCOL_PROGRESS_COMMENT.md) ===
+이 태스크는 giip issue #${isn} 에 연동돼 있다. 진행 상황을 자주 코멘트로 남겨, 코멘트만 봐도 어디까지
+왔고 무엇이 바뀌었는지 재구성되게 하라. 파일 1개당 코멘트 1개를 강제하지 말고 "논리 묶음" 단위로
+각 1~3줄 짧게 남긴다(같은 내용 연타·스팸 금지). 남기는 시점:
+  1) 착수: 로드해서 따르는 role/rule/skill/workflow 를 명시.
+  2) 참조 정본 변경: 따라야 할 role/rule/skill/workflow 파일 자체를 수정할 때 — 무엇을 왜.
+  3) 대상 파일 변경: 실제 수정/생성/삭제한 소스·문서가 생길 때마다(논리 묶음마다) — 경로 + 한 줄.
+  4) 검색 발생: 부득이 grep/find 했으면 (a)왜 (b)어디에 링크로 흡수했는지(Search→Link→Report).
+  5) 분기·막힘·판단: 에러·사람 확인 필요, 중요한 설계 판단이 생길 때.
+  6) **완료 직전(필수, 2026-07-29)**: 작업을 마치기 직전, 봇이 최종 "완료" 코멘트를 달기 *전에* 아래 두
+     코멘트를 네가 먼저 남겨라 — (a) **테스트 결과**: 실제로 무엇을 어떻게 실행/재현해서 검증했는지와
+     결과(성공/실패/부분성공). 기존 테스트가 있으면 커맨드·종료코드·출력 요약, 없으면 수행한 수동
+     재현·재검증 절차와 결과("테스트 없음"이라고만 쓰고 넘기지 말 것 — 최소 1건의 재현 검증 필수).
+     (b) **사용자 테스트 방법**: 사람이 직접 확인하려면 무엇을 클릭/실행/조회하면 되는지 재현 가능한
+     구체 절차(URL·커맨드·화면 경로 등). 막연하게 "확인해보세요"라고 쓰지 말 것.
+빈도: 몇 분 이상 걸리는 작업이면 최소 시작·중간·끝이 코멘트로 남게 한다.
+명령(직접-DB append, 한글 안 깨짐):
+  pwsh -File "${addCommentScript}" -isn ${isn} -content "<본문>" -issuetype note -author "slack-bot"
+  (중간 진행은 issuetype=note. 상태 전이/최종 코멘트는 봇이 별도 처리하므로 여기서 상태는 바꾸지 말 것.)
+` : '';
+  const executionPrompt = `You are a senior software engineer working in the Lowyworkenv workspace. Always respond in Korean.
 Working directory: ${baseDir}
-Current branch: ${currentBranch}
+Current branch: ${currentBranch} (task 전용 브랜치, base=${baseBranch} 최신 기준)
 
 === 담당 태스크 ===
 ${taskContent}
@@ -216,12 +427,12 @@ ${rolesContext || '(roles not found)'}
 ${claims.length > 0 ? claims.map(c => `• ${c}`).join('\n') : '(없음)'}
 
 === 작업 지시 ===
+0. **되묻지 말고 실측하라**: 경로·설정·사양 등 조회로 확정 가능한 값은 사용자에게 다시 묻지 말고 직접 찾아 결정한다.
+   - giip 서비스 설정(SMTP·메일·인증 등)의 정본은 **giipdb 사양서(\`giipprj/giipdb/docs/30_Specs/\`)와 DB**다. 사람에게 묻기 전에 반드시 그곳부터 grep/조회하라. 예: SMTP 설정은 \`tEmailServerConfig\` 테이블에 있고 giip API \`EmailServerConfigGetActive\`(SP \`pApiEmailServerConfigGetActivebyAK\`, 서버측 \`bySk\`)로 조회한다.
+   - 정말로 사람만 아는 값(외부 자격증명 실물, 사용자의 의도적 선택)만 질문한다.
 1. 위 태스크의 실행 계획을 순서대로 실행하세요.
-2. Read/Edit/Write/Bash 도구를 사용해 실제 코드 변경을 수행하세요.
-3. **파일을 변경하면 즉시 git push (명시적 지시 없어도 필수)**:
-   - 현재 브랜치(${currentBranch})에 그대로 push — 브랜치 전환 금지
-   - git add -A && git commit -m "feat/fix/chore(...): 설명" && git pull --rebase origin ${currentBranch} && git push origin ${currentBranch}
-   - 커밋 메시지는 .agent/rules/11_structured_commit.md 형식 준수
+2. Read/Edit/Write/Bash 도구를 사용해 이 저장소(${baseDir}) 안에서 실제 코드 변경을 수행하세요.
+3. **git 커밋·push·PR·브랜치 전환은 절대 하지 마세요.** 작업트리는 이미 태스크 전용 브랜치 \`${currentBranch}\`(base=${baseBranch} 최신 fetch 기준)로 준비돼 있습니다. 파일 변경만 마치면, 봇이 작업 종료 후 자동으로 이 브랜치에 커밋·push 하고 \`${baseBranch}\` 로 PR 을 생성합니다. (당신이 직접 git 을 만지면 브랜치/PR 흐름이 깨집니다.)
 4. 모든 단계 완료 후 반드시 다음 경로에 결과 보고서를 작성하세요:
    ${resultFile}
 
@@ -244,7 +455,7 @@ ${new Date().toISOString()}
 ## 다음 단계
 (후속 작업이 필요한 경우 명기)
 ---
-
+${progressBlock}
 지금 바로 작업을 시작하세요.`;
 
   // 実行サブエージェントが roles/rules/skills/workflows を参照できるよう .agent を許可
@@ -252,37 +463,97 @@ ${new Date().toISOString()}
   const agentDir = fs.existsSync(path.join(baseDir, '.agent'))
     ? path.join(baseDir, '.agent')
     : path.join(BASE_DIR, '.agent');
-  const proc = spawn('claude', ['-p', executionPrompt, '--dangerously-skip-permissions', '--add-dir', agentDir], {
-    cwd: baseDir,
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
+  // 프롬프트는 argv 대신 stdin 으로 전달(ENAMETOOLONG 회피) → proc.stdin 으로 씀
+  const args = ['-p', '--dangerously-skip-permissions', '--add-dir', agentDir];
 
-  let stdout = '';
-  let stderr = '';
-  proc.stdout.on('data', d => { stdout += d; process.stdout.write(`[Subagent] ${d}`); });
-  proc.stderr.on('data', d => { stderr += d; });
+  // 계정 라우팅: weight 비율대로 계정 선택. 실행 중 사용량 한도에 걸리면
+  // 해당 계정을 쿨다운하고 다음 계정으로 태스크를 처음부터 재실행한다.
+  // (주의: 재실행이므로 이미 push된 커밋이 있으면 중복 커밋 가능 — fail보다 나은 동작)
+  const tried = new Set();
+  // 우선순위(사용자 지정): MiniMax 먼저, MiniMax 한도 소진 시에만 Claude로 폴백.
+  // mmExhausted=true 가 되면(이번 태스크 한정) 이후 attempt() 는 MiniMax를 다시 시도하지 않는다
+  // (minimax.resolve() 는 별도로 자체 쿨다운을 갖고 있어 다음 태스크에서는 그 쿨다운을 그대로 따른다).
+  let mmExhausted = false;
 
-  proc.on('close', (code) => {
-    // 결과 파일이 없으면 기본 파일 생성
-    if (!fs.existsSync(resultFile)) {
-      fs.writeFileSync(resultFile, [
-        `# 작업 결과: ${taskId}`,
-        `\n완료 일시: ${new Date().toISOString()}`,
-        `\n## Claude 출력\n${stdout.slice(0, 3000)}`,
-        stderr ? `\n## Errors\n${stderr.slice(0, 500)}` : '',
-      ].join('\n'));
-    }
-
-    if (code === 0) {
-      onComplete(resultFile);
+  function attempt() {
+    let acct = mmExhausted ? null : minimax.resolve();
+    let env;
+    if (acct) {
+      env = minimax.envFor(acct);
+      console.log(`[TaskManager] task ${taskId}: MiniMax(${acct.model}) 로 실행`);
     } else {
-      onError(new Error(`claude exit ${code}: ${stderr.slice(0, 200)}`), resultFile);
+      acct = accounts.pickAccount();
+      if (!acct) {
+        onError(new Error('MiniMax 미설정/한도 소진 + Claude 전 계정 사용량 한도 소진 — 잠시 후 재실행 필요'), null);
+        return null;
+      }
+      env = accounts.envFor(acct);
+      if (mmExhausted) console.log(`[TaskManager] task ${taskId}: MiniMax 한도 소진 → Claude(${acct.name}) 폴백`);
     }
-  });
+    // tried 는 Claude 계정 로테이션 가드(tried.size < accounts.count())에만 쓰인다.
+    // MiniMax 는 별도 mmExhausted 플래그로 추적하므로 여기 섞으면 카운트가 어긋난다(오프바이원 방지).
+    if (acct.provider !== 'minimax') tried.add(acct.name);
+    // MiniMax 폴백은 claude CLI 기본 모델 선택을 안 타므로 --model 로 명시 지정한다.
+    const spawnArgs = acct.provider === 'minimax' ? [...args, '--model', acct.model] : args;
+    const proc = spawn('claude', spawnArgs, {
+      cwd: baseDir,
+      stdio: ['pipe', 'pipe', 'pipe'], // stdin 으로 프롬프트 전달(ENAMETOOLONG 회피)
+      env,
+    });
+    proc.stdin.on('error', () => {}); // 자식이 먼저 종료하면 EPIPE — 무시
+    proc.stdin.end(executionPrompt);
 
-  proc.on('error', (err) => onError(err, null));
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', d => { stdout += d; process.stdout.write(`[Subagent:${acct.name}] ${d}`); });
+    proc.stderr.on('data', d => { stderr += d; });
 
-  return proc;
+    proc.on('close', (code) => {
+      const combinedOut = `${stdout}\n${stderr}`;
+
+      // MiniMax(1순위) 실패 → 이번 태스크는 더 이상 MiniMax를 시도하지 않고 Claude 풀로 전환.
+      // 한도성 실패면 minimax 자체 쿨다운도 걸어(다음 태스크들도 그동안 Claude 사용), 원인 불명 실패는
+      // 쿨다운 없이(다음 태스크는 다시 MiniMax부터 시도) 이번만 Claude로 넘어간다.
+      if (code !== 0 && acct.provider === 'minimax') {
+        mmExhausted = true;
+        if (minimax.isUsageLimit(combinedOut)) minimax.noteUsageLimit();
+        console.log(`[TaskManager] task ${taskId}: MiniMax 실패 → Claude 폴백으로 전환`);
+        attempt();
+        return;
+      }
+
+      // 사용량 한도로 실패 & 아직 안 쓴 계정이 남아 있으면 다음 계정으로 재실행
+      // 한도 메시지("You've hit your weekly limit ...")는 stderr가 아니라 stdout에
+      // 찍히는 경우가 있어(giip-759, PR #430) 두 스트림을 모두 확인한다.
+      if (code !== 0 && acct.provider !== 'minimax' && accounts.isUsageLimit(combinedOut) && tried.size < accounts.count()) {
+        accounts.noteUsageLimit(acct, combinedOut);
+        console.log(`[TaskManager] task ${taskId}: ${acct.name} usage limit → 다음 계정으로 재실행`);
+        attempt();
+        return;
+      }
+
+      // 결과 파일이 없으면 기본 파일 생성
+      if (!fs.existsSync(resultFile)) {
+        fs.writeFileSync(resultFile, [
+          `# 작업 결과: ${taskId}`,
+          `\n완료 일시: ${new Date().toISOString()}`,
+          `\n## Claude 출력\n${stdout.slice(0, 3000)}`,
+          stderr ? `\n## Errors\n${stderr.slice(0, 500)}` : '',
+        ].join('\n'));
+      }
+
+      if (code === 0) {
+        onComplete(resultFile);
+      } else {
+        onError(new Error(`claude exit ${code}: ${stderr.slice(0, 200)}`), resultFile);
+      }
+    });
+
+    proc.on('error', (err) => onError(err, null));
+    return proc;
+  }
+
+  return attempt();
 }
 
 // ── 작업 완료: 결과를 태스크 파일에 추가 후 done/ 폴더로 이동 ─────────────────
@@ -338,54 +609,62 @@ function gitPushResult(taskId, taskTitle, resultFile, doneTaskFile = null) {
   const branch = getCurrentBranch();
   const relResult = path.relative(BASE_DIR, resultFile).replace(/\\/g, '/');
 
-  // result file を stage
-  spawnSync('git', ['add', relResult], { cwd: BASE_DIR, encoding: 'utf8', windowsHide: true });
-
-  // done task file を stage（あれば優先）、なければ元のタスクファイルを試みる
+  // done task file の URL 用に相対パスだけ先に確定（stage は下の add -A が担う）
   let relDoneTask = null;
   if (doneTaskFile && fs.existsSync(doneTaskFile)) {
     relDoneTask = path.relative(BASE_DIR, doneTaskFile).replace(/\\/g, '/');
-    spawnSync('git', ['add', relDoneTask], { cwd: BASE_DIR, encoding: 'utf8', windowsHide: true });
-  } else {
-    const relTask = `.agent/tasks/${taskId}.md`;
-    if (fs.existsSync(path.join(BASE_DIR, relTask))) {
-      spawnSync('git', ['add', relTask], { cwd: BASE_DIR, encoding: 'utf8', windowsHide: true });
+  }
+
+  // 스테이지 범위 = 태스크가 실제로 만든/바꾼 산출물 전부(경로 무관). 固定パス（結果ファイル +
+  // .agent/tasks/<id>.md）だけ add すると 02-ActiveProjects/** 等の任意パス成果物が取りこぼされ
+  // 「ファイルは出来たのにコミットされない」事故になる（2026-07-08 mimity 事件, task 20260708174823）。
+  // ランタイム状態 json(.bot-threads/.task-state/tasklist/claude-accounts/.conversations)は
+  // .gitignore 済みなので add -A に混入しない。→ rule 35「스테이지 범위」/ rule 38 ②.
+  // lowyworkenv 루트는 giipcodex·gissue 스케줄러·대화형 세션도 동시에 git 쓰기를 하는 유일한
+  // 레포라, add~push 구간 전체를 저장소 락으로 감싼다(2026-07-28, scripts/repo-lock.ps1과
+  // 파일 공유). 봇은 다른 Slack 요청도 처리해야 하므로 대기 예산을 짧게(2분) 두고, 못 잡아도
+  // 막지 않는다 — 아래 pull --rebase + 재시도가 이미 어느 정도 충돌 회복력을 갖고 있다.
+  const lockHolder = `task-manager:${process.pid}:${taskId}`;
+  acquireRepoLock(lockHolder, `task ${taskId}`, { waitMs: 120000 });
+  try {
+    spawnSync('git', ['add', '-A'], { cwd: BASE_DIR, encoding: 'utf8', windowsHide: true });
+
+    // commit
+    const msg = `task(${taskId}): ${taskTitle.slice(0, 60)}\n\nAuto-committed by giipclaude Bot\n\nDirective: task result push on ${branch}`;
+    const commitRes = spawnSync('git', ['commit', '-m', msg], { cwd: BASE_DIR, encoding: 'utf8', windowsHide: true });
+    if (commitRes.status !== 0 && !(commitRes.stdout || '').includes('nothing to commit')) {
+      console.error('[TaskManager] git commit:', (commitRes.stderr || '').trim());
+      return null;
     }
-  }
 
-  // commit
-  const msg = `task(${taskId}): ${taskTitle.slice(0, 60)}\n\nAuto-committed by giipclaude Bot\n\nDirective: task result push on ${branch}`;
-  const commitRes = spawnSync('git', ['commit', '-m', msg], { cwd: BASE_DIR, encoding: 'utf8', windowsHide: true });
-  if (commitRes.status !== 0 && !(commitRes.stdout || '').includes('nothing to commit')) {
-    console.error('[TaskManager] git commit:', (commitRes.stderr || '').trim());
-    return null;
-  }
-
-  // Rebase onto latest remote and push, retrying once on non-fast-forward.
-  // --autostash so uncommitted runtime state (bot json) never blocks the rebase. This was the
-  // bug that silently dropped result URLs: dirty tree → rebase refused → push rejected → null.
-  const runGit = (args) => spawnSync('git', args, { cwd: BASE_DIR, encoding: 'utf8', windowsHide: true });
-  const rebaseAndPush = () => {
-    const pull = runGit(['pull', '--rebase', '--autostash', 'origin', branch]);
-    if (pull.status !== 0) {
-      console.error('[TaskManager] git pull --rebase:', (pull.stderr || '').trim());
-      runGit(['rebase', '--abort']); // never leave the repo mid-rebase
+    // Rebase onto latest remote and push, retrying once on non-fast-forward.
+    // --autostash so uncommitted runtime state (bot json) never blocks the rebase. This was the
+    // bug that silently dropped result URLs: dirty tree → rebase refused → push rejected → null.
+    const runGit = (args) => spawnSync('git', args, { cwd: BASE_DIR, encoding: 'utf8', windowsHide: true });
+    const rebaseAndPush = () => {
+      const pull = runGit(['pull', '--rebase', '--autostash', 'origin', branch]);
+      if (pull.status !== 0) {
+        console.error('[TaskManager] git pull --rebase:', (pull.stderr || '').trim());
+        runGit(['rebase', '--abort']); // never leave the repo mid-rebase
+      }
+      return runGit(['push', 'origin', branch]);
+    };
+    let pushRes = rebaseAndPush();
+    if (pushRes.status !== 0) {
+      console.error('[TaskManager] git push rejected, retrying after fetch:', (pushRes.stderr || '').trim());
+      runGit(['fetch', 'origin', branch]);
+      pushRes = rebaseAndPush();
     }
-    return runGit(['push', 'origin', branch]);
-  };
-  let pushRes = rebaseAndPush();
-  if (pushRes.status !== 0) {
-    console.error('[TaskManager] git push rejected, retrying after fetch:', (pushRes.stderr || '').trim());
-    runGit(['fetch', 'origin', branch]);
-    pushRes = rebaseAndPush();
-  }
-  if (pushRes.status !== 0) {
-    console.error('[TaskManager] git push:', (pushRes.stderr || '').trim());
-    return null;
-  }
+    if (pushRes.status !== 0) {
+      console.error('[TaskManager] git push:', (pushRes.stderr || '').trim());
+      return null;
+    }
 
-  // done task file の URL を優先返却
-  return buildGitHubUrl(relDoneTask || relResult);
+    // done task file の URL を優先返却
+    return buildGitHubUrl(relDoneTask || relResult);
+  } finally {
+    releaseRepoLock(lockHolder);
+  }
 }
 
 function buildGitHubUrl(relativePath) {
@@ -402,6 +681,730 @@ function buildGitHubUrl(relativePath) {
   const branch = (branchRes.stdout || '').trim() || 'master';
 
   return `${base}/blob/${branch}/${relativePath}`;
+}
+
+// remote(origin) → PR compare URL (gh pr create 실패 시 폴백)
+function buildCompareUrl(branch, base, baseDir = BASE_DIR) {
+  const remoteRes = spawnSync('git', ['remote', 'get-url', 'origin'], { cwd: baseDir, encoding: 'utf8', windowsHide: true });
+  const remote = (remoteRes.stdout || '').trim();
+  const b = remote.replace(/^git@github\.com:/, 'https://github.com/').replace(/\.git$/, '');
+  return `${b}/compare/${base}...${branch}?expand=1`;
+}
+
+// ── 작업 전: 최신 base 에서 태스크 전용 브랜치를 만들어 checkout ────────────────
+// 반환 ctx 는 gitPushResultAndPR 에서 push·PR·작업트리 복원에 사용한다.
+// 핵심: 반드시 `git fetch origin <base>` 직후 `origin/<base>` 를 기점으로 브랜치를 만든다.
+// (오래된 로컬 base 위에서 브랜치를 파면 나중에 PR/merge conflict → 이번 재발방지의 요체.)
+function prepareTaskBranch(taskId, baseDir = BASE_DIR) {
+  const git = (args) => spawnSync('git', args, { cwd: baseDir, encoding: 'utf8', windowsHide: true });
+  const isRepo = git(['rev-parse', '--git-dir']);
+  if (isRepo.status !== 0) return { ok: false, notRepo: true, error: 'git 저장소가 아님' };
+  if (gitTreeBusy) {
+    return { ok: false, busy: true, error: '다른 태스크가 작업트리(git)를 점유 중 — 완료 후 다시 go 하세요.' };
+  }
+
+  clearStaleRebaseState(baseDir);
+
+  const originalBranch = getCurrentBranch(baseDir);
+  const base = getBaseBranch(baseDir);
+  const branch = `bot/task-${taskId}`;
+
+  // 드리프트 조기 감지: 새 작업은 항상 기본 브랜치에서 쉬고 있어야 한다(rule 41).
+  // 시작 시점에 비-기본 브랜치(대개 이전 태스크의 bot/task-*)에 있다면 과거에 복원이
+  // 누락됐다는 증거 → 로그로 남긴다. restoreTaskBranch 가 base 로 복원하므로 이번 턴에 자가 치유된다.
+  if (originalBranch !== base) {
+    console.error(`[TaskManager] prepareTaskBranch: ⚠️ 작업 시작 시 트리가 base(${base})가 아닌 '${originalBranch}' 에 있었음 (드리프트 흔적). 이번 작업 종료 시 ${base} 로 복원됩니다.`);
+  }
+
+  const fetched = git(['fetch', 'origin', base]);
+  const startPoint = fetched.status === 0 ? `origin/${base}` : base;
+
+  // 자가 치유: 워킹트리에 커밋 안 된 tracked 변경이 있으면 `checkout -B` 가
+  // "your local changes would be overwritten by checkout … Aborting" 으로 중단한다
+  // (02-ActiveProjects/README.md 수정 등). 아무도 치우지 않으므로 go 가 영구 루프로 실패했다.
+  // → checkout 을 막는 tracked 변경만 stash 하고 restoreTaskBranch 에서 pop 한다.
+  //   untracked(.agent/tasks/<id>.md = 실행할 태스크 파일)은 checkout 을 막지 않고
+  //   서브에이전트가 봐야 하므로 stash 에 넣지 않는다(-u 금지).
+  //   gitPushResult 의 `pull --rebase --autostash` 와 같은 철학.
+  let stashed = false;
+  const dirtyTracked = git(['status', '--porcelain', '--untracked-files=no']);
+  if ((dirtyTracked.stdout || '').trim()) {
+    const stash = git(['stash', 'push', '-m', `giipclaude-autostash-${taskId}`]);
+    stashed = stash.status === 0 && !/No local changes/.test(stash.stdout || '');
+  }
+
+  // 자가 치유 ②: untracked 태스크 파일이 startPoint(origin/base)에 이미 tracked 로
+  // 존재하면(과거 시도가 PR 로 base 에 머지된 경우 — giip-645), `checkout -B` 가
+  // "untracked working tree files would be overwritten by checkout … Aborting" 으로
+  // 영구 실패한다. autostash 는 tracked 변경만 다루므로 이 충돌은 치우지 못한다.
+  //   → 현재 요청(untracked)본을 보존하고 파일을 잠시 치워 checkout 을 통과시킨 뒤,
+  //     checkout 후 다시 써서 서브에이전트가 최신 요청을 보게 한다.
+  const taskRel = `.agent/tasks/${taskId}.md`;
+  const taskAbs = path.join(baseDir, taskRel);
+  let savedTaskFile = null;
+  const taskTracked = git(['ls-files', '--error-unmatch', taskRel]).status === 0;
+  const taskOnStart = git(['cat-file', '-e', `${startPoint}:${taskRel}`]).status === 0;
+  if (!taskTracked && taskOnStart) {
+    try {
+      savedTaskFile = fs.readFileSync(taskAbs, 'utf8');
+      fs.rmSync(taskAbs);
+    } catch { savedTaskFile = null; }
+  }
+
+  const co = git(['checkout', '-B', branch, startPoint]);
+  if (co.status !== 0) {
+    if (savedTaskFile != null) { try { fs.writeFileSync(taskAbs, savedTaskFile); } catch {} }
+    if (stashed) git(['stash', 'pop']); // 실패 시 사용자 변경을 되돌려 유실 방지
+    return { ok: false, error: `브랜치 생성 실패: ${(co.stderr || '').trim().slice(0, 200)}` };
+  }
+  // checkout 성공: base 의 옛 태스크 파일이 트리에 올라왔을 수 있으므로 현재 요청본으로
+  // 덮어써 서브에이전트가 최신 요청을 실행하게 한다(커밋되면 이번 태스크 변경으로 남음).
+  if (savedTaskFile != null) { try { fs.writeFileSync(taskAbs, savedTaskFile); } catch {} }
+
+  gitTreeBusy = true;
+  return { ok: true, branch, base, originalBranch, fetchedBase: fetched.status === 0, stashed };
+}
+
+// 작업트리를 기본(base) 브랜치로 복원하고 busy 락을 해제한다. (성공/실패 무관 항상 호출)
+//
+// rule 41(브랜치 생명주기): 한 작업의 종료 = PR 생성 + 기본 브랜치(master/main) 복귀.
+// ⚠️ 근본 원인 수정(giip-633): 예전에는 `ctx.originalBranch`(작업 시작 시점의 브랜치)로 복원했다.
+//   그러나 트리가 한 번이라도 비-master 브랜치(강제종료로 남은 bot/task-*, 이전 복원 실패,
+//   수동 checkout 등)에 놓이면, 그 브랜치가 다음 태스크의 originalBranch 로 기록되고 복원도
+//   다시 그 브랜치로 돌아가, 작업트리가 영구히 master 로 못 돌아오는 드리프트가 됐다
+//   (= 사용자가 지적한 "자꾸 디폴트 브랜치에서 시작 안 함"). 복원 목적지를 항상 base 로 고정해
+//   태스크가 끝날 때마다 트리를 master 로 되돌려(self-heal) 드리프트를 끊는다.
+function restoreTaskBranch(ctx, baseDir = BASE_DIR) {
+  const git = (args) => spawnSync('git', args, { cwd: baseDir, encoding: 'utf8', windowsHide: true });
+  // ctx 가 없으면 prepareTaskBranch 가 트리를 전환하지 않은 경우(비-repo/busy 등) → 복원할 것이 없다.
+  if (!ctx) { gitTreeBusy = false; return; }
+  try {
+    // 복원 목적지 = 기본 브랜치. ctx.base 우선, 없으면 실측(getBaseBranch).
+    const base = ctx.base || getBaseBranch(baseDir);
+    const co = git(['checkout', base]);
+    if (co.status !== 0) {
+      console.error(`[TaskManager] restoreTaskBranch: base(${base}) 체크아웃 실패 —`, (co.stderr || '').trim());
+    } else {
+      // rule 41 step 5: 기본 브랜치를 origin 최신으로 ff 동기화(다음 태스크의 startPoint 신선도 확보).
+      // 절대 로컬 base 에 커밋하지 않으므로 diverge 없음 → ff-only 로 안전. 실패해도 비치명(로그만).
+      const pull = git(['pull', '--ff-only', 'origin', base]);
+      if (pull.status !== 0) {
+        console.error(`[TaskManager] restoreTaskBranch: ${base} ff-pull 실패(비치명) —`, (pull.stderr || '').trim());
+      }
+    }
+    // prepareTaskBranch 에서 autostash 한 tracked 변경을 기본 브랜치로 되돌린다.
+    // (정상 경로에서는 originalBranch == base 이므로 팝 대상 브랜치가 동일. 드리프트 상황이었다면
+    //  변경을 master 로 합류시켜 브랜치 오염을 정리한다.)
+    if (ctx.stashed) {
+      const pop = git(['stash', 'pop']);
+      if (pop.status !== 0) {
+        // pop 충돌 시 stash 는 보존된다(git 기본 동작) — 사용자 변경을 유실하지 않는다.
+        console.error('[TaskManager] restoreTaskBranch stash pop 충돌 — stash 보존:', (pop.stderr || '').trim());
+      }
+    }
+  } finally {
+    gitTreeBusy = false;
+  }
+}
+
+// 태스크 브랜치 → base 로 PR 을 보장한다. 이미 열린 PR 이 있으면 그 URL, 없으면 새로 만든다.
+function ensurePR(taskId, taskTitle, branch, base, baseDir = BASE_DIR) {
+  // gh 는 GH_TOKEN/GITHUB_TOKEN 이 있으면 그 토큰을 우선 사용한다. 봇 .env 의 GITHUB_TOKEN 은
+  // PR 생성 권한이 없어 `gh pr create` 가 "Resource not accessible by personal access token" 로
+  // 실패하고 compare 링크로 폴백됐다. 이 두 토큰을 제거해 gh 자체 로그인(gh auth login — PR 권한 보유)을
+  // 쓰게 한다. (github-issues.js 등 다른 곳의 GITHUB_TOKEN 사용에는 영향 없음: 여기 spawn 에만 적용.)
+  const ghEnv = { ...process.env };
+  delete ghEnv.GITHUB_TOKEN;
+  delete ghEnv.GH_TOKEN;
+  const gh = (args) => spawnSync('gh', args, { cwd: baseDir, encoding: 'utf8', windowsHide: true, env: ghEnv });
+
+  // 기존 PR 확인 (재실행/중복 방지)
+  const existing = gh(['pr', 'list', '--head', branch, '--state', 'open', '--json', 'url', '--jq', '.[0].url']);
+  const existingUrl = (existing.stdout || '').trim();
+  if (existing.status === 0 && existingUrl.startsWith('http')) return existingUrl;
+
+  const title = `task(${taskId}): ${taskTitle.slice(0, 60)}`;
+  const body = [
+    'giipclaude Bot 자동 생성 PR.',
+    '',
+    `- 태스크: \`${taskId}\``,
+    `- 브랜치: \`${branch}\` → \`${base}\``,
+    `- 결과 보고서: \`.agent/results/${taskId}.md\``,
+    '',
+    '🤖 Generated by giipclaude Bot',
+  ].join('\n');
+
+  const create = gh(['pr', 'create', '--base', base, '--head', branch, '--title', title, '--body', body]);
+  if (create.status === 0) {
+    const url = (create.stdout || '').trim().split(/\s+/).filter(u => u.startsWith('http')).pop();
+    if (url) return url;
+  }
+  console.error('[TaskManager] gh pr create 실패:', (create.stderr || create.stdout || '').trim().slice(0, 300));
+  return buildCompareUrl(branch, base, baseDir); // 폴백: compare 링크 (수동 PR 생성 가능)
+}
+
+// ── PR 충돌 게이트: 변경 파일이 '미머지 열린 PR'의 대상이면 그 PR 목록을 돌려준다 ──────
+// 목적(사용자 요청): 같은 파일을 대상으로 한 PR 이 아직 머지 안 된 상태에서 또 다른 작업이
+//   같은 파일을 건드리면 나중에 반드시 conflict 가 난다(#84/#85 사례). PR 을 새로 만들기
+//   '직전'에 검사해 경쟁 PR 을 만들지 않고 멈춘 뒤, 사용자에게 "먼저 그 PR 을 머지하라"고 알린다.
+//   서브에이전트는 작업이 끝나기 전엔 어떤 파일을 바꿀지 알 수 없으므로, 확실한 차단 지점은
+//   '변경 파일이 확정된 = PR 생성 직전'이다.
+// selfBranch(= 지금 만들 브랜치)의 PR 은 제외한다(자기 자신과는 충돌 아님).
+// gh 실패/파싱 실패는 비치명 → 빈 배열(게이트 미적용). 데이터 안전 원칙상 '막지 못해도 진행'.
+function findBlockingPRs(root, changedFiles, selfBranch) {
+  if (!changedFiles || changedFiles.length === 0) return [];
+  const ghEnv = { ...process.env };
+  delete ghEnv.GITHUB_TOKEN; // ensurePR 과 동일: 봇 PAT 대신 gh 자체 로그인 사용
+  delete ghEnv.GH_TOKEN;
+  const r = spawnSync('gh', ['pr', 'list', '--state', 'open', '--json', 'number,headRefName,url,files', '--limit', '100'],
+    { cwd: root, encoding: 'utf8', windowsHide: true, env: ghEnv });
+  if (r.status !== 0) {
+    console.error('[TaskManager] findBlockingPRs: gh pr list 실패(게이트 미적용):', (r.stderr || '').trim().slice(0, 120));
+    return [];
+  }
+  let prs;
+  try { prs = JSON.parse(r.stdout || '[]'); } catch { return []; }
+  const changed = new Set(changedFiles); // repo-relative path 로 비교(양쪽 동일 기준)
+  const blocking = [];
+  for (const pr of (prs || [])) {
+    if (pr.headRefName === selfBranch) continue;
+    const overlap = (pr.files || []).map(f => f.path).filter(p => changed.has(p));
+    if (overlap.length) blocking.push({ number: pr.number, url: pr.url, branch: pr.headRefName, files: overlap });
+  }
+  return blocking;
+}
+
+// ── Phase 3': 태스크 브랜치에 커밋·push → base 로 PR 생성 → 작업트리 복원 ────────
+// 반환값 = PR URL(성공) / compare URL(폴백) / null(push 실패). 항상 작업트리를 원복한다.
+function gitPushResultAndPR(taskId, taskTitle, resultFile, doneTaskFile, ctx, baseDir = BASE_DIR) {
+  const git = (args) => spawnSync('git', args, { cwd: baseDir, encoding: 'utf8', windowsHide: true });
+  try {
+    const branch = (ctx && ctx.branch) || getCurrentBranch(baseDir);
+    const base = (ctx && ctx.base) || getBaseBranch(baseDir);
+
+    // 산출물 전부 스테이지(경로 무관, rule 35). 런타임 json 은 .gitignore 처리됨.
+    git(['add', '-A']);
+    const msg = `task(${taskId}): ${taskTitle.slice(0, 60)}\n\nAuto-committed by giipclaude Bot\n\nDirective: ${branch} → PR to ${base}`;
+    const commitRes = git(['commit', '-m', msg]);
+    if (commitRes.status !== 0 && !(commitRes.stdout || '').includes('nothing to commit')) {
+      console.error('[TaskManager] git commit:', (commitRes.stderr || '').trim());
+      return null;
+    }
+
+    // 태스크 전용 브랜치 push. 신규면 -u, 이미 있으면 rebase 후 재시도.
+    let push = git(['push', '-u', 'origin', branch]);
+    if (push.status !== 0) {
+      console.error('[TaskManager] push rejected, retry after fetch+rebase:', (push.stderr || '').trim());
+      git(['fetch', 'origin', branch]);
+      git(['pull', '--rebase', '--autostash', 'origin', branch]);
+      push = git(['push', '-u', 'origin', branch]);
+    }
+    if (push.status !== 0) {
+      console.error('[TaskManager] git push:', (push.stderr || '').trim());
+      return null;
+    }
+
+    return ensurePR(taskId, taskTitle, branch, base, baseDir);
+  } finally {
+    restoreTaskBranch(ctx, baseDir); // 성공/실패/예외 무관 항상 원복 + busy 해제
+  }
+}
+
+// ── Phase 3'': タスクが実際に変更した「全リポジトリ」を安全に commit·push·PR ──────
+//
+// 背景: サブエージェントは effWorkDir 直下のリポだけでなく、その配下の独立した
+//   nested git repo (例: giipprj/giipv3, giipprj/giipdb) も変更しうる。従来は単一リポ
+//   しか扱わず、nested repo の変更は commit も push も PR もされず「作業ツリーに孤児の
+//   未コミット変更」として取り残されていた。ここではそれを解消する。
+//
+// データ安全性が最優先ルール:
+//   ① 実行「前」に clean だったリポだけを自動 PR する。実行前から dirt があったリポは
+//      一切触らず skip+報告する（ユーザの未コミット作業を絶対に失わない/上書きしない）。
+//   ② タスク由来の変更は git stash で退避してから origin/base 起点の bot/task ブランチへ
+//      pop する。pop が conflict した場合は必ず元ブランチへ変更を戻し、stash を捨てない。
+//   ③ 各リポは try/finally 相当で必ず元ブランチへ復元する。conflict のまま放置しない。
+
+function gitC(root, args) {
+  return spawnSync('git', args, { cwd: root, encoding: 'utf8', windowsHide: true });
+}
+
+// リポジトリ root を Windows 大小文字無視で正規化（除外集合との突合に使う）
+function normRoot(p) {
+  return path.resolve(p).replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+}
+
+// dir を含む git リポジトリの toplevel（無ければ null）
+function repoToplevel(dir) {
+  const r = gitC(dir, ['rev-parse', '--show-toplevel']);
+  if (r.status !== 0) return null;
+  return (r.stdout || '').trim() || null;
+}
+
+function isGitRepoDir(dir) {
+  try { return fs.existsSync(path.join(dir, '.git')); } catch { return false; }
+}
+
+// `git status --porcelain` の各行から「変更パス」だけを Set で返す。
+// rename(`old -> new`)は new 側、quoted path は unquote して比較キーにする。
+function porcelainPathSet(root) {
+  const set = new Set();
+  const r = gitC(root, ['status', '--porcelain']);
+  if (r.status !== 0) return set;
+  (r.stdout || '').split('\n').forEach(line => {
+    if (!line.trim()) return;
+    let p = line.slice(3); // 先頭3文字はステータス(XY + 空白)
+    const arrow = p.indexOf(' -> ');
+    if (arrow >= 0) p = p.slice(arrow + 4);
+    p = p.trim().replace(/^"(.*)"$/, '$1');
+    if (p) set.add(p);
+  });
+  return set;
+}
+
+// 実行「前」に候補リポの dirty 状態をスナップショットする。
+// 候補 = effWorkDir を含むリポ(toplevel) + その 1〜2 階層下の nested git repo。
+// 返り値: [{ root, normRoot, originalBranch, preDirt:Set<path> }]
+// 候補リポの root 一覧(Map<normRoot, root>)を返す。
+// = effWorkDir を含むリポ(toplevel) + その 1〜2 階層下の nested git repo。
+// repo を見つけたらその中へは降りない(サブサブ repo は追わない)。
+function candidateRepoRoots(effWorkDir) {
+  const roots = new Map(); // normRoot -> 実際の root
+  const addRoot = (dir) => {
+    const top = repoToplevel(dir);
+    if (top) roots.set(normRoot(top), top);
+  };
+
+  addRoot(effWorkDir); // primary: effWorkDir を含むリポ
+
+  // nested repo 探索(1〜2 階層)。repo を見つけたらその中へは降りない(サブサブ repo は追わない)。
+  const listDirs = (base) => {
+    try {
+      return fs.readdirSync(base, { withFileTypes: true })
+        .filter(d => d.isDirectory() && !d.name.startsWith('.') && d.name !== 'node_modules')
+        .map(d => path.join(base, d.name));
+    } catch { return []; }
+  };
+  const scanNested = (base) => {
+    for (const d1 of listDirs(base)) {
+      if (isGitRepoDir(d1)) { addRoot(d1); continue; }
+      for (const d2 of listDirs(d1)) {
+        if (isGitRepoDir(d2)) addRoot(d2);
+      }
+    }
+  };
+  scanNested(effWorkDir);
+
+  // ── 追加: effWorkDir の「兄弟」リポも候補に含める(root cause 修正) ──
+  // 背景: プレフィックス無しのタスク(例:「azure-rg …修正」)は effWorkDir=BASE_DIR(lowyworkenv)
+  //   になるが、サブエージェントは projects/giipprj/giipv3 のような lowyworkenv の兄弟パスを編集する。
+  //   effWorkDir 配下しか見ない従来スキャンでは、その変更は発見されず auto-PR から丸ごと漏れ、
+  //   コードは commit も PR もされないまま「完了」報告される(= giipv3 を直したのに PR が無い、の根因)。
+  //   → PROJECTS_ROOT を常に 1〜2 階層スキャンして兄弟 repo(giipprj/giipv3, giipprj/giipdb 等)も候補化。
+  //   実際に「このタスクが変更した」repo だけが後段(commitAndPRChangedRepos)で preDirt 差分により
+  //   commit/PR/skip 判定されるため、候補を広げても無関係リポには一切触れない。
+  const PROJECTS_ROOT = path.dirname(BASE_DIR); // …/projects
+  scanNested(PROJECTS_ROOT);
+
+  return roots;
+}
+
+// ── 作業「前」: 候補 nested repo の base ブランチを origin 最新へ ff 同期する ──
+// 根本原因(ユーザ指摘「giipv3 は毎回 conflict」): prepareTaskBranch/restoreTaskBranch の
+//   ff-pull は BASE_DIR(lowyworkenv) だけを同期し、nested repo(giipprj/giipv3 等)の
+//   ローカル base は誰も更新しなかった。その結果サブエージェントは「数コミット遅れた
+//   stale な base」上でファイルを編集し、後段 auto-PR が最新 origin/base から切った
+//   ブランチへ replay する時に、既に origin へ merge 済みの変更と衝突していた
+//   (= giip-701 が作った SES ファイルを giip-705 が「新規」として再作成 → add/add conflict)。
+// 対策: 作業を始める前に、各候補 repo が「base ブランチ上」かつ「クリーン(未コミット無し)」
+//   の時だけ origin/base へ ff 同期する。feature ブランチや dirty(= 未統合 WIP)は触らない。
+// 安全性: 常に ff-only。ローカル base に独自コミットは積まない前提なので diverge しない。
+//   失敗・skip は非致命(ログのみ) — 同期できなくても従来同様に実行は続く。
+function syncCandidateReposBase(effWorkDir) {
+  const results = [];
+  let roots;
+  try { roots = candidateRepoRoots(effWorkDir); }
+  catch (e) { console.error('[TaskManager] syncCandidateReposBase: 列挙失敗 —', e.message); return results; }
+  for (const [, root] of roots) {
+    try {
+      const base = getBaseBranch(root);
+      const cur = getCurrentBranch(root);
+      if (cur !== base) { results.push({ root, base, synced: false, reason: `on '${cur}' (not base)` }); continue; }
+      if (porcelainPathSet(root).size > 0) { results.push({ root, base, synced: false, reason: 'dirty working tree' }); continue; }
+      const fetched = gitC(root, ['fetch', 'origin', base]);
+      if (fetched.status !== 0) { results.push({ root, base, synced: false, reason: `fetch failed: ${(fetched.stderr || '').trim().slice(0, 80)}` }); continue; }
+      const ff = gitC(root, ['merge', '--ff-only', `origin/${base}`]);
+      if (ff.status !== 0) { results.push({ root, base, synced: false, reason: `ff-merge failed: ${(ff.stderr || '').trim().slice(0, 80)}` }); continue; }
+      results.push({ root, base, synced: true, advanced: !/Already up to date/i.test(ff.stdout || '') });
+    } catch (e) {
+      results.push({ root, synced: false, reason: e.message });
+    }
+  }
+  for (const r of results) {
+    if (r.synced) console.log(`[TaskManager] syncCandidateReposBase: ${r.root} ${r.base} ${r.advanced ? 'ff-synced to origin' : 'up to date'}`);
+    else console.log(`[TaskManager] syncCandidateReposBase: skip ${r.root} — ${r.reason}`);
+  }
+  return results;
+}
+
+// ── 作業「前」: 候補 nested repo を「このタスク専用ブランチ」へ切り替える(スト孤児化の根本予防) ──
+//
+// 근본원인: prepareTaskBranch/restoreTaskBranch 는 BASE_DIR(lowyworkenv)만 bot/task-<id> 로
+//   전환·복원했고, nested repo(giipprj/giipv3, giipprj/giipdb)는 직전 태스크가 남긴 브랜치
+//   (예: bot/task-giip-705)에 파킹된 채 방치됐다. 그래서 서브에이전트의 nested 편집은
+//   '남의 브랜치'에 쌓였고, 후단 commitAndPRChangedRepos 는 originalBranch≠bot/task-<id> 를
+//   'foreign branch' 로 판정해 skip → 코드가 PR 없이 스트랜드됐다(= "REVIEW인데 배포 0"의 뿌리).
+//
+// 대책: 서브에이전트 실행 '전'에, base 위에서 clean 한 후보 repo 만 origin/base 起点의
+//   bot/task-<id> 로 checkout 한다. 그러면 편집이 올바른 전용 브랜치에 쌓여 자동 commit·PR 이
+//   성립하고, unlanded(스트랜드)가 정상 경로에서 사라진다.
+//
+// 안전 원칙(데이터 최우선):
+//   · clean(미커밋 0) & base 브랜치 위 인 repo 만 만진다.
+//   · dirty(미정리 WIP) 나 이미 비-base(foreign)에 있는 repo 는 절대 건드리지 않는다
+//     (= 기존 스트랜드/사용자 WIP 를 덮지 않음 — 그건 감사/재개가 별도 처리).
+//   · BASE_DIR 은 prepareTaskBranch 가 이미 담당하므로 제외.
+// 반환: [{ root, base, branch, restoreTo }] — restoreNestedBranches 로 원복할 목록.
+function prepareNestedBranches(effWorkDir, taskId, excludeRoots = [BASE_DIR]) {
+  const branch = `bot/task-${taskId}`;
+  const exclude = new Set((excludeRoots || []).map(normRoot));
+  const prepared = [];
+  let roots;
+  try { roots = candidateRepoRoots(effWorkDir); }
+  catch (e) { console.error('[TaskManager] prepareNestedBranches: 열거 실패 —', e.message); return prepared; }
+  for (const [nr, root] of roots) {
+    if (exclude.has(nr)) continue;
+    try {
+      clearStaleRebaseState(root);
+      const base = getBaseBranch(root);
+      const cur = getCurrentBranch(root);
+      if (porcelainPathSet(root).size > 0) {
+        console.log(`[TaskManager] prepareNestedBranches: skip ${root} — dirty(미정리 WIP); ${branch} 전환 안 함`);
+        continue;
+      }
+      if (cur !== base) {
+        console.log(`[TaskManager] prepareNestedBranches: skip ${root} — '${cur}'(≠base ${base}); 스트랜드 흔적, 이번엔 만지지 않음`);
+        continue;
+      }
+      const fetched = gitC(root, ['fetch', 'origin', base]);
+      const startPoint = fetched.status === 0 ? `origin/${base}` : base;
+      const co = gitC(root, ['checkout', '-B', branch, startPoint]);
+      if (co.status !== 0) {
+        console.error(`[TaskManager] prepareNestedBranches: ${root} checkout 실패 —`, (co.stderr || '').trim().slice(0, 120));
+        continue;
+      }
+      prepared.push({ root, base, branch, restoreTo: base });
+      console.log(`[TaskManager] prepareNestedBranches: ${root} → ${branch} (from ${startPoint})`);
+    } catch (e) {
+      console.error(`[TaskManager] prepareNestedBranches: ${root} 오류 —`, e.message);
+    }
+  }
+  return prepared;
+}
+
+// ── 作業「後」: prepareNestedBranches 로 전환한 nested repo 를 base 로 복원한다 ──
+// commitAndPRChangedRepos 가 이미 각 repo 를 commit·push·PR 하고 그 전용 브랜치로 checkout 해 둔다.
+//   여기서 base 로 되돌려(ff-pull) 다음 태스크가 clean·on-base 에서 시작하게 한다
+//   (= restoreTaskBranch 의 nested 판; 드리프트 누적을 끊는다).
+// 안전: 커밋 안 된 변경이 남은 repo 는 base 로 옮기면 변경이 딸려가 오염되므로 복원을 보류한다
+//   (= commitAndPR 가 skip/blocked 로 남긴 잔여물은 그대로 두고 감사/재개가 처리).
+function restoreNestedBranches(prepared) {
+  for (const p of (prepared || [])) {
+    const root = p.root, base = p.restoreTo || p.base;
+    try {
+      if (porcelainPathSet(root).size > 0) {
+        console.log(`[TaskManager] restoreNestedBranches: ${root} 에 미커밋 변경 잔존 → base 복원 보류(스트랜드 방지)`);
+        continue;
+      }
+      const co = gitC(root, ['checkout', base]);
+      if (co.status !== 0) { console.error(`[TaskManager] restoreNestedBranches: ${root} base(${base}) 복원 실패 —`, (co.stderr || '').trim().slice(0, 120)); continue; }
+      const pull = gitC(root, ['pull', '--ff-only', 'origin', base]);
+      if (pull.status !== 0) console.error(`[TaskManager] restoreNestedBranches: ${root} ${base} ff-pull 실패(비치명) —`, (pull.stderr || '').trim().slice(0, 80));
+    } catch (e) {
+      console.error(`[TaskManager] restoreNestedBranches: ${root} 오류 —`, e.message);
+    }
+  }
+}
+
+// ── 크래시 감지 후 nested repo 브랜치 회수(2026-07-28) ──
+// startTaskExecution 이 prepareNestedBranches 로 bot/task-<id> 전환한 "후", giip issue
+// IN_PROGRESS 전이(handlers.js maybeFinish) "전"에 프로세스가 죽으면(예: Slack 소켓
+// self-heal exit) nested repo 가 그 브랜치에 취소선 없이 남는다. index.js 의
+// reconcileTaskState 가 이 태스크를 pending 으로 되돌릴 때 호출해, restoreNestedBranches 와
+// 동일한 안전 기준(미커밋 변경 남은 repo 는 절대 건드리지 않음)으로 clean 한 취소분만
+// 자동 복원하고, 나머지는 stranded 로 보고해 감사 대상을 명확히 한다.
+// (실사고: giipv3 가 bot/task-giip-780 에 15시간+ 방치돼 gissue 스케줄러 큐 전체가
+//  30시간 넘게 막힌 원인 중 하나 — 크래시 시점에 브랜치만 남고 아무도 감시하지 않았다.)
+function reclaimCrashedTaskBranches(workDir, taskId) {
+  const branch = `bot/task-${taskId}`;
+  const restored = [];
+  const stranded = [];
+  let roots;
+  try { roots = candidateRepoRoots(workDir); }
+  catch (e) { console.error(`[TaskManager] reclaimCrashedTaskBranches: 열거 실패 —`, e.message); return { restored, stranded }; }
+  for (const [, root] of roots) {
+    try {
+      const cur = getCurrentBranch(root);
+      if (cur !== branch) continue; // 이 태스크가 남긴 취소분이 아님
+      if (porcelainPathSet(root).size > 0) {
+        console.log(`[TaskManager] reclaimCrashedTaskBranches: ${root} 에 미커밋 변경 잔존 → 복원 보류(stranded, 확인 필요)`);
+        stranded.push(root);
+        continue;
+      }
+      const base = getBaseBranch(root);
+      const co = gitC(root, ['checkout', base]);
+      if (co.status !== 0) {
+        console.error(`[TaskManager] reclaimCrashedTaskBranches: ${root} base(${base}) 복원 실패 —`, (co.stderr || '').trim().slice(0, 120));
+        stranded.push(root);
+        continue;
+      }
+      gitC(root, ['pull', '--ff-only', 'origin', base]);
+      console.log(`[TaskManager] reclaimCrashedTaskBranches: ${root} → ${base} 자동 복원 완료(크래시 취소분 회수)`);
+      restored.push(root);
+    } catch (e) {
+      console.error(`[TaskManager] reclaimCrashedTaskBranches: ${root} 오류 —`, e.message);
+      stranded.push(root);
+    }
+  }
+  return { restored, stranded };
+}
+
+function snapshotCandidateRepos(effWorkDir) {
+  const roots = candidateRepoRoots(effWorkDir);
+  const snaps = [];
+  for (const [norm, root] of roots) {
+    snaps.push({
+      root,
+      normRoot: norm,
+      originalBranch: getCurrentBranch(root),
+      preDirt: porcelainPathSet(root),
+    });
+  }
+  return snaps;
+}
+
+// スナップショットした候補リポのうち、タスクが実際に変更したものを各々 commit·push·PR する。
+// opts.excludeRoots: ここで扱わないリポ(既存の gitPushResultAndPR が扱う BASE_DIR 等)。
+// 返り値: { prs:[{repo,url}], skipped:[{repo,reason}] }
+function commitAndPRChangedRepos(taskId, taskTitle, snapshots, opts = {}) {
+  const excludeRoots = new Set((opts.excludeRoots || []).map(normRoot));
+  const prs = [];
+  const skipped = [];
+  const blocked = []; // PR 충돌 게이트에 걸려 PR 생성을 보류한 저장소(브랜치는 push 됨)
+  const branch = `bot/task-${taskId}`;
+  const coAuthor = 'Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>';
+
+  for (const snap of (snapshots || [])) {
+    const root = snap.root;
+    const nr = snap.normRoot || normRoot(root);
+    if (excludeRoots.has(nr)) continue; // 別経路が担当 → ここでは扱わない
+
+    const git = (args) => gitC(root, args);
+    const originalBranch = snap.originalBranch || getCurrentBranch(root);
+
+    try {
+      const postDirt = porcelainPathSet(root);
+      const newPaths = [...postDirt].filter(p => !snap.preDirt.has(p));
+      if (newPaths.length === 0) continue; // タスクはこのリポを変更していない → 静かに skip
+
+      // ── データ安全ガード ①: 実行前から dirt があったリポの扱い ──
+      // 背景: giipv3/giipdb 等の nested repo は、サブエージェントが「git 操作禁止」指示の下で
+      //   作業ツリーにのみ変更を残す（あるいは前段セッションが残す）ため、スナップショット時点で
+      //   ほぼ常に preDirt > 0 になる。旧実装はこれを一律 skip していたため nested repo の変更は
+      //   永遠に自動 PR されなかった（= ユーザ指摘の「毎回 手動 PR」問題の根因）。
+      //
+      // 判別の鍵: 「専用 feature/task ブランチ上の dirt」はそのタスクの作業とみなせる（base で
+      //   ないブランチに居る = 誰かが意図してそのブランチを切って作業した強いシグナル）。一方
+      //   「base ブランチ上の dirt」はユーザの無関係な WIP かもしれず、従来通り触らない。
+      if (snap.preDirt.size > 0) {
+        const base0 = getBaseBranch(root);
+        const onFeatureBranch = originalBranch && originalBranch !== base0 && originalBranch !== 'HEAD';
+        if (!onFeatureBranch) {
+          // base ブランチ上の未コミット変更 = 曖昧な WIP。安全側に倒して従来通り skip。
+          skipped.push({ repo: root, reason: `pre-existing uncommitted changes on base branch '${base0}'; manual PR needed`, files: newPaths });
+          continue;
+        }
+        // ── 誤帰属ガード: 「別タスクのブランチ」に停まった共有チェックアウトは自動 commit しない ──
+        // 背景(giip-720 実例): giipprj/giipv3 は複数タスクで共有される単一チェックアウトで、
+        //   別タスクのブランチ(例 bot/task-giip-705)に停まったまま、そのタスクの未コミット変更と
+        //   今回タスクの変更が同じ作業ツリーで混在する。ここで git add -A + commit すると
+        //   (1) 他タスクの churn まで巻き込み、(2) 他タスクのブランチ/PR へ push してしまう。
+        //   → このタスク専用ブランチ(bot/task-<taskId>)に居る時だけ自動 commit。そうでなければ
+        //     手動 PR が必要な旨を明示して skip(= 後段の完了報告で警告される)。
+        if (originalBranch !== branch) {
+          skipped.push({
+            repo: root,
+            reason: `changes tangled on foreign branch '${originalBranch}' (≠ ${branch}); shared checkout — manual PR needed`,
+            files: newPaths,
+          });
+          continue;
+        }
+        // 専用 feature/task ブランチ上の変更 → そのブランチのまま commit·push·PR する。
+        // (stash→bot/task ブランチ の付け替えはしない: ブランチは既にセッション/前段が選んでいる。)
+        git(['add', '-A']);
+        const msgF = `task(${taskId}): ${String(taskTitle).slice(0, 60)}\n\nAuto-committed by giipclaude Bot\n\n${coAuthor}`;
+        const commitF = git(['commit', '-m', msgF]);
+        if (commitF.status !== 0 && !/nothing to commit/.test(commitF.stdout || '')) {
+          skipped.push({ repo: root, reason: `commit failed on '${originalBranch}': ${(commitF.stderr || '').trim().slice(0, 120)}` });
+          continue;
+        }
+        let pushF = git(['push', '-u', 'origin', originalBranch]);
+        if (pushF.status !== 0) {
+          git(['pull', '--rebase', '--autostash', 'origin', originalBranch]);
+          pushF = git(['push', '-u', 'origin', originalBranch]);
+        }
+        if (pushF.status !== 0) {
+          skipped.push({ repo: root, reason: `push failed: ${(pushF.stderr || '').trim().slice(0, 120)} (commit is local on '${originalBranch}')` });
+          continue;
+        }
+        // ── PR 충돌 게이트: 변경 파일이 미머지 열린 PR 대상이면 PR 생성 보류(브랜치는 이미 push) ──
+        const blkF = findBlockingPRs(root, newPaths, originalBranch);
+        if (blkF.length) {
+          blocked.push({ repo: root, branch: originalBranch, base: base0, prs: blkF, files: newPaths });
+          continue; // 경쟁 PR 을 만들지 않는다. "머지완료 <taskid>" 로 재개.
+        }
+        const urlF = ensurePR(taskId, taskTitle, originalBranch, base0, root);
+        prs.push({ repo: root, url: urlF });
+        continue; // このリポは完了。以降の clean-before(stash) フローには進まない。
+      }
+
+      const base = getBaseBranch(root);
+
+      // タスク由来の変更を stash に退避(未追跡ファイル含む -u)
+      const stash = git(['stash', 'push', '-u', '-m', `bot-task-${taskId}`]);
+      if (stash.status !== 0) {
+        skipped.push({ repo: root, reason: `stash failed: ${(stash.stderr || '').trim().slice(0, 120)}` });
+        continue;
+      }
+      if (/No local changes to save/.test(stash.stdout || '')) continue; // 念のため
+
+      // origin/base 起点で bot/task ブランチを作る(常に最新 base 基準)
+      const fetched = git(['fetch', 'origin', base]);
+      const startPoint = fetched.status === 0 ? `origin/${base}` : base;
+      const co = git(['checkout', '-B', branch, startPoint]);
+      if (co.status !== 0) {
+        // ブランチ作成失敗 → まだ originalBranch に居るので stash を戻して skip(データ保全)
+        git(['checkout', originalBranch]);
+        git(['stash', 'pop']);
+        skipped.push({ repo: root, reason: `branch create failed; changes restored to ${originalBranch}` });
+        continue;
+      }
+
+      // 退避した変更を bot ブランチへ適用
+      const pop = git(['stash', 'pop']);
+      const conflicts = git(['diff', '--name-only', '--diff-filter=U']);
+      const hasConflict = (conflicts.stdout || '').trim().length > 0;
+      if (pop.status !== 0 || hasConflict) {
+        // ── conflict 回復(データ非損失を保証) ──
+        // pop が conflict した場合、stash エントリは list に残る(pop は drop しない)。
+        // bot ブランチ側の部分適用を破棄 → 元ブランチへ戻り → そこへ stash を再適用する。
+        // clean-before 保証があるため、この reset --hard + clean は「タスク由来の未追跡物」
+        // だけを消し、stash に全て残っているので損失ゼロ。
+        git(['reset', '--hard', 'HEAD']);
+        git(['clean', '-fd']); // clean-before なので untracked は全てタスク/stash 由来 = 復元可能
+        git(['checkout', originalBranch]);
+        const pop2 = git(['stash', 'pop']); // clean な元ブランチへ再適用
+        git(['branch', '-D', branch]);       // 空の bot ブランチを削除
+        skipped.push({
+          repo: root,
+          reason: pop2.status === 0
+            ? 'auto-PR conflict; changes left on original branch'
+            : 'auto-PR conflict; stash retained (see `git stash list`) — manual recovery needed',
+        });
+        continue;
+      }
+
+      // clean pop → commit
+      git(['add', '-A']);
+      const msg = `task(${taskId}): ${String(taskTitle).slice(0, 60)}\n\nAuto-committed by giipclaude Bot\n\n${coAuthor}`;
+      const commit = git(['commit', '-m', msg]);
+      if (commit.status !== 0 && !/nothing to commit/.test(commit.stdout || '')) {
+        git(['checkout', originalBranch]);
+        skipped.push({ repo: root, reason: `commit failed: ${(commit.stderr || '').trim().slice(0, 120)}` });
+        continue;
+      }
+
+      // push(新規は -u、拒否時は fetch+rebase して再試行)
+      let push = git(['push', '-u', 'origin', branch]);
+      if (push.status !== 0) {
+        git(['fetch', 'origin', branch]);
+        git(['pull', '--rebase', '--autostash', 'origin', branch]);
+        push = git(['push', '-u', 'origin', branch]);
+      }
+      if (push.status !== 0) {
+        // push 失敗: commit はローカル bot ブランチに残る(損失なし)。元ブランチへ戻して報告。
+        git(['checkout', originalBranch]);
+        skipped.push({ repo: root, reason: `push failed: ${(push.stderr || '').trim().slice(0, 120)} (commit is local on ${branch})` });
+        continue;
+      }
+
+      // ── PR 충돌 게이트: 변경 파일이 미머지 열린 PR 대상이면 PR 생성 보류(브랜치는 이미 push) ──
+      const blk = findBlockingPRs(root, newPaths, branch);
+      if (blk.length) {
+        blocked.push({ repo: root, branch, base, prs: blk, files: newPaths });
+        git(['checkout', originalBranch]); // 작업트리 복원(PR 은 보류)
+        continue; // 경쟁 PR 을 만들지 않는다. "머지완료 <taskid>" 로 재개.
+      }
+      // PR 作成(gh 失敗時は ensurePR が compare URL にフォールバック)
+      const url = ensurePR(taskId, taskTitle, branch, base, root);
+      prs.push({ repo: root, url });
+      git(['checkout', originalBranch]); // 作業ツリーを元ブランチへ復元
+    } catch (e) {
+      // best-effort: 例外時も必ず元ブランチへ戻し、mid-conflict のまま放置しない
+      try { git(['checkout', originalBranch]); } catch {}
+      skipped.push({ repo: root, reason: `error: ${e.message}` });
+    }
+  }
+  return { prs, skipped, blocked };
+}
+
+// ── 재개: 사용자가 "머지완료 <taskid>" 로 선행 PR 머지를 알리면, 보류했던 저장소들을
+//   최신 base 로 rebase 후 PR 을 생성한다. 머지된 변경이 base 에 들어왔으므로 대개 자동 해소.
+//   여전히 같은 라인을 건드려 conflict 나면 그 저장소는 수동 필요로 보고(브랜치는 보존).
+// blockedRecords: commitAndPRChangedRepos 가 tasklist 에 남긴 [{repo,branch,base,prs,files}].
+// 반환: { prs:[{repo,url}], stillBlocked:[{repo,reason,branch,prs?}], failed:[{repo,reason}] }.
+function resumeBlockedTask(taskId, taskTitle, blockedRecords) {
+  const prs = [], stillBlocked = [], failed = [];
+  for (const rec of (blockedRecords || [])) {
+    const root = rec.repo;
+    const branch = rec.branch;
+    const base = rec.base || getBaseBranch(root);
+    const git = (args) => gitC(root, args);
+    let originalBranch = null;
+    try {
+      originalBranch = getCurrentBranch(root);
+      git(['fetch', 'origin', base]);
+      git(['fetch', 'origin', branch]);
+      const co = git(['checkout', branch]);
+      if (co.status !== 0) { failed.push({ repo: root, reason: `checkout '${branch}' 실패: ${(co.stderr || '').trim().slice(0, 120)}` }); continue; }
+      const rb = git(['rebase', `origin/${base}`]);
+      if (rb.status !== 0) {
+        git(['rebase', '--abort']);
+        if (originalBranch) git(['checkout', originalBranch]);
+        stillBlocked.push({ repo: root, branch, reason: `origin/${base} 로 rebase conflict — 수동 해소 필요` });
+        continue;
+      }
+      const push = git(['push', '--force-with-lease', 'origin', branch]);
+      if (push.status !== 0) {
+        if (originalBranch) git(['checkout', originalBranch]);
+        failed.push({ repo: root, reason: `push 실패: ${(push.stderr || '').trim().slice(0, 120)} (커밋은 로컬 '${branch}' 에 보존)` });
+        continue;
+      }
+      // 재검사: rebase 후에도 아직 겹치는 미머지 PR 이 있으면 또 보류
+      const blk = findBlockingPRs(root, rec.files || [], branch);
+      if (blk.length) {
+        if (originalBranch) git(['checkout', originalBranch]);
+        stillBlocked.push({ repo: root, branch, prs: blk, reason: `아직 미머지 PR ${blk.map(b => '#' + b.number).join(', ')} 대상` });
+        continue;
+      }
+      const url = ensurePR(taskId, taskTitle, branch, base, root);
+      prs.push({ repo: root, url });
+      if (originalBranch) git(['checkout', originalBranch]);
+    } catch (e) {
+      try { if (originalBranch) git(['checkout', originalBranch]); } catch {}
+      failed.push({ repo: root, reason: e.message });
+    }
+  }
+  return { prs, stillBlocked, failed };
 }
 
 // ── Tasklist ファイル管理 ──────────────────────────────────────────────────────
@@ -454,7 +1457,7 @@ function getTasklistByStatus(status = null) {
 
 // ステータス絵文字
 function statusEmoji(status) {
-  return { pending: '🕐', running: '⚙️', completed: '✅', cancelled: '🚫' }[status] || '❓';
+  return { pending: '🕐', running: '⚙️', completed: '✅', cancelled: '🚫', blocked: '⏸️' }[status] || '❓';
 }
 
 // タスクファイルの GitHub URL を動的に生成
@@ -505,16 +1508,33 @@ module.exports = {
   getTimestampId,
   analyzeRequest,
   createTaskFile,
+  updateTaskFile,
+  rebuildTaskFileFromIssue,
   extractTitle,
   extractSummary,
   startExecution,
   completeTaskFile,
   appendTaskNote,
   gitPushResult,
+  prepareTaskBranch,
+  restoreTaskBranch,
+  gitPushResultAndPR,
+  snapshotCandidateRepos,
+  syncCandidateReposBase,
+  prepareNestedBranches,
+  restoreNestedBranches,
+  reclaimCrashedTaskBranches,
+  commitAndPRChangedRepos,
+  findBlockingPRs,
+  resumeBlockedTask,
+  getBaseBranch,
   addToTasklist,
   updateTasklistEntry,
   getTasklistByStatus,
   statusEmoji,
   cancelTaskFile,
   getTaskFileUrl,
+  buildContextCatalog,
+  selectContextFiles,
+  normalizeFilesRead,
 };


### PR DESCRIPTION
## 배경
`lowyworkenv/slack-bot`이 이 프로젝트의 기준(reference) 소스이며, `giip-fde-agent/slack-bot`은 거기서 동기화받는 공개 배포본입니다. 오늘 lowyworkenv 쪽에 추가한 `allowlist` 명령어를 포함해, 그동안 쌓인 드리프트를 반영합니다.

## 주요 변경
- **`allowlist` 명령어(신규)**: DM/채널에서 입력하면 현재 `SLACK_ALLOWED_USERS`/`SLACK_CHANNEL_IDS` 화이트리스트를 유저명/채널명과 함께 표시
- **Claude 계정 로테이션** (`claude-accounts.js`): 여러 구독 계정에 weighted round-robin + 사용량 한도 자동 쿨다운
- **MiniMax 폴백 엔진** (`minimax-accounts.js`): 설정 시 1순위 실행, 실패/한도시에만 Claude 계정 풀로 폴백
- **claude-cli.js**: 프롬프트를 stdin으로 전달(Windows `ENAMETOOLONG` 회피), Q&A 경로에 `--disallowedTools Write/Edit/NotebookEdit`로 오분류된 작업요청의 무단 파일변경 방지
- **repo-lock.js**: pm2 상시 데몬과 다른 프로세스 간 git 작업 상호배제 락
- **dashboard.js**: 처리 현황 대시보드 자동 갱신(선택 기능)
- 그 외 handlers.js/index.js/task-manager.js 등 다수 버그수정

## 병합 시 주의해서 처리한 부분
- `config.js`: lowyworkenv 쪽은 `PROJECTS_ROOT`가 로컬 절대경로(`C:\Users\...`)로 하드코딩돼 있어 **그대로 가져오지 않고**, 이 저장소의 기존 `WORKSPACE_DIR`/`PROJECTS_ROOT` env 기반 범용 경로 해석 로직을 보존한 채 `ALLOWED_USERS`/`getSelfBotId`/`setSelfBotId`만 추가했습니다.
- `.env.example`: 기존 섹션(WORKSPACE_DIR 등)은 보존하고 `SLACK_ALLOWED_USERS`/MiniMax/Claude 계정 로테이션 문서만 추가했습니다.

## 의도적으로 제외
- `check_stock_db.js` — 실제 운영 DB 평문 비밀번호가 하드코딩돼 있어(내부 전용) 배포 금지
- `reset_password.js` — 다른 내부 프로젝트(vgt-vegetrade-auth-api) 전용 스크립트
- `channel-project.json` / `project-csn.json` — 실제 워크스페이스 데이터라 이 저장소는 빈 템플릿(`map:{}`)을 유지해야 함
- `package-lock.json` / `tasklist.json` — 잠금파일/런타임 상태

## 검증
- 동기화된 모든 `.js` 파일 `node --check` 통과
- 로컬 `require('./...')` 대상이 전부 존재하는지 확인
- 하드코딩된 시크릿/토큰/개인 절대경로가 섞여 들어가지 않았는지 전수 grep 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)