### PR TITLE
fix(slack-bot): 매핑 JSON 파싱 실패 시 조용한 폴백 대신 경고 로깅 (giip-885)

### DIFF
--- a/slack-bot/config.js
+++ b/slack-bot/config.js
@@ -81,16 +81,28 @@ function parseProjectPrefix(text) {
   return { workDir: BASE_DIR, cleanText: text, projectName: null };
 }
 
+// マッピング JSON ファイルを読み込んで parse する共通ヘルパ。
+// ファイル未存在（ENOENT）は正常ケース（新規インストール等）として静かに null を返すが、
+// ファイルは在るのに JSON が壊れている／読めない（ディスク障害・同時書き込み衝突・手動編集ミス等）
+// 場合は console.error で警告を残す。黙って空マッピングにフォールバックすると、プロジェクト／
+// チャンネル対応が全部消えたように動きながら何のログも残らず原因究明が遅れるため（issue #885）。
+function readMappingJson(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (e) {
+    if (e && e.code !== 'ENOENT') {
+      console.error(`[config] 매핑 파일 파싱/읽기 실패 (${file}): ${e && e.message}`);
+    }
+    return null;
+  }
+}
+
 // ── プロジェクト名 → giip csn マッピング（project-csn.json 駆動） ──────────────
 // `<プロジェクト名> issue 등록 <内容>` を、そのプロジェクトの csn で登録するための対応表。
 // ハードコードせず project-csn.json で管理し、呼び出しごとに読み直す（再起動なしで反映）。
 function loadProjectCsnMap() {
-  try {
-    const j = JSON.parse(fs.readFileSync(PROJECT_CSN_FILE, 'utf8'));
-    return (j && j.map) || {};
-  } catch {
-    return {};
-  }
+  const j = readMappingJson(PROJECT_CSN_FILE);
+  return (j && j.map) || {};
 }
 
 // workDir（またはプロジェクト名）→ csn(Number) or null。未登録なら null を返し、
@@ -106,12 +118,8 @@ function resolveProjectCsn(workDirOrName) {
 // _comment 等 map 以外のフィールドを保存したまま map だけ更新する。読み込みは
 // loadProjectCsnMap と同じく毎回読み直すので再起動なしで即時反映される。
 function readProjectCsnFile() {
-  try {
-    const j = JSON.parse(fs.readFileSync(PROJECT_CSN_FILE, 'utf8'));
-    return (j && typeof j === 'object') ? j : {};
-  } catch {
-    return {};
-  }
+  const j = readMappingJson(PROJECT_CSN_FILE);
+  return (j && typeof j === 'object') ? j : {};
 }
 function writeProjectCsnFile(obj) {
   fs.writeFileSync(PROJECT_CSN_FILE, JSON.stringify(obj, null, 2) + '\n', 'utf8');
@@ -174,12 +182,8 @@ function deleteProjectCsn(name) {
 // 「このチャンネルの発話はすべて <project> として扱う」を実現する。project-csn.json と同じく
 // 呼び出しごとに読み直す（再起動なしで反映）。giip csn とは独立に channelId → プロジェクト名を持つ。
 function loadChannelProjectMap() {
-  try {
-    const j = JSON.parse(fs.readFileSync(CHANNEL_PROJECT_FILE, 'utf8'));
-    return (j && j.map) || {};
-  } catch {
-    return {};
-  }
+  const j = readMappingJson(CHANNEL_PROJECT_FILE);
+  return (j && j.map) || {};
 }
 
 // channelId → プロジェクト名(小文字) or null。未登録なら null。
@@ -214,12 +218,8 @@ function applyChannelPin(channelId, parsed) {
 
 // ── channel-project.json の読み書き（Slack `giip channel` コマンドから利用） ────
 function readChannelProjectFile() {
-  try {
-    const j = JSON.parse(fs.readFileSync(CHANNEL_PROJECT_FILE, 'utf8'));
-    return (j && typeof j === 'object') ? j : {};
-  } catch {
-    return {};
-  }
+  const j = readMappingJson(CHANNEL_PROJECT_FILE);
+  return (j && typeof j === 'object') ? j : {};
 }
 function writeChannelProjectFile(obj) {
   fs.writeFileSync(CHANNEL_PROJECT_FILE, JSON.stringify(obj, null, 2) + '\n', 'utf8');


### PR DESCRIPTION
## 배경 (giip-885)
`slack-bot/config.js`의 매핑 로더 4함수 — `loadProjectCsnMap` / `readProjectCsnFile` / `loadChannelProjectMap` / `readChannelProjectFile` — 가 매핑 JSON(`project-csn.json`, `channel-project.json`) 파싱 실패를 전부 `catch { return {} }` 로 조용히 삼켰다.

이 때문에 **파일 미존재(신규 설치 등 정상)** 와 **파일은 있으나 JSON이 깨진 비정상**(디스크 오류·동시쓰기 충돌·수동 편집 실수)이 로그상 구분되지 않았다. 후자가 나면 프로젝트/채널 매핑이 전부 사라진 듯 동작하며 아무 경고도 안 남아 원인 파악이 늦어진다 (giip-821 / giip-867 계열의 "조용한 폴백" 실패모드).

## 변경
- 공통 헬퍼 `readMappingJson(file)` 도입.
  - `ENOENT`(파일 미존재) → 정상으로 취급, **조용히** `null` 반환.
  - 그 외(파싱 실패·읽기 오류) → `console.error`로 경고 후 `null` 반환.
- 4개 함수는 헬퍼를 통해 읽되 **기존 반환 형태(`{}` / 원본 객체)를 그대로 유지** → 동작 보존.

## 검증
로컬 node 재현 테스트(임시 스크립트, 원본 파일 백업/복원):
- ✅ 정상 파일 → 맵 반환, `console.error` 없음
- ✅ 파일 미존재(ENOENT) → `{}` 반환, `console.error` **없음**(오탐 방지)
- ✅ 깨진 JSON → `{}` 반환 + `console.error` **1회** 발생(파일명 포함)
- ✅ `node --check` 문법 통과

## 참고
- 관련: giip-885, giip-821, giip-867
- 대상 레포는 giip-fde-agent (lowyworkenv/slack-bot 은 reference-only 라 대상 아님)

🤖 Generated with [Claude Code](https://claude.com/claude-code)