### PR TITLE
task(giip-1063): AI 토큰·모델 비용 최적화 — 컨텍스트 선별/등급별 모델 라우팅/Fast Path/checkpoint 재시도/비용 계측

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ slack-bot/tasklist.json
 # slack-bot giip 계정 시크릿(SK) — 실값 비커밋, *.sample 만 추적
 slack-bot/.secrets/*
 !slack-bot/.secrets/*.sample.json
+
+# giip-1063: 비용 로그 / 재시도 checkpoint 등 런타임 산출물 (머신 로컬, 커밋 금지)
+.agent/runtime/

--- a/slack-bot/.env.example
+++ b/slack-bot/.env.example
@@ -26,10 +26,37 @@ WORKSPACE_DIR=/path/to/your/workspace
 # Default: parent of WORKSPACE_DIR
 # PROJECTS_ROOT=/path/to/projects
 
-# ── Claude CLI ────────────────────────────────────────────────────────────────
-# Model to use for analysis and Q&A (sync calls)
-# Defaults to claude-opus-4-8
-# CLAUDE_MODEL=claude-opus-4-8
+# ── Model routing (giip-1063 cost optimisation) ──────────────────────────────
+# Models are resolved centrally in model-config.js — never hardcode them in code.
+# Tiers map to task classes decided by model-router.js
+# (trivial / standard / complex / critical).
+#
+# The special token `minimax-default` means "use the MiniMax provider with the
+# model configured in MINIMAX_MODEL". If MiniMax is unset or cooling down, the
+# tier falls back to MODEL_FALLBACK_STANDARD / MODEL_FALLBACK_CRITICAL.
+# `sonnet` / `opus` / `haiku` are aliases the `claude` CLI resolves itself.
+#
+# MODEL_TRIVIAL=minimax-default
+# MODEL_STANDARD=minimax-default
+# MODEL_COMPLEX=sonnet
+# MODEL_CRITICAL=claude-opus-4-8
+# MODEL_PLANNER=minimax-default
+# MODEL_FALLBACK_STANDARD=sonnet
+# MODEL_FALLBACK_CRITICAL=claude-opus-4-8
+# Q&A path (answerInChannel / handleDM). Default: MODEL_FALLBACK_STANDARD
+# MODEL_QA=sonnet
+# task/question intent classifier. Default: MODEL_FALLBACK_STANDARD
+# MODEL_CLASSIFIER=sonnet
+
+# ── Retry limits (never retry forever) ───────────────────────────────────────
+# MAX_PROVIDER_RETRIES=1
+# MAX_TOTAL_ATTEMPTS=3
+
+# ── Auto-injected context limits (per task) ──────────────────────────────────
+# CONTEXT_DEFAULT_MAX_FILES=6
+# CONTEXT_HARD_MAX_FILES=8
+# CONTEXT_PER_FILE_MAX_CHARS=4000
+# CONTEXT_TOTAL_MAX_CHARS=48000
 
 # ── GitHub Integration (optional) ────────────────────────────────────────────
 # GitHub personal access token (repo scope)

--- a/slack-bot/batch-planner.js
+++ b/slack-bot/batch-planner.js
@@ -1,0 +1,107 @@
+/**
+ * batch-planner.js — 한 메시지 안의 독립 조회를 한 번에 묶기 (giip-1063, 3.8)
+ *
+ * 목적: "파일 5개 존재 확인", "설정값 3개 비교"처럼 한 메시지에 담긴 독립적인 read/search/status
+ * 요청을 각각 모델 호출로 쪼개지 않고 한 번에 처리하도록 프롬프트에 배치 지시를 넣는다.
+ *
+ * 하지 않는 것
+ *  - Slack 메시지를 일정 시간 대기시켜 강제로 묶지 않는다(한 메시지 안의 복수 요청만 대상).
+ *  - 서로 종속된 "수정" 작업을 한 호출로 무리하게 합치지 않는다.
+ */
+
+// 읽기 전용 신호 (조회/확인/검색/비교)
+const READONLY_RE = new RegExp([
+  '확인', '조회', '보여', '알려', '어디', '무엇', '뭐야', '뭔가요', '있나', '있어', '있는지', '목록', '리스트',
+  '비교', '검색', '찾아', '상태', '몇\\s*개',
+  '確認', '一覧', 'どこ', 'なに', '検索', '状態',
+  '\\bcheck\\b', '\\blist\\b', '\\bshow\\b', '\\bwhat\\b', '\\bwhere\\b', '\\bwhich\\b', '\\bfind\\b',
+  '\\bsearch\\b', '\\bstatus\\b', '\\bcompare\\b', '\\bexists?\\b', '\\bdoes\\b',
+].join('|'), 'i');
+
+// 변경 신호 (있으면 배치 대상에서 제외 — 충돌 가능성)
+const MUTATING_RE = new RegExp([
+  '수정', '변경', '삭제', '추가', '생성', '작성', '만들', '고쳐', '바꿔', '배포', '커밋', '푸시', '리팩',
+  '修正', '変更', '削除', '追加', '作成', 'デプロイ',
+  '\\bfix\\b', '\\bchange\\b', '\\bdelete\\b', '\\bremove\\b', '\\badd\\b', '\\bcreate\\b', '\\bwrite\\b',
+  '\\bupdate\\b', '\\bdeploy\\b', '\\bcommit\\b', '\\brefactor\\b', '\\brename\\b',
+].join('|'), 'i');
+
+// 앞 항목에 종속됨을 나타내는 지시어
+const DEPENDENT_RE = /(그\s*(결과|다음|후|걸|것)|위의|앞의|이어서|거기서|それ|その後|then\b|after that\b|based on (that|the above))/i;
+
+/**
+ * 메시지를 독립 항목 후보로 쪼갠다.
+ *  - 번호 목록(1. 2. / 1) 2))
+ *  - 불릿(- , •)
+ *  - 줄바꿈
+ *  - 물음표로 끝나는 문장들
+ */
+function splitItems(text) {
+  const raw = String(text || '').trim();
+  if (!raw) return [];
+
+  const lines = raw.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
+
+  const numbered = lines.filter(l => /^(\d+[.)]|[-*•])\s+/.test(l));
+  if (numbered.length >= 2) {
+    return numbered.map(l => l.replace(/^(\d+[.)]|[-*•])\s+/, '').trim()).filter(Boolean);
+  }
+
+  if (lines.length >= 2) return lines;
+
+  // 한 줄에 물음표로 구분된 복수 질문
+  const questions = raw.split(/(?<=[?？])\s+/).map(s => s.trim()).filter(Boolean);
+  if (questions.length >= 2) return questions;
+
+  return [raw];
+}
+
+/**
+ * 한 메시지 안의 독립 조회를 묶을 수 있는지 판정한다.
+ *
+ * @returns {{
+ *   batchable: boolean, batch_size: number, model_calls_saved: number,
+ *   items: string[], reason: string, instruction: string|null
+ * }}
+ */
+function planBatch(text) {
+  const items = splitItems(text);
+  const none = (reason) => ({
+    batchable: false, batch_size: items.length || 1, model_calls_saved: 0, items, reason, instruction: null,
+  });
+
+  if (items.length < 2) return none('단일 요청');
+  if (items.length > 20) return none('항목이 너무 많음(20개 초과) — 배치 지시 생략');
+
+  const readonlyItems = items.filter(i => READONLY_RE.test(i) && !MUTATING_RE.test(i));
+  const dependent = items.some(i => DEPENDENT_RE.test(i));
+
+  if (dependent) return none('항목 간 종속 표현 검출 — 직렬 처리');
+  if (readonlyItems.length < 2) return none('독립 read/search/status 항목이 2개 미만');
+  if (readonlyItems.length !== items.length) {
+    return none('변경 작업이 섞여 있음 — 배치하지 않고 기존 경로로 처리');
+  }
+
+  return {
+    batchable: true,
+    batch_size: items.length,
+    // 항목마다 따로 물었다면 items.length 회 호출이 필요했을 것 → 1회로 처리하므로 n-1 절약
+    model_calls_saved: items.length - 1,
+    items,
+    reason: '한 메시지 안의 독립 read/search/status 요청',
+    instruction: buildBatchInstruction(items),
+  };
+}
+
+/** 배치 처리 지시문. 모델에게 항목별 답을 한 번의 응답으로 만들게 한다. */
+function buildBatchInstruction(items) {
+  return [
+    '=== 배치 처리 지시 ===',
+    `이 메시지에는 서로 독립적인 조회 요청이 ${items.length}건 들어 있다. 항목마다 따로 되묻지 말고,`,
+    '필요한 읽기/검색/상태 확인을 한 번에(가능하면 병렬로) 수행한 뒤 아래 번호대로 한 응답에 정리해 답하라.',
+    ...items.map((it, i) => `${i + 1}. ${it}`),
+    '항목 중 하나가 실패하면 그 항목만 실패로 표시하고 나머지는 그대로 답하라.',
+  ].join('\n');
+}
+
+module.exports = { planBatch, splitItems, buildBatchInstruction, READONLY_RE, MUTATING_RE };

--- a/slack-bot/claude-cli.js
+++ b/slack-bot/claude-cli.js
@@ -5,6 +5,9 @@ const { spawn } = require('child_process');
 const accounts = require('./claude-accounts');
 const minimax = require('./minimax-accounts');
 const { getAgentDir, BASE_DIR, PROJECTS_ROOT } = require('./config');
+const modelConfig = require('./model-config'); // giip-1063: 모델명 하드코딩 제거(중앙 설정)
+const costTracker = require('./cost-tracker');
+const batchPlanner = require('./batch-planner');
 
 // ── spawn → Promise 래퍼 (이벤트 루프 비차단) ────────────────────────────────
 function spawnAsync(cmd, args, opts = {}) {
@@ -72,8 +75,42 @@ async function reAuthClaude(account = null) {
 }
 
 // ── claude CLI (비동기 — 이벤트 루프 비차단) ──────────────────────────────────
-async function callClaude(prompt, workDir = BASE_DIR) {
+/**
+ * Q&A 경로. giip-1063 변경점
+ *  - Claude 폴백 모델을 `claude-opus-4-8` 로 하드코딩하지 않고 model-config(MODEL_QA)에서 읽는다.
+ *  - opts.userText 가 주어지면 한 메시지 안의 독립 조회를 한 번에 처리하도록 배치 지시를 덧붙인다(3.8).
+ *  - 호출마다 토큰/비용/재시도를 cost-tracker 에 기록한다.
+ *
+ * @param {string} prompt
+ * @param {string} [workDir]
+ * @param {object} [opts] { userText, taskId }
+ */
+async function callClaude(prompt, workDir = BASE_DIR, opts = {}) {
   const agentDir = getAgentDir(workDir);
+  // 3.8 배치: 한 메시지 안의 독립 read/search/status 요청만 묶는다(대기시켜 강제 배치하지 않음).
+  let batch = { batchable: false, batch_size: 1, model_calls_saved: 0 };
+  if (opts.userText) {
+    try {
+      batch = batchPlanner.planBatch(opts.userText);
+      if (batch.batchable && batch.instruction) {
+        prompt = `${prompt}\n\n${batch.instruction}`;
+        console.log(`[Bot] 배치 처리: ${batch.batch_size}개 독립 조회 → 모델 호출 ${batch.model_calls_saved}회 절약`);
+      }
+    } catch { /* 배치 판정 실패는 무시 */ }
+  }
+  const logCost = (extra) => {
+    try {
+      costTracker.record(BASE_DIR, {
+        task_id: opts.taskId || null,
+        phase: 'qa',
+        task_class: 'standard',
+        input_chars: prompt.length,
+        batch_size: batch.batch_size,
+        model_calls_saved: batch.model_calls_saved,
+        ...extra,
+      });
+    } catch { /* 계측 실패가 응답을 막지 않는다 */ }
+  };
   const baseArgs = [
     '-p', // プロンプトは argv ではなく stdin で渡す（ENAMETOOLONG 回避）→ spawnAsync opts.input
     // callClaude は Q&A（answerInChannel / handleDM）専用。ファイル変更は
@@ -94,13 +131,20 @@ async function callClaude(prompt, workDir = BASE_DIR) {
   const mm = minimax.resolve();
   if (mm) {
     console.log(`[Bot] MiniMax(${mm.model}) 로 실행(Q&A)`);
+    const t0 = Date.now();
     const result = await spawnAsync('claude', [...baseArgs, '--model', mm.model], {
       cwd: workDir,
       timeout: 20 * 60 * 1000,
       env: minimax.envFor(mm),
       input: prompt,
     });
-    if (result.status === 0) return (result.stdout || '').trim();
+    const out0 = (result.stdout || '').trim();
+    logCost({
+      provider: 'minimax', model: mm.model, attempt: 1, duration_ms: Date.now() - t0,
+      status: result.status === 0 ? 'success' : 'failed', output_chars: out0.length,
+      ...(costTracker.parseUsageFromOutput(`${result.stdout || ''}\n${result.stderr || ''}`) || {}),
+    });
+    if (result.status === 0) return out0;
     const mmOut = `${result.stdout || ''}\n${result.stderr || ''}`;
     if (minimax.isUsageLimit(mmOut)) minimax.noteUsageLimit();
     mmExhausted = true;
@@ -114,8 +158,11 @@ async function callClaude(prompt, workDir = BASE_DIR) {
     const acct = accounts.pickAccount();
     if (!acct) break; // 전 계정 쿨다운
     const env = accounts.envFor(acct);
-    const args = [...baseArgs, '--model', 'claude-opus-4-8'];
+    // giip-1063: Q&A 에 최상위 모델을 고정하지 않는다. MODEL_QA(기본 MODEL_FALLBACK_STANDARD).
+    const qaModel = modelConfig.qaModel();
+    const args = [...baseArgs, '--model', qaModel];
 
+    const t1 = Date.now();
     const result = await spawnAsync('claude', args, {
       cwd: workDir,
       timeout: 20 * 60 * 1000, // 20分
@@ -123,7 +170,14 @@ async function callClaude(prompt, workDir = BASE_DIR) {
       input: prompt, // 프롬프트는 stdin 으로 (ENAMETOOLONG 회피)
     }); // ETIMEDOUT 등은 그대로 throw
 
-    if (result.status === 0) return (result.stdout || '').trim();
+    const out1 = (result.stdout || '').trim();
+    logCost({
+      provider: 'claude', model: qaModel, attempt: attempt + 1, duration_ms: Date.now() - t1,
+      status: result.status === 0 ? 'success' : 'failed', output_chars: out1.length,
+      fallback_from: mmExhausted ? 'minimax' : null,
+      ...(costTracker.parseUsageFromOutput(`${result.stdout || ''}\n${result.stderr || ''}`) || {}),
+    });
+    if (result.status === 0) return out1;
 
     // 사용량 한도 → 해당 계정 쿨다운 후 다음 계정으로
     // 한도 메시지("You've hit your weekly limit ...")는 stderr가 아니라 stdout에

--- a/slack-bot/context-builder.js
+++ b/slack-bot/context-builder.js
@@ -1,0 +1,486 @@
+/**
+ * context-builder.js — 선별 컨텍스트 로딩 (giip-1063, 3.1 / 3.7)
+ *
+ * 기존 문제
+ *   - 분석 단계에서 관련 파일을 골라놓고, 실행 단계(startExecution)에서 `readRolesContext()` 로
+ *     `.agent/roles/*.md` 전체를 다시 프롬프트에 넣었다.
+ *   - 파일 본문을 `content.slice(0, 800)` 로 무조건 앞부분만 잘라 후반부의 중요한 규칙이 사라졌다.
+ *   - 카탈로그를 만들려고 모든 SKILL 본문을 통째로 읽었다.
+ *
+ * 여기서 제공하는 것
+ *   - buildContextCatalog: 파일 헤드만 읽어 name/description/trigger 를 뽑는다(+mtime/hash 캐시)
+ *   - selectContextFilesStatic: LLM 호출 없이 정적 점수로 선별(Fast Path 및 LLM 실패 폴백)
+ *   - readSelectedContext: 개수/길이 한도, 중복 제거, 제목 기반 섹션 축약
+ *   - minimalDefaultContext: 선택 결과가 없거나 손상됐을 때 쓰는 "최소" 기본 컨텍스트
+ *                            (전체 roles 를 다시 읽지 않는다)
+ *   - formatContextFilesYaml / parseContextFiles: 태스크 파일에 구조화 저장/복원
+ */
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const modelConfig = require('./model-config');
+
+const HEAD_BYTES = 4096;   // 카탈로그용으로 읽는 최대 바이트 (본문 전체를 읽지 않는다)
+
+// ── 파일 헤드 캐시 (경로 + mtime + size 로 무효화, content hash 병기) ─────────
+const _headCache = new Map();   // absPath → { mtimeMs, size, hash, meta }
+const _bodyCache = new Map();   // absPath → { mtimeMs, size, hash, content }
+
+function statSafe(p) {
+  try { return fs.statSync(p); } catch { return null; }
+}
+
+function sha1(s) {
+  return crypto.createHash('sha1').update(s, 'utf8').digest('hex').slice(0, 16);
+}
+
+/** 파일 앞부분만 읽는다(전체 로드 방지). */
+function readHead(absPath, bytes = HEAD_BYTES) {
+  let fd;
+  try {
+    fd = fs.openSync(absPath, 'r');
+    const buf = Buffer.alloc(bytes);
+    const n = fs.readSync(fd, buf, 0, bytes, 0);
+    return buf.slice(0, n).toString('utf8');
+  } catch {
+    return '';
+  } finally {
+    if (fd !== undefined) { try { fs.closeSync(fd); } catch {} }
+  }
+}
+
+/**
+ * SKILL/role/rule 파일의 메타(name/description/trigger)만 헤드에서 추출.
+ * @returns {{name:string, description:string, trigger:string}}
+ */
+function extractMeta(head, fallbackName) {
+  const fmMatch = head.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  const fm = fmMatch ? fmMatch[1] : '';
+  const pick = (key) => {
+    const m = fm.match(new RegExp(`^${key}\\s*:\\s*(.+)$`, 'im'))
+           || head.match(new RegExp(`^${key}\\s*:\\s*(.+)$`, 'im'));
+    return m ? m[1].trim().replace(/^["']|["']$/g, '') : '';
+  };
+  const name = pick('name') || fallbackName;
+  let description = pick('description');
+  if (!description) {
+    const body = fmMatch ? head.slice(fmMatch[0].length) : head;
+    const line = body.split(/\r?\n/).map(l => l.trim()).find(l => l && l !== '---');
+    description = (line || '').replace(/^#+\s*/, '');
+  }
+  const trigger = pick('trigger') || pick('triggers') || pick('when-to-use');
+  return {
+    name: String(name).slice(0, 120),
+    description: String(description).slice(0, 200),
+    trigger: String(trigger).slice(0, 200),
+  };
+}
+
+/** 캐시된 메타 조회. 변경되지 않은 파일은 재파싱하지 않는다(3.7-4). */
+function getMeta(absPath, fallbackName) {
+  const st = statSafe(absPath);
+  if (!st) return null;
+  const hit = _headCache.get(absPath);
+  if (hit && hit.mtimeMs === st.mtimeMs && hit.size === st.size) {
+    return { ...hit.meta, hash: hit.hash, cached: true };
+  }
+  const head = readHead(absPath);
+  const meta = extractMeta(head, fallbackName);
+  const hash = sha1(head);
+  _headCache.set(absPath, { mtimeMs: st.mtimeMs, size: st.size, hash, meta });
+  return { ...meta, hash, cached: false };
+}
+
+/** 본문 캐시 조회(선택된 파일만). 해시가 같으면 재읽기 없이 재사용한다. */
+function getBody(absPath) {
+  const st = statSafe(absPath);
+  if (!st) return null;
+  const hit = _bodyCache.get(absPath);
+  if (hit && hit.mtimeMs === st.mtimeMs && hit.size === st.size) {
+    return { content: hit.content, hash: hit.hash, cached: true };
+  }
+  let content;
+  try { content = fs.readFileSync(absPath, 'utf8'); } catch { return null; }
+  const hash = sha1(content);
+  _bodyCache.set(absPath, { mtimeMs: st.mtimeMs, size: st.size, hash, content });
+  return { content, hash, cached: false };
+}
+
+function resetCaches() { _headCache.clear(); _bodyCache.clear(); }
+
+// ── 카탈로그 ────────────────────────────────────────────────────────────────
+/**
+ * .agent/roles·rules·skills 의 파일 목록 + (헤드에서 뽑은) name/description/trigger.
+ * 본문은 읽지 않는다.
+ * @returns {Array<{type,path,abs,name,desc,trigger,hash}>}
+ */
+function buildContextCatalog(baseDir, workspaceDir = baseDir) {
+  const out = [];
+  const addFile = (type, absPath) => {
+    const meta = getMeta(absPath, path.basename(absPath, '.md'));
+    if (!meta) return;
+    out.push({
+      type,
+      path: path.relative(baseDir, absPath).replace(/\\/g, '/'),
+      abs: absPath,
+      name: meta.name,
+      desc: meta.description,
+      trigger: meta.trigger,
+      hash: meta.hash,
+    });
+  };
+
+  for (const [type, sub] of [['role', 'roles'], ['rule', 'rules']]) {
+    let dir = path.join(baseDir, '.agent', sub);
+    try { if (!fs.readdirSync(dir).some(f => f.endsWith('.md'))) dir = path.join(workspaceDir, '.agent', sub); }
+    catch { dir = path.join(workspaceDir, '.agent', sub); }
+    try { fs.readdirSync(dir).filter(f => f.endsWith('.md')).forEach(f => addFile(type, path.join(dir, f))); } catch {}
+  }
+
+  let skillsDir = path.join(baseDir, '.agent', 'skills');
+  if (!fs.existsSync(skillsDir)) skillsDir = path.join(workspaceDir, '.agent', 'skills');
+  try {
+    for (const e of fs.readdirSync(skillsDir, { withFileTypes: true })) {
+      if (e.isDirectory()) {
+        const sk = path.join(skillsDir, e.name, 'SKILL.md');
+        if (fs.existsSync(sk)) addFile('skill', sk);
+      } else if (e.name.endsWith('.md')) {
+        addFile('skill', path.join(skillsDir, e.name));
+      }
+    }
+  } catch {}
+  return out;
+}
+
+/** 카탈로그를 LLM 프롬프트용 한 줄 요약으로. 본문이 아니라 메타만 나간다(3.7-2). */
+function formatCatalogForPrompt(catalog) {
+  return catalog
+    .map((c, i) => {
+      const t = c.trigger ? ` | trigger: ${c.trigger}` : '';
+      return `${i + 1}. [${c.type}] ${c.path} — ${c.desc}${t}`;
+    })
+    .join('\n');
+}
+
+// ── 정적 선별 (LLM 호출 없음) ────────────────────────────────────────────────
+const STOPWORDS = new Set([
+  'the', 'and', 'for', 'with', 'this', 'that', 'from', 'into', 'please', '해줘', '해라', '하고', '하는',
+  '수정', '변경', '파일', '작업', '해', '를', '을', '이', '가', '에', '의', 'して', 'する', 'ください',
+]);
+
+function tokenize(text) {
+  return String(text || '')
+    .toLowerCase()
+    .split(/[^0-9a-z가-힣ぁ-んァ-ヶ一-龥_.\-/]+/)
+    .filter(t => t.length >= 2 && !STOPWORDS.has(t));
+}
+
+/**
+ * LLM 없이 요청과 카탈로그 메타의 키워드 겹침으로 컨텍스트 파일을 고른다.
+ * Fast Path(계획 호출 생략) 및 LLM 선별 실패 시 폴백으로 쓴다.
+ */
+function selectContextFilesStatic(requestText, catalog, limits = modelConfig.contextLimits()) {
+  if (!catalog || !catalog.length) return [];
+  const terms = tokenize(requestText);
+  const termSet = new Set(terms);
+  const scored = catalog.map(c => {
+    const hay = tokenize(`${c.path} ${c.name} ${c.desc} ${c.trigger}`);
+    let score = 0;
+    for (const h of hay) if (termSet.has(h)) score += 1;
+    // rule 은 항상 약간의 기본 가중치(요청 범위 밖 수정 방지 등 공통 규칙)
+    if (c.type === 'rule') score += 0.25;
+    return { c, score };
+  }).filter(x => x.score > 0.5);
+
+  scored.sort((a, b) => b.score - a.score);
+  const picked = scored.slice(0, limits.defaultMaxFiles).map(x => ({
+    path: x.c.path,
+    reason: `요청 키워드와 ${x.c.type} 메타가 일치(정적 선별, score=${x.score.toFixed(2)})`,
+    max_chars: limits.perFileMaxChars,
+  }));
+  return picked;
+}
+
+/**
+ * 카탈로그가 너무 크면 선별 호출 프롬프트 자체가 비싸진다(role/rule/skill 60개 = 약 17k자).
+ * 정적 점수로 상위 후보만 남겨 선별 모델에 넘긴다. 점수 0인 파일도 뒤쪽에 섞어 넣어
+ * "키워드가 안 겹치는데 실제로는 필요한" 파일이 완전히 배제되지 않게 한다.
+ */
+function narrowCatalog(requestText, catalog, maxEntries = 30) {
+  if (!catalog || catalog.length <= maxEntries) return catalog || [];
+  const terms = new Set(tokenize(requestText));
+  const scored = catalog.map((c, i) => {
+    const hay = tokenize(`${c.path} ${c.name} ${c.desc} ${c.trigger}`);
+    let score = 0;
+    for (const h of hay) if (terms.has(h)) score += 1;
+    if (c.type === 'rule') score += 0.25;
+    return { c, i, score };
+  });
+  scored.sort((a, b) => b.score - a.score || a.i - b.i);
+  return scored.slice(0, maxEntries).sort((a, b) => a.i - b.i).map(x => x.c);
+}
+
+/**
+ * 선택 결과가 없거나 손상됐을 때 쓰는 "최소" 기본 컨텍스트(3.1-4).
+ * 전체 roles 를 다시 읽지 않는다 — 공통 가드레일 rule 몇 개만.
+ */
+const MINIMAL_DEFAULTS = [
+  '.agent/rules/10_karpathy_guidelines.md',
+  '.agent/rules/00_core_principles.md',
+];
+
+function minimalDefaultContext(baseDir, workspaceDir = baseDir) {
+  const out = [];
+  for (const rel of MINIMAL_DEFAULTS) {
+    for (const root of [baseDir, workspaceDir]) {
+      const abs = path.join(root, rel);
+      if (fs.existsSync(abs)) {
+        out.push({ path: rel, reason: '최소 기본 컨텍스트(선택 목록 없음/손상) — 요청 범위 밖 수정 방지', max_chars: 3000 });
+        break;
+      }
+    }
+  }
+  return out;
+}
+
+// ── 제목 기반 축약 ───────────────────────────────────────────────────────────
+/**
+ * Markdown 을 제목 단위로 쪼개, 요청과 관련된 섹션을 우선 보존하며 maxChars 로 줄인다.
+ * 앞부분만 자르지 않는다 — frontmatter/제목/관련 섹션을 살린다.
+ */
+function condenseMarkdown(content, maxChars, queryTerms = []) {
+  const text = String(content || '');
+  if (text.length <= maxChars) return { text, condensed: false };
+
+  // frontmatter 는 통째로 보존(짧고 메타가 들어있다)
+  let fm = '';
+  let body = text;
+  const fmMatch = text.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n/);
+  if (fmMatch && fmMatch[0].length < Math.min(1200, maxChars / 2)) {
+    fm = fmMatch[0];
+    body = text.slice(fmMatch[0].length);
+  }
+
+  // 제목 단위 분할
+  const lines = body.split(/\r?\n/);
+  const sections = [];
+  let cur = { heading: '', level: 0, lines: [] };
+  for (const line of lines) {
+    const h = line.match(/^(#{1,6})\s+(.*)$/);
+    if (h) {
+      if (cur.lines.length || cur.heading) sections.push(cur);
+      cur = { heading: line, level: h[1].length, lines: [] };
+    } else {
+      cur.lines.push(line);
+    }
+  }
+  if (cur.lines.length || cur.heading) sections.push(cur);
+
+  const termSet = new Set((queryTerms || []).map(t => String(t).toLowerCase()));
+  const scoreOf = (sec) => {
+    const hay = `${sec.heading}\n${sec.lines.join('\n')}`.toLowerCase();
+    let s = 0;
+    for (const t of termSet) if (t.length >= 2 && hay.includes(t)) s += 1;
+    // 규칙/금지/필수 같은 핵심 규칙 섹션은 가중
+    if (/금지|필수|반드시|mandatory|must|never|규칙|rule/i.test(hay)) s += 1.5;
+    return s;
+  };
+
+  const budget = maxChars - fm.length - 80;
+  const chosen = [];
+  let used = 0;
+
+  // 1) 첫 섹션(제목/개요)은 항상 포함
+  if (sections.length) {
+    const first = sections[0];
+    const t = `${first.heading}\n${first.lines.join('\n')}`.trim();
+    const clipped = t.length > budget * 0.4 ? `${t.slice(0, Math.floor(budget * 0.4))}\n…(중략)` : t;
+    chosen.push({ idx: 0, text: clipped });
+    used += clipped.length + 2;
+  }
+
+  // 2) 나머지는 점수 순으로 채운다(원문 순서는 나중에 복원)
+  const rest = sections.map((s, i) => ({ s, i })).slice(1)
+    .map(x => ({ ...x, score: scoreOf(x.s) }))
+    .sort((a, b) => b.score - a.score || a.i - b.i);
+
+  for (const r of rest) {
+    if (used >= budget) break;
+    const t = `${r.s.heading}\n${r.s.lines.join('\n')}`.trim();
+    if (!t) continue;
+    const room = budget - used;
+    const clipped = t.length > room ? `${t.slice(0, Math.max(0, room - 12))}\n…(중략)` : t;
+    if (clipped.trim().length < 10) break;
+    chosen.push({ idx: r.i, text: clipped });
+    used += clipped.length + 2;
+  }
+
+  chosen.sort((a, b) => a.idx - b.idx);
+  const outText = `${fm}${chosen.map(c => c.text).join('\n\n')}`.trim();
+  return { text: `${outText}\n\n…(관련도 낮은 섹션 생략 — 원문: 위 경로 참조)`, condensed: true };
+}
+
+// ── 선택 파일 읽기 ───────────────────────────────────────────────────────────
+/**
+ * 선택된 파일 내용을 한도 안에서 읽어 프롬프트용 문자열을 만든다.
+ *
+ * @param {Array<{path:string,reason?:string,max_chars?:number}>} selected
+ * @param {string} baseDir
+ * @param {object} [opts] { workspaceDir, queryText, limits }
+ * @returns {{context:string, filesRead:Array, stats:object}}
+ */
+function readSelectedContext(selected, baseDir, opts = {}) {
+  const limits = opts.limits || modelConfig.contextLimits();
+  const workspaceDir = opts.workspaceDir || baseDir;
+  const queryTerms = tokenize(opts.queryText || '');
+
+  const parts = [];
+  const filesRead = [];
+  const seenPath = new Set();
+  const seenHash = new Set();   // 같은 내용이 다른 경로로 들어오면 한 번만
+  let totalChars = 0;
+  let skippedForLimit = 0;
+  let cacheHits = 0;
+
+  const list = (selected || []).slice(0, limits.hardMaxFiles);
+
+  for (const s of list) {
+    const rel = String(s && s.path || '').replace(/\\/g, '/');
+    if (!rel) continue;
+
+    // 같은 파일이 여러 경로 표기로 선택되면 한 번만
+    let abs = path.resolve(baseDir, rel);
+    if (!fs.existsSync(abs)) abs = path.resolve(workspaceDir, rel);
+    let key;
+    try { key = fs.realpathSync(abs); } catch { key = abs; }
+    if (seenPath.has(key)) continue;
+
+    const body = getBody(abs);
+    if (!body) continue;
+    if (seenHash.has(body.hash)) continue;   // 동일 내용 중복 규칙 제거
+    if (body.cached) cacheHits += 1;
+
+    const perFile = Math.min(Number(s.max_chars) || limits.perFileMaxChars, limits.perFileMaxChars);
+    const room = limits.totalMaxChars - totalChars;
+    if (room <= 200) { skippedForLimit += 1; continue; }
+
+    const { text, condensed } = condenseMarkdown(body.content, Math.min(perFile, room), queryTerms);
+    const reason = (s.reason && String(s.reason).trim()) || '(사유 미기재)';
+    parts.push(`### ${rel} (로드 사유: ${reason})\n${text}`);
+    totalChars += text.length;
+    seenPath.add(key);
+    seenHash.add(body.hash);
+    filesRead.push({
+      path: rel,
+      reason,
+      max_chars: perFile,
+      chars: text.length,
+      condensed,
+      hash: body.hash,
+      cached: body.cached,
+    });
+  }
+
+  return {
+    context: parts.join('\n\n---\n\n'),
+    filesRead,
+    stats: {
+      files: filesRead.length,
+      chars: totalChars,
+      skipped_for_limit: skippedForLimit,
+      cache_hits: cacheHits,
+      limits,
+    },
+  };
+}
+
+// ── 태스크 파일에 구조화 저장/복원 ───────────────────────────────────────────
+/** context_files 를 태스크 파일 frontmatter 에 넣을 YAML 블록으로. */
+function formatContextFilesYaml(files) {
+  const norm = normalize(files);
+  if (!norm.length) return 'context_files: []';
+  const esc = s => String(s).replace(/"/g, '\\"');
+  return ['context_files:'].concat(
+    norm.map(f => [
+      `  - path: ${f.path}`,
+      `    reason: "${esc(f.reason)}"`,
+      `    max_chars: ${f.max_chars || modelConfig.contextLimits().perFileMaxChars}`,
+    ].join('\n'))
+  ).join('\n');
+}
+
+/**
+ * 태스크 파일 본문에서 선택 컨텍스트 목록을 복원한다.
+ * 신규 형식(context_files: YAML) 우선, 없으면 구 형식(`#   - path — reason` 주석)도 읽는다(하위 호환).
+ */
+function parseContextFiles(taskContent) {
+  const text = String(taskContent || '');
+
+  const block = text.match(/^context_files:\s*(\[\]|\r?\n(?:[ \t]+.*\r?\n?)*)/m);
+  if (block) {
+    if (block[1].trim() === '[]') return [];
+    const out = [];
+    let cur = null;
+    for (const raw of block[1].split(/\r?\n/)) {
+      const line = raw.replace(/\s+$/, '');
+      const p = line.match(/^\s*-\s*path:\s*(.+)$/);
+      if (p) { if (cur) out.push(cur); cur = { path: p[1].trim(), reason: '', max_chars: undefined }; continue; }
+      if (!cur) continue;
+      const r = line.match(/^\s*reason:\s*(.+)$/);
+      if (r) { cur.reason = r[1].trim().replace(/^"|"$/g, '').replace(/\\"/g, '"'); continue; }
+      const m = line.match(/^\s*max_chars:\s*(\d+)\s*$/);
+      if (m) { cur.max_chars = Number(m[1]); continue; }
+    }
+    if (cur) out.push(cur);
+    if (out.length) return out;
+  }
+
+  // 하위 호환: `#   - <path> — <reason>` 주석 형식
+  const legacy = [];
+  const legacyBlock = text.match(/#\s*분석에 로드된 컨텍스트 파일[^\n]*\n((?:#\s+-\s+[^\n]*\n?)+)/);
+  if (legacyBlock) {
+    for (const line of legacyBlock[1].split(/\r?\n/)) {
+      const m = line.match(/^#\s+-\s+(\S+)\s+—\s*(.*)$/);
+      if (m) legacy.push({ path: m[1], reason: m[2].trim() });
+    }
+  }
+  return legacy;
+}
+
+/** filesRead 항목을 {path, reason, max_chars} 로 정규화(문자열/절대경로 입력 후방호환). */
+function normalize(files, baseDir = null) {
+  const per = modelConfig.contextLimits().perFileMaxChars;
+  return (files || []).map(f => {
+    if (typeof f === 'string') {
+      const rel = (baseDir && path.isAbsolute(f))
+        ? path.relative(baseDir, f).replace(/\\/g, '/')
+        : f.replace(/\\/g, '/');
+      return { path: rel, reason: '(직접 지정)', max_chars: per };
+    }
+    return {
+      path: String((f && f.path) || '').replace(/\\/g, '/'),
+      reason: (f && f.reason) || '(사유 미기재)',
+      max_chars: (f && Number(f.max_chars)) || per,
+    };
+  }).filter(f => f.path);
+}
+
+module.exports = {
+  buildContextCatalog,
+  formatCatalogForPrompt,
+  selectContextFilesStatic,
+  narrowCatalog,
+  readSelectedContext,
+  minimalDefaultContext,
+  condenseMarkdown,
+  formatContextFilesYaml,
+  parseContextFiles,
+  normalize,
+  tokenize,
+  getMeta,
+  getBody,
+  resetCaches,
+  MINIMAL_DEFAULTS,
+};

--- a/slack-bot/cost-tracker.js
+++ b/slack-bot/cost-tracker.js
@@ -1,0 +1,283 @@
+/**
+ * cost-tracker.js — 모델 호출별 토큰/비용/재시도/컨텍스트 계측 (giip-1063, 3.9)
+ *
+ * 저장 위치: `.agent/runtime/cost-usage.jsonl` (JSON Lines, .gitignore 대상)
+ *
+ * 측정 원칙
+ *  - CLI 가 토큰 사용량을 알려주면 실제값을 쓰고 estimated:false
+ *  - 안 알려주면 문자 수 기반 추정치 + estimated:true
+ *  - 가격이 설정돼 있지 않은 모델은 비용을 지어내지 않고 estimated_cost_usd:null (토큰만 기록)
+ *  - 기록 전 secret 마스킹
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const modelConfig = require('./model-config');
+const { maskDeep } = require('./secret-mask');
+
+const RUNTIME_SUBDIR = path.join('.agent', 'runtime');
+const LOG_BASENAME = 'cost-usage.jsonl';
+
+function logPath(baseDir) {
+  return path.join(baseDir, RUNTIME_SUBDIR, LOG_BASENAME);
+}
+
+/**
+ * 문자 수 → 토큰 추정. 정확한 tokenizer 가 없으므로 보수적 근사(≈4 chars/token)를 쓰고,
+ * 반드시 estimated:true 로 표시한다.
+ */
+function estimateTokensFromChars(chars) {
+  const n = Number(chars) || 0;
+  return Math.ceil(n / 4);
+}
+
+/**
+ * claude CLI stdout/stderr 에서 토큰 사용량을 best-effort 로 파싱한다.
+ * 현재 `claude -p` 기본 출력은 사용량을 싣지 않으므로 대부분 null 이 나오고,
+ * 그때는 호출측이 문자 수 추정으로 대체한다(estimated:true).
+ */
+function parseUsageFromOutput(output) {
+  const text = String(output || '');
+  // 1) JSON usage 블록 (--output-format json 등)
+  const j = text.match(/"usage"\s*:\s*\{[^}]*"input_tokens"\s*:\s*(\d+)[^}]*"output_tokens"\s*:\s*(\d+)/);
+  if (j) return { input_tokens: Number(j[1]), output_tokens: Number(j[2]), estimated: false };
+  // 2) 사람이 읽는 형태 "Input tokens: 1234 / Output tokens: 567"
+  const i = text.match(/input[_ ]tokens?\s*[:=]\s*(\d+)/i);
+  const o = text.match(/output[_ ]tokens?\s*[:=]\s*(\d+)/i);
+  if (i && o) return { input_tokens: Number(i[1]), output_tokens: Number(o[1]), estimated: false };
+  return null;
+}
+
+/**
+ * 한 건의 모델 호출을 기록한다.
+ *
+ * @param {string} baseDir 기록할 저장소 루트
+ * @param {object} entry
+ *   { task_id, phase, task_class, provider, model, attempt,
+ *     input_chars, output_chars, input_tokens, output_tokens, estimated,
+ *     context_chars, context_files, skills_loaded, cache_hit, duration_ms,
+ *     status, fallback_from, batch_size, model_calls_saved, fast_path,
+ *     prompt_version, context_selection }
+ * @returns {object|null} 기록된 엔트리(마스킹 후)
+ */
+function record(baseDir, entry = {}) {
+  const inputTokens = Number.isFinite(entry.input_tokens)
+    ? entry.input_tokens
+    : estimateTokensFromChars(entry.input_chars);
+  const outputTokens = Number.isFinite(entry.output_tokens)
+    ? entry.output_tokens
+    : estimateTokensFromChars(entry.output_chars);
+  const estimated = entry.estimated !== undefined
+    ? !!entry.estimated
+    : !(Number.isFinite(entry.input_tokens) && Number.isFinite(entry.output_tokens));
+
+  const priced = modelConfig.estimateCostUsd(entry.model, inputTokens, outputTokens);
+
+  const row = maskDeep({
+    timestamp: new Date().toISOString(),
+    task_id: entry.task_id || null,
+    phase: entry.phase || null,
+    task_class: entry.task_class || null,
+    provider: entry.provider || null,
+    model: entry.model || null,
+    attempt: Number(entry.attempt) || 1,
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    estimated,
+    context_chars: Number(entry.context_chars) || 0,
+    context_files: Number(entry.context_files) || 0,
+    skills_loaded: Number(entry.skills_loaded) || 0,
+    cache_hit: entry.cache_hit === undefined ? null : entry.cache_hit,
+    duration_ms: Number(entry.duration_ms) || 0,
+    status: entry.status || 'unknown',
+    fallback_from: entry.fallback_from || null,
+    estimated_cost_usd: priced.cost,
+    price_as_of: priced.as_of,
+    price_source: priced.source,
+    prompt_version: entry.prompt_version || null,
+    fast_path: entry.fast_path === undefined ? null : !!entry.fast_path,
+    batch_size: entry.batch_size === undefined ? null : Number(entry.batch_size),
+    model_calls_saved: entry.model_calls_saved === undefined ? null : Number(entry.model_calls_saved),
+    context_selection: entry.context_selection || null,   // [{path, reason}] — 선택 이유(3.7-7)
+    // checkpoint 로 "이어서" 재개한 시도인지. false 인 재시도는 작업을 처음부터 다시 한 것.
+    resumed: entry.resumed === undefined ? null : !!entry.resumed,
+  });
+
+  try {
+    fs.mkdirSync(path.join(baseDir, RUNTIME_SUBDIR), { recursive: true });
+    fs.appendFileSync(logPath(baseDir), `${JSON.stringify(row)}\n`, 'utf8');
+  } catch (e) {
+    console.error('[cost-tracker] 기록 실패:', e.message);
+    return null;
+  }
+  return row;
+}
+
+/** JSONL 을 읽어 배열로. 깨진 줄은 건너뛴다. */
+function readAll(baseDir) {
+  let raw;
+  try { raw = fs.readFileSync(logPath(baseDir), 'utf8'); } catch { return []; }
+  const out = [];
+  for (const line of raw.split(/\r?\n/)) {
+    const t = line.trim();
+    if (!t) continue;
+    try { out.push(JSON.parse(t)); } catch {}
+  }
+  return out;
+}
+
+/**
+ * 집계. `!cost`, `!cost today`, `!cost task <id>`, `!cost models` 의 공통 백엔드.
+ * @param {object} [opts] { since:Date|string, taskId:string }
+ */
+function summarize(baseDir, opts = {}) {
+  let rows = readAll(baseDir);
+  if (opts.since) {
+    const since = new Date(opts.since).getTime();
+    rows = rows.filter(r => new Date(r.timestamp).getTime() >= since);
+  }
+  if (opts.taskId) rows = rows.filter(r => r.task_id === opts.taskId);
+
+  const byModel = {};
+  const byClass = {};
+  let inputTokens = 0, outputTokens = 0, cost = 0, costKnown = 0;
+  let fallbacks = 0, retryDuplicateTokens = 0, fastPathCalls = 0, batchSaved = 0;
+  let retries = 0, resumedRetries = 0;
+  const fastPathTasks = new Set();
+  let estimatedRows = 0;
+
+  for (const r of rows) {
+    inputTokens += Number(r.input_tokens) || 0;
+    outputTokens += Number(r.output_tokens) || 0;
+    if (typeof r.estimated_cost_usd === 'number') { cost += r.estimated_cost_usd; costKnown += 1; }
+    if (r.estimated) estimatedRows += 1;
+    if (r.fallback_from) fallbacks += 1;
+    // 재시도 시도에서 다시 보낸 입력 토큰 = 그 호출의 입력 토큰 전부(고정 prefix + 컨텍스트 재전송)
+    if ((Number(r.attempt) || 1) > 1) {
+      retries += 1;
+      retryDuplicateTokens += Number(r.input_tokens) || 0;
+      if (r.resumed) resumedRetries += 1;
+    }
+    if (r.fast_path) { fastPathCalls += 1; if (r.task_id) fastPathTasks.add(r.task_id); }
+    if (Number(r.model_calls_saved)) batchSaved += Number(r.model_calls_saved);
+
+    const mk = `${r.provider || '?'}/${r.model || '?'}`;
+    byModel[mk] = byModel[mk] || { calls: 0, input_tokens: 0, output_tokens: 0, cost: null };
+    byModel[mk].calls += 1;
+    byModel[mk].input_tokens += Number(r.input_tokens) || 0;
+    byModel[mk].output_tokens += Number(r.output_tokens) || 0;
+    if (typeof r.estimated_cost_usd === 'number') {
+      byModel[mk].cost = (byModel[mk].cost || 0) + r.estimated_cost_usd;
+    }
+
+    const ck = r.task_class || 'unknown';
+    byClass[ck] = byClass[ck] || { calls: 0, input_tokens: 0, output_tokens: 0, cost: null, tasks: new Set() };
+    byClass[ck].calls += 1;
+    byClass[ck].input_tokens += Number(r.input_tokens) || 0;
+    byClass[ck].output_tokens += Number(r.output_tokens) || 0;
+    if (r.task_id) byClass[ck].tasks.add(r.task_id);
+    if (typeof r.estimated_cost_usd === 'number') {
+      byClass[ck].cost = (byClass[ck].cost || 0) + r.estimated_cost_usd;
+    }
+  }
+
+  const byClassOut = {};
+  for (const [k, v] of Object.entries(byClass)) {
+    const taskCount = v.tasks.size || 1;
+    byClassOut[k] = {
+      calls: v.calls,
+      tasks: v.tasks.size,
+      input_tokens: v.input_tokens,
+      output_tokens: v.output_tokens,
+      avg_calls_per_task: Math.round((v.calls / taskCount) * 100) / 100,
+      avg_input_tokens_per_task: Math.round(v.input_tokens / taskCount),
+      cost: v.cost,
+    };
+  }
+
+  return {
+    rows: rows.length,
+    calls: rows.length,
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    estimated_rows: estimatedRows,
+    estimated_cost_usd: costKnown ? Math.round(cost * 1e6) / 1e6 : null,
+    priced_calls: costKnown,
+    fallbacks,
+    retry_duplicate_input_tokens: retryDuplicateTokens,
+    retries,
+    resumed_retries: resumedRetries,
+    fast_path_calls: fastPathCalls,
+    fast_path_tasks: fastPathTasks.size,
+    // 추정치: Fast Path 태스크 1건당 컨텍스트 선별 호출 1회 + 계획 생성 호출 1회를 생략한다.
+    fast_path_model_calls_saved_estimated: fastPathTasks.size * 2,
+    batch_model_calls_saved: batchSaved,
+    by_model: byModel,
+    by_class: byClassOut,
+  };
+}
+
+/** Slack/CLI 공용 텍스트 리포트. */
+function formatSummary(sum, title = '비용 요약') {
+  if (!sum.rows) return `${title}: 기록된 모델 호출이 없습니다 (.agent/runtime/${LOG_BASENAME}).`;
+  const lines = [];
+  lines.push(`*${title}*`);
+  lines.push(`• 총 호출 수: ${sum.calls}`);
+  lines.push(`• 입력 토큰: ${sum.input_tokens.toLocaleString()} / 출력 토큰: ${sum.output_tokens.toLocaleString()}`);
+  lines.push(`• 추정 토큰 기반 기록: ${sum.estimated_rows}/${sum.rows}건 (estimated:true)`);
+  lines.push(sum.estimated_cost_usd === null
+    ? '• 추정 비용: 측정 불가 (model-pricing.json 에 단가 미설정 — 토큰만 기록)'
+    : `• 추정 비용: $${sum.estimated_cost_usd} (단가 설정된 ${sum.priced_calls}건 기준)`);
+  lines.push(`• fallback 횟수: ${sum.fallbacks}`);
+  lines.push(`• 재시도 ${sum.retries}회 (그중 checkpoint 로 이어서 재개 ${sum.resumed_retries}회), 재전송된 입력 토큰: ${sum.retry_duplicate_input_tokens.toLocaleString()}`);
+  lines.push(`• Fast Path 태스크 ${sum.fast_path_tasks}건 → 생략된 모델 호출 ${sum.fast_path_model_calls_saved_estimated}회(추정: 선별 1 + 계획 1)`);
+  lines.push(`• 배치로 절약한 모델 호출: ${sum.batch_model_calls_saved}회`);
+  lines.push('');
+  lines.push('*모델별*');
+  for (const [k, v] of Object.entries(sum.by_model)) {
+    lines.push(`• ${k}: ${v.calls}회, in ${v.input_tokens.toLocaleString()} / out ${v.output_tokens.toLocaleString()}${v.cost === null ? '' : `, $${Math.round(v.cost * 1e6) / 1e6}`}`);
+  }
+  lines.push('');
+  lines.push('*작업 등급별*');
+  for (const [k, v] of Object.entries(sum.by_class)) {
+    lines.push(`• ${k}: 태스크 ${v.tasks}건 / 호출 ${v.calls}회 (태스크당 ${v.avg_calls_per_task}회, 평균 입력 ${v.avg_input_tokens_per_task.toLocaleString()} 토큰)${v.cost === null ? ', 비용 측정 불가' : `, $${Math.round(v.cost * 1e6) / 1e6}`}`);
+  }
+  return lines.join('\n');
+}
+
+/** `!cost ...` 인자를 해석해 리포트 문자열을 만든다. Slack/CLI 공용. */
+function report(baseDir, arg = '') {
+  const a = String(arg || '').trim().toLowerCase();
+  if (a === 'today') {
+    const d = new Date(); d.setHours(0, 0, 0, 0);
+    return formatSummary(summarize(baseDir, { since: d }), '비용 요약 (오늘)');
+  }
+  if (a.startsWith('task ')) {
+    const id = String(arg).trim().slice(5).trim();
+    return formatSummary(summarize(baseDir, { taskId: id }), `비용 요약 (task ${id})`);
+  }
+  if (a === 'models') {
+    const sum = summarize(baseDir);
+    if (!sum.rows) return '기록된 모델 호출이 없습니다.';
+    const lines = ['*모델별 사용량*'];
+    for (const [k, v] of Object.entries(sum.by_model)) {
+      lines.push(`• ${k}: ${v.calls}회, in ${v.input_tokens.toLocaleString()} / out ${v.output_tokens.toLocaleString()}${v.cost === null ? ' (단가 미설정 — 비용 측정 불가)' : `, $${Math.round(v.cost * 1e6) / 1e6}`}`);
+    }
+    return lines.join('\n');
+  }
+  return formatSummary(summarize(baseDir), '비용 요약 (전체)');
+}
+
+module.exports = {
+  RUNTIME_SUBDIR,
+  LOG_BASENAME,
+  logPath,
+  estimateTokensFromChars,
+  parseUsageFromOutput,
+  record,
+  readAll,
+  summarize,
+  formatSummary,
+  report,
+};

--- a/slack-bot/handlers.js
+++ b/slack-bot/handlers.js
@@ -153,7 +153,8 @@ MANDATORY RULE — Task Number: If the user's message contains a 14-digit task n
   catch (e) { console.error('[Bot] answer snapshot error:', e.message); }
 
   try {
-    const reply = await callClaude(prompt, workDir);
+    // giip-1063: userText 를 넘겨 한 메시지 안의 독립 조회를 한 번에 처리하도록(배치)
+    const reply = await callClaude(prompt, workDir, { userText: text });
     // 코드레벨 강제: 사용자 메시지의 태스크 ID가 응답에 없으면 첫 줄에 삽입
     const missingIds = extractExistingTaskIds(text).filter(id => !reply.includes(id));
     const finalReply = missingIds.length > 0
@@ -208,6 +209,7 @@ async function handleDM({ channelId, ts, threadTs, text, conversations, workDir 
       '• `!issues` — GitHub Issue 一覧',
       '• `!issues refresh` — Issue 強制更新',
       '• `!klayer <キーワード>` — K-Layer 知識検索',
+      '• `!cost` / `!cost today` / `!cost task <id>` / `!cost models` — 토큰·비용 리포트',
       '• `!reset` — 会話履歴リセット',
       '',
       '*giip issue 連携:*',
@@ -234,6 +236,12 @@ async function handleDM({ channelId, ts, threadTs, text, conversations, workDir 
   if (cmd === '!reset') {
     conversations[convKey] = [];
     await postMessage(channelId, '会話履歴をリセットしました。', replyTs);
+    return;
+  }
+  // giip-1063: 토큰·비용 리포트 (`!cost` / `!cost today` / `!cost task <id>` / `!cost models`)
+  if (cmd === '!cost' || cmd.startsWith('!cost ')) {
+    const arg = text.trim().slice('!cost'.length).trim();
+    await postMessage(channelId, require('./cost-tracker').report(BASE_DIR, arg), replyTs);
     return;
   }
   if (cmd === '!issues' || cmd === '!issues refresh') {
@@ -292,7 +300,7 @@ async function handleDM({ channelId, ts, threadTs, text, conversations, workDir 
   prompt += `\n\nUser: ${text}\nAssistant:`;
 
   try {
-    const reply = await callClaude(prompt, workDir);
+    const reply = await callClaude(prompt, workDir, { userText: text }); // giip-1063: 배치 처리 힌트
     if (!conversations[convKey]) conversations[convKey] = [];
     conversations[convKey].push({ role: 'user', content: text });
     conversations[convKey].push({ role: 'assistant', content: reply });
@@ -812,6 +820,7 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
       '*情報:*',
       '• `!issues` — GitHub Issue 一覧',
       '• `!klayer <キーワード>` — K-Layer 検索',
+      '• `!cost` / `!cost today` / `!cost task <id>` / `!cost models` — 토큰·비용 리포트',
       '• `allowlist` — 허용된 user/channel 화이트리스트 표시',
       '• `!help` — ヘルプ',
     ].join('\n'), replyTs);
@@ -832,6 +841,12 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
     const kw = cmd.slice(8).trim();
     const claims = searchKLayer(kw);
     await postMessage(channelId, claims.length ? `K-Layer "${kw}":\n${claims.map(c=>`• ${c}`).join('\n')}` : `"${kw}" に関連する claim はありません`, replyTs);
+    return;
+  }
+  // giip-1063: 토큰·비용 리포트 (`!cost` / `!cost today` / `!cost task <id>` / `!cost models`)
+  if (cmd === '!cost' || cmd.startsWith('!cost ')) {
+    const arg = text.trim().slice('!cost'.length).trim();
+    await postMessage(channelId, require('./cost-tracker').report(BASE_DIR, arg), replyTs);
     return;
   }
 
@@ -1402,13 +1417,19 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
   // 修正依頼（既存タスクID言及）の場合は親タスク文脈を本文に付加して分析・保存する
   const taskRequestText = text + refTaskContext;
 
-  let planContent, filesRead;
+  let planContent, filesRead, classification, contextStats, fastPath;
   try {
-    ({ planContent, filesRead } = tm.analyzeRequest(taskRequestText, null, workDir));
+    ({ planContent, filesRead, classification, contextStats, fastPath } =
+      tm.analyzeRequest(taskRequestText, null, workDir));
   } catch (err) {
     await postMessage(channelId, `分析エラー: ${err.message}`, replyTs);
     return;
   }
+  // giip-1063: 분석에서 결정한 작업 등급/Fast Path 여부를 태스크 파일에 남겨 실행 단계가 재사용한다.
+  const taskMeta = {
+    taskClass: (classification && classification.class) || 'standard',
+    fastPath: !!fastPath,
+  };
 
   const taskTitle = tm.extractTitle(planContent);
   const taskSummary = tm.extractSummary(planContent);
@@ -1435,8 +1456,8 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
   // ID 통일: 기존 태스크 갱신이면 그 ID, 신규+issue 등록 성공이면 giip-<isn>, 그 외엔 타임스탬프.
   const taskId = reuseTaskId || (giipIsn ? `giip-${giipIsn}` : tm.getTimestampId());
   const taskFile = reuseTaskId
-    ? tm.updateTaskFile(taskId, taskRequestText, planContent, filesRead)
-    : tm.createTaskFile(taskId, taskRequestText, planContent, filesRead);
+    ? tm.updateTaskFile(taskId, taskRequestText, planContent, filesRead, taskMeta)
+    : tm.createTaskFile(taskId, taskRequestText, planContent, filesRead, taskMeta);
 
   taskState.pending[convKey] = { taskId, taskTitle, taskFile, requestText: taskRequestText, workDir };
   if (giipIsn) taskState.pending[convKey].isn = giipIsn;
@@ -1462,8 +1483,14 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
     : `*実行: \`go ${taskId}\` / キャンセル: \`cancel ${taskId}\`*`;
 
   const headline = (reuseTaskId && !linkedIsn) ? 'Task 更新完了' : 'Task 分析完了';
+  // giip-1063: 어떤 등급으로 분류해 어떤 컨텍스트를 실었는지 한 줄로 보인다(비용 가시성).
+  const routeLine = classification
+    ? `\n🧭 등급: \`${classification.class}\`${fastPath ? ' (Fast Path — 계획 생성 호출 생략)' : ''}`
+      + ` / 컨텍스트 ${contextStats ? contextStats.files : filesRead.length}개 파일`
+      + `${contextStats ? ` · ${contextStats.chars.toLocaleString()}자` : ''}`
+    : '';
   await postLong(channelId,
-    `📋 *${headline}* (\`${taskId}\`)${isnLine}${closedNotice}\n\n${planContent}\n\n---\n${footer}`,
+    `📋 *${headline}* (\`${taskId}\`)${isnLine}${routeLine}${closedNotice}\n\n${planContent}\n\n---\n${footer}`,
     replyTs
   );
 

--- a/slack-bot/intent.js
+++ b/slack-bot/intent.js
@@ -134,7 +134,8 @@ Reply with only one word: "task" or "question". No explanation needed.`;
 
   try {
     const acct = accounts.pickAccount();
-    const result = await spawnAsync('claude', ['-p', '--model', 'claude-opus-4-8'], {
+    // giip-1063: 분류(task/question 1단어 판정)에 최상위 모델을 쓰지 않는다 — MODEL_CLASSIFIER.
+    const result = await spawnAsync('claude', ['-p', '--model', require('./model-config').classifierModel()], {
       cwd: workDir,
       timeout: 60000,
       env: accounts.envFor(acct),

--- a/slack-bot/model-config.js
+++ b/slack-bot/model-config.js
@@ -1,0 +1,155 @@
+/**
+ * model-config.js — 모델명·티어·가격의 중앙 설정 (giip-1063)
+ *
+ * 목적: `claude-opus-4-8` 같은 모델명이 코드 곳곳에 하드코딩돼 "모든 호출이 최상위 모델"이 되는
+ * 것을 막는다. 여기서만 모델명을 해석하고, 나머지 모듈은 티어 이름(trivial/standard/complex/
+ * critical/planner)만 다룬다.
+ *
+ * 설정이 하나도 없어도 동작해야 하므로(기존 동작 보존) 모든 값에 기본값을 둔다.
+ *
+ * 특수 토큰 `minimax-default`
+ *   = "MiniMax 공급자를 그 계정에 설정된 모델로 쓴다". MiniMax 가 미설정/쿨다운이면
+ *     해당 티어의 fallback(Claude) 모델로 내려간다. 기존 MiniMax-우선 → Claude-폴백
+ *     구조를 그대로 유지하기 위한 표현.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const MINIMAX_DEFAULT = 'minimax-default';
+
+// 기존 코드에 하드코딩돼 있던 값. critical 티어의 기본값으로만 남긴다(현행 동작 보존).
+const LEGACY_PREMIUM_MODEL = 'claude-opus-4-8';
+// claude CLI 는 `--model sonnet|opus|haiku` 별칭을 해석한다. 버전 문자열을 임의로 지어내지 않기 위해
+// 중간 티어는 별칭을 기본값으로 쓴다(환경변수로 정확한 모델명 지정 가능).
+const DEFAULT_MID_MODEL = 'sonnet';
+
+const TIERS = ['trivial', 'standard', 'complex', 'critical'];
+
+/** 환경변수 우선, 없으면 기본값. 매 호출마다 읽어서 런타임 변경(테스트)에도 반응한다. */
+function env(name, fallback) {
+  const v = process.env[name];
+  return (v && String(v).trim()) || fallback;
+}
+
+/** 티어별 1순위 모델 토큰. */
+function modelForTier(tier) {
+  switch (tier) {
+    case 'trivial':  return env('MODEL_TRIVIAL', MINIMAX_DEFAULT);
+    case 'standard': return env('MODEL_STANDARD', MINIMAX_DEFAULT);
+    case 'complex':  return env('MODEL_COMPLEX', DEFAULT_MID_MODEL);
+    case 'critical': return env('MODEL_CRITICAL', LEGACY_PREMIUM_MODEL);
+    case 'planner':  return env('MODEL_PLANNER', MINIMAX_DEFAULT);
+    default:         return env('MODEL_STANDARD', MINIMAX_DEFAULT);
+  }
+}
+
+/** 티어별 Claude 폴백 모델(= MiniMax 실패/미설정 시 쓸 모델). */
+function fallbackModelForTier(tier) {
+  return tier === 'critical'
+    ? env('MODEL_FALLBACK_CRITICAL', LEGACY_PREMIUM_MODEL)
+    : env('MODEL_FALLBACK_STANDARD', DEFAULT_MID_MODEL);
+}
+
+/**
+ * Q&A(질문 응답) 경로 모델. 기존에는 claude-opus-4-8 하드코딩이었다.
+ * MODEL_QA 로 덮어쓸 수 있고, 기본은 standard 폴백(=중간급).
+ */
+function qaModel() {
+  return env('MODEL_QA', fallbackModelForTier('standard'));
+}
+
+/**
+ * intent 분류(task/question 1단어 판정) 모델. 분류에 프리미엄 모델을 쓰지 않는다.
+ */
+function classifierModel() {
+  return env('MODEL_CLASSIFIER', fallbackModelForTier('standard'));
+}
+
+function isMiniMaxToken(model) {
+  return String(model || '').trim().toLowerCase() === MINIMAX_DEFAULT;
+}
+
+/** 재시도 상한(무한 재시도 금지). */
+function retryLimits() {
+  const n = (name, def) => {
+    const v = Number(process.env[name]);
+    return Number.isFinite(v) && v >= 0 ? v : def;
+  };
+  return {
+    maxProviderRetries: n('MAX_PROVIDER_RETRIES', 1),
+    maxTotalAttempts: n('MAX_TOTAL_ATTEMPTS', 3),
+  };
+}
+
+/** 컨텍스트 자동 주입 한도(3.1). */
+function contextLimits() {
+  const n = (name, def) => {
+    const v = Number(process.env[name]);
+    return Number.isFinite(v) && v > 0 ? v : def;
+  };
+  return {
+    minFiles: n('CONTEXT_MIN_FILES', 2),
+    defaultMaxFiles: n('CONTEXT_DEFAULT_MAX_FILES', 6),
+    hardMaxFiles: n('CONTEXT_HARD_MAX_FILES', 8),
+    perFileMaxChars: n('CONTEXT_PER_FILE_MAX_CHARS', 4000),
+    totalMaxChars: n('CONTEXT_TOTAL_MAX_CHARS', 48000),
+  };
+}
+
+// ── 가격표 ───────────────────────────────────────────────────────────────────
+// 가격은 코드에 산재시키지 않고 model-pricing.json 에서만 읽는다.
+// 값이 없으면 비용을 지어내지 않고 null 을 돌려준다(토큰량까지만 기록).
+const PRICING_FILE = path.join(__dirname, 'model-pricing.json');
+let _pricingCache = null;
+let _pricingMtime = 0;
+
+function loadPricing() {
+  try {
+    const st = fs.statSync(PRICING_FILE);
+    if (_pricingCache && st.mtimeMs === _pricingMtime) return _pricingCache;
+    const parsed = JSON.parse(fs.readFileSync(PRICING_FILE, 'utf8'));
+    _pricingCache = parsed && typeof parsed === 'object' ? parsed : { models: {} };
+    _pricingMtime = st.mtimeMs;
+  } catch {
+    _pricingCache = { models: {} };
+    _pricingMtime = 0;
+  }
+  if (!_pricingCache.models || typeof _pricingCache.models !== 'object') _pricingCache.models = {};
+  return _pricingCache;
+}
+
+/**
+ * 토큰 수 → USD 추정 비용. 가격 미설정 모델이면 null(= 비용 미기록, 토큰만 기록).
+ * @returns {{ cost: number|null, as_of: string|null, source: string|null }}
+ */
+function estimateCostUsd(model, inputTokens, outputTokens) {
+  const pricing = loadPricing();
+  const entry = pricing.models[model];
+  if (!entry || typeof entry.input_per_mtok !== 'number' || typeof entry.output_per_mtok !== 'number') {
+    return { cost: null, as_of: null, source: null };
+  }
+  const cost = (Number(inputTokens || 0) / 1e6) * entry.input_per_mtok
+             + (Number(outputTokens || 0) / 1e6) * entry.output_per_mtok;
+  return {
+    cost: Math.round(cost * 1e6) / 1e6,
+    as_of: entry.as_of || pricing.as_of || null,
+    source: entry.source || pricing.source || null,
+  };
+}
+
+module.exports = {
+  TIERS,
+  MINIMAX_DEFAULT,
+  LEGACY_PREMIUM_MODEL,
+  modelForTier,
+  fallbackModelForTier,
+  qaModel,
+  classifierModel,
+  isMiniMaxToken,
+  retryLimits,
+  contextLimits,
+  loadPricing,
+  estimateCostUsd,
+  PRICING_FILE,
+};

--- a/slack-bot/model-pricing.json
+++ b/slack-bot/model-pricing.json
@@ -1,0 +1,18 @@
+{
+  "_readme": [
+    "모델별 토큰 단가(USD / 1M tokens). cost-tracker 가 estimated_cost_usd 를 계산할 때만 쓴다.",
+    "이 봇은 Claude 구독 계정과 MiniMax Token Plan(정액제)으로 동작하므로 종량제 단가가 그대로",
+    "적용되지 않는다. 그래서 기본값은 비워 둔다 — 값이 없으면 비용을 지어내지 않고 토큰 수만",
+    "기록한다(estimated_cost_usd: null).",
+    "실제 단가를 확인했다면 아래 models 에 추가하라. as_of(기준일)와 source(출처)는 필수다.",
+    "예:",
+    "  \"models\": {",
+    "    \"sonnet\": { \"input_per_mtok\": 0.0, \"output_per_mtok\": 0.0, \"as_of\": \"YYYY-MM-DD\", \"source\": \"https://...\" }",
+    "  }"
+  ],
+  "currency": "USD",
+  "unit": "per_1M_tokens",
+  "as_of": null,
+  "source": null,
+  "models": {}
+}

--- a/slack-bot/model-router.js
+++ b/slack-bot/model-router.js
@@ -1,0 +1,323 @@
+/**
+ * model-router.js — 작업 난이도 분류 + 단계별 모델 선택 (giip-1063)
+ *
+ * 두 가지만 한다.
+ *   classifyTask(requestText, selectedContext, taskPlan) → { class, confidence, reasons }
+ *   selectModel(taskClass, phase, availableProviders)    → { tier, provider, model, fallback, reasons }
+ *
+ * 원칙
+ *  - 분류는 정적 규칙 우선. 애매할 때만 저비용 모델 1회. 분류에 Opus 를 쓰지 않는다.
+ *  - 보안/인증/결제/개인정보/운영DB/인프라 삭제 → 최소 critical
+ *  - 마이그레이션/스키마/배포 설정 → 최소 complex
+ *  - 신뢰도가 낮으면 한 단계 높은 등급으로 올린다(안전 우선).
+ */
+
+const modelConfig = require('./model-config');
+
+const ORDER = ['trivial', 'standard', 'complex', 'critical'];
+const rank = c => Math.max(0, ORDER.indexOf(c));
+const atLeast = (a, b) => (rank(a) >= rank(b) ? a : b);
+const bump = c => ORDER[Math.min(ORDER.length - 1, rank(c) + 1)];
+
+// ── 정적 규칙 사전 ────────────────────────────────────────────────────────────
+// 한국어/일본어/영어를 함께 본다(이 봇은 3개 언어로 요청을 받는다).
+
+// 최소 critical: 보안·인증·권한·결제·개인정보·운영 DB·인프라 삭제
+const CRITICAL_RE = new RegExp([
+  '보안', '인증', '권한', '로그인', '세션\\s*탈취', '암호화', '복호화', '비밀번호', '패스워드',
+  '결제', '과금', '청구', '환불', '개인정보', '주민등록', '운영\\s*(디비|db)', '프로덕션\\s*(디비|db)',
+  '인증서', '토큰\\s*발급', '시크릿', '크리덴셜',
+  '認証', '認可', '権限', 'セキュリティ', '決済', '課金', '個人情報', '本番\\s*(db|データベース)',
+  '\\bauth\\b', 'authn', 'authz', 'oauth', '\\bsso\\b', 'login', 'logout', 'session\\s*token',
+  'permission', 'security', 'vulnerab', '\\bcve\\b', 'payment', 'billing', 'invoice', 'refund',
+  '\\bpii\\b', 'gdpr', 'credential', 'api\\s*key', 'secret', 'encrypt', 'decrypt', 'password',
+  'production\\s*(db|database)', 'drop\\s+table', 'truncate\\s+table', 'delete\\s+from',
+  'terraform\\s+destroy', 'rm\\s+-rf',
+].join('|'), 'i');
+
+// 최소 complex: 마이그레이션·스키마 변경·배포 설정 변경
+const MIN_COMPLEX_RE = new RegExp([
+  '마이그레이션', '스키마', '배포\\s*설정', '파이프라인', '인프라',
+  'マイグレーション', 'スキーマ', 'デプロイ設定',
+  'migration', 'schema', 'ddl', 'alter\\s+table', 'ci/?cd', 'pipeline', 'deploy(ment)?\\s*(config|설정)?',
+  'dockerfile', 'kubernetes', 'k8s', 'helm', 'terraform', 'github\\s*actions', 'workflow\\.ya?ml',
+].join('|'), 'i');
+
+// complex 신호: 신규 기능·다수 파일·여러 서브시스템·데이터 흐름 변경
+const COMPLEX_RE = new RegExp([
+  '신규\\s*기능', '새\\s*기능', '리팩터링', '리팩토링', '재설계', '아키텍처', '연동', '통합',
+  '데이터\\s*흐름', '전면', '대규모', '마이그레', '설계해',
+  '新機能', 'リファクタ', '再設計', 'アーキテクチャ', '連携',
+  'new\\s+feature', 'refactor', 'redesign', 'architect', 'integrat', 'end-to-end', 'e2e',
+  'multi[- ]?service', 'data\\s*flow', 'rewrite',
+].join('|'), 'i');
+
+// trivial 신호: 오탈자·문구·rename·lint/format·주석·설정값 한두 개
+const TRIVIAL_RE = new RegExp([
+  '오탈자', '오타', '문구\\s*(수정|변경)', '텍스트\\s*(수정|변경)', '이름\\s*(변경|바꿔)', '리네임',
+  '주석', '들여쓰기', '포맷', '서식', '색상\\s*(변경|바꿔)', '오탈',
+  '誤字', '文言', 'リネーム', 'コメント', 'インデント',
+  '\\btypo\\b', 'wording', 'rename', '\\blint\\b', 'eslint', 'prettier', 'format(ting)?\\b',
+  'comment\\s*(fix|update|change)', 'indent', 'whitespace', 'spelling',
+].join('|'), 'i');
+
+// "A"를 "B"로 변경 / replace "A" with "B" — 전형적인 문구 치환(= trivial) 관용구
+const REPLACE_IDIOM_RE = new RegExp([
+  '["\'“”「][^"\'“”」]{1,80}["\'“”」]\\s*(?:을|를|은|는)?\\s*'
+  + '["\'“”「][^"\'“”」]{1,80}["\'“”」]\\s*(?:으로|로)\\s*(?:변경|수정|바꿔|교체)',
+  'replace\\s+["\'][^"\']{1,80}["\']\\s+(?:with|to)\\s+["\'][^"\']{1,80}["\']',
+  '["\'「][^"\'」]{1,80}["\'」]\\s*(?:を)\\s*["\'「][^"\'」]{1,80}["\'」]\\s*(?:に)\\s*(?:変更|修正)',
+].join('|'), 'i');
+
+// 명시적 파일 경로 (a/b/c.ext 또는 확장자 붙은 토큰)
+const PATH_RE = /[\w.\-/\\]+\.(?:js|ts|tsx|jsx|md|json|ya?ml|css|scss|html|py|ps1|sh|sql|txt|cs|java|go|rb|php)\b/gi;
+
+const DESTRUCTIVE_RE = /(전부\s*삭제|모두\s*삭제|일괄\s*삭제|全削除|delete\s+all|remove\s+all|purge|wipe)/i;
+
+function uniq(arr) { return Array.from(new Set(arr)); }
+
+/** taskPlan(분석 결과 마크다운)에서 "영향 파일/서브시스템" 항목 수를 센다. */
+function countPlanImpactFiles(taskPlan) {
+  if (!taskPlan) return 0;
+  const m = String(taskPlan).match(/##\s*영향\s*파일[^\n]*\n([\s\S]*?)(?=\n##\s|$)/);
+  if (!m) return 0;
+  return m[1].split(/\r?\n/).filter(l => /^\s*[-*]\s+\S/.test(l)).length;
+}
+
+/** 요청문에서 명시된 파일 경로들. */
+function extractPaths(text) {
+  return uniq(String(text || '').match(PATH_RE) || []).map(s => s.replace(/\\/g, '/'));
+}
+
+/**
+ * 작업 난이도 분류. 정적 규칙만으로 판정하고, 애매하면(옵션으로 llm 이 주어졌을 때만)
+ * 저비용 모델 1회를 호출해 보정한다.
+ *
+ * @param {string} requestText          사용자 요청 원문
+ * @param {Array}  selectedContext      선택된 컨텍스트 파일 [{path, reason}]
+ * @param {string} taskPlan             분석 단계 산출 계획(있으면)
+ * @param {object} [opts]
+ * @param {(prompt:string)=>string} [opts.llm]  저비용 모델 호출자(없으면 정적 판정만)
+ * @returns {{class:string, confidence:number, reasons:string[], method:string,
+ *            estimatedFiles:number, explicitPaths:string[], fastPathEligible:boolean}}
+ */
+function classifyTask(requestText, selectedContext = [], taskPlan = '', opts = {}) {
+  const text = `${requestText || ''}\n${taskPlan || ''}`;
+  const reasons = [];
+  let cls = 'standard';
+  let confidence = 0.5;
+  let method = 'static';
+
+  const explicitPaths = extractPaths(requestText);
+  const planFiles = countPlanImpactFiles(taskPlan);
+  const estimatedFiles = Math.max(explicitPaths.length, planFiles, 1);
+
+  const hitCritical = CRITICAL_RE.test(text);
+  const hitMinComplex = MIN_COMPLEX_RE.test(text);
+  const hitComplex = COMPLEX_RE.test(text);
+  const hitReplaceIdiom = REPLACE_IDIOM_RE.test(requestText || '');
+  const hitTrivial = TRIVIAL_RE.test(text) || hitReplaceIdiom;
+  const hitDestructive = DESTRUCTIVE_RE.test(text);
+
+  if (hitCritical) {
+    cls = 'critical';
+    confidence = 0.9;
+    reasons.push('보안/인증/결제/개인정보/운영DB/인프라 관련 키워드 검출 → 최소 critical');
+  } else if (hitComplex || estimatedFiles > 3) {
+    cls = 'complex';
+    confidence = hitComplex ? 0.75 : 0.65;
+    reasons.push(hitComplex ? '신규 기능/재설계/연동 등 광범위 변경 신호' : `변경 예상 파일 ${estimatedFiles}개(3개 초과)`);
+  } else if (hitTrivial && estimatedFiles <= 3 && !hitDestructive) {
+    cls = 'trivial';
+    confidence = explicitPaths.length ? 0.88 : 0.7;
+    reasons.push(hitReplaceIdiom
+      ? '"A"를 "B"로 치환하는 단순 문구 수정'
+      : '오탈자/문구/rename/lint/주석 등 저위험 변경 신호');
+    if (explicitPaths.length) reasons.push(`대상 파일 경로가 요청에 명시됨(${explicitPaths.length}개)`);
+  } else {
+    cls = 'standard';
+    confidence = 0.6;
+    reasons.push(`변경 예상 파일 ${estimatedFiles}개`);
+    reasons.push('보안/인증/DB 변경 신호 없음');
+    reasons.push('기존 기능의 제한된 수정으로 판단');
+  }
+
+  if (hitMinComplex) {
+    const before = cls;
+    cls = atLeast(cls, 'complex');
+    if (cls !== before) reasons.push('마이그레이션/스키마/배포 설정 변경 → 최소 complex 로 승격');
+  }
+  if (hitDestructive) {
+    const before = cls;
+    cls = atLeast(cls, 'complex');
+    if (cls !== before) reasons.push('대량 삭제 신호 → 최소 complex 로 승격');
+  }
+
+  // 애매한 경우에만 저비용 모델 1회. Opus 는 절대 쓰지 않는다(호출자가 티어를 강제).
+  if (confidence < 0.6 && typeof opts.llm === 'function') {
+    const prompt = [
+      '다음 개발 요청의 난이도를 trivial / standard / complex / critical 중 하나로만 분류하라.',
+      'trivial=오탈자·문구·rename·lint·주석, standard=작은 버그/단일 API·화면 수정,',
+      'complex=여러 파일/서브시스템·신규 기능, critical=보안·인증·결제·개인정보·운영DB·인프라.',
+      '',
+      '요청:',
+      String(requestText || '').slice(0, 2000),
+      '',
+      '한 단어만 출력하라.',
+    ].join('\n');
+    try {
+      const out = String(opts.llm(prompt) || '').toLowerCase();
+      const found = ORDER.find(c => out.includes(c));
+      if (found) {
+        method = 'static+llm';
+        // 정적 판정과 LLM 판정 중 높은 쪽을 취한다(안전 우선).
+        const merged = atLeast(cls, found);
+        if (merged !== cls) reasons.push(`저비용 모델 보조 분류(${found}) 반영`);
+        cls = merged;
+        confidence = 0.7;
+      }
+    } catch { /* 보조 분류 실패는 무시 — 정적 판정 유지 */ }
+  }
+
+  // 신뢰도가 낮으면 한 단계 높은 등급을 적용한다.
+  if (confidence < 0.6 && cls !== 'critical') {
+    cls = bump(cls);
+    reasons.push(`신뢰도 낮음(${confidence.toFixed(2)}) → 한 단계 상향`);
+  }
+
+  const fastPathEligible = isFastPathEligible({
+    taskClass: cls,
+    explicitPaths,
+    estimatedFiles,
+    destructive: hitDestructive,
+    contextCount: (selectedContext || []).length,
+  });
+
+  return {
+    class: cls,
+    confidence: Math.round(confidence * 100) / 100,
+    reasons: uniq(reasons),
+    method,
+    estimatedFiles,
+    explicitPaths,
+    fastPathEligible,
+  };
+}
+
+/**
+ * Fast Path(3.4) 적용 가능 여부. 아래를 모두 만족해야 한다.
+ *  - trivial 등급
+ *  - 변경 대상 1~3개 파일로 제한됨(요청에 경로가 명시돼 정적으로 특정 가능)
+ *  - 인증/보안/결제/DB 스키마/배포 변경이 아님(= trivial 이면 이미 보장)
+ *  - 삭제·대량 변경이 아님
+ */
+function isFastPathEligible({ taskClass, explicitPaths = [], estimatedFiles = 1, destructive = false }) {
+  if (taskClass !== 'trivial') return false;
+  if (destructive) return false;
+  if (!explicitPaths.length) return false;            // 요구사항이 "명확"하다는 정적 근거
+  if (explicitPaths.length > 3) return false;
+  if (estimatedFiles > 3) return false;
+  return true;
+}
+
+// ── 모델 선택 ────────────────────────────────────────────────────────────────
+// phase: 'classify' | 'context' | 'plan' | 'execute' | 'review'
+const PHASES = ['classify', 'context', 'plan', 'execute', 'review'];
+
+/**
+ * 작업 등급 + 단계 → 사용할 티어/모델.
+ *
+ * @param {string} taskClass trivial|standard|complex|critical
+ * @param {string} phase
+ * @param {{minimax?:boolean, claude?:boolean}} [availableProviders]
+ * @returns {{tier:string, model:string, provider:string, fallback:{provider:string,model:string},
+ *            premiumAllowed:boolean, reasons:string[]}}
+ */
+function selectModel(taskClass, phase, availableProviders = {}) {
+  const providers = { minimax: true, claude: true, ...availableProviders };
+  const cls = ORDER.includes(taskClass) ? taskClass : 'standard';
+  const ph = PHASES.includes(phase) ? phase : 'execute';
+  const reasons = [];
+
+  let tier;
+  if (ph === 'classify' || ph === 'context') {
+    // 분류·컨텍스트 선별은 언제나 최저 비용 티어. critical 이라도 Opus 를 쓰지 않는다.
+    tier = 'trivial';
+    reasons.push('분류/컨텍스트 선별 단계 — 저비용 티어 고정(프리미엄 모델 금지)');
+  } else if (cls === 'trivial') {
+    tier = 'trivial';
+    reasons.push('trivial 작업 — 저가 모델 단일 호출');
+  } else if (cls === 'standard') {
+    tier = ph === 'plan' ? 'planner' : 'standard';
+    reasons.push('standard 작업 — MiniMax/중간급 우선');
+  } else if (cls === 'complex') {
+    tier = 'complex';
+    reasons.push('complex 작업 — 계획·실행 모두 중간급 모델');
+  } else { // critical
+    if (ph === 'plan' || ph === 'review') {
+      tier = 'critical';
+      reasons.push('critical 작업의 계획/최종 검토 — 최상위 모델 허용');
+    } else {
+      tier = 'complex';
+      reasons.push('critical 작업이지만 탐색/실행 단계 — 중간급 모델(최상위 모델은 계획/검토에만)');
+    }
+  }
+
+  const token = modelConfig.modelForTier(tier);
+  const fallbackTier = cls === 'critical' ? 'critical' : 'standard';
+  const fallbackModel = modelConfig.fallbackModelForTier(fallbackTier);
+
+  let provider, model;
+  if (modelConfig.isMiniMaxToken(token)) {
+    if (providers.minimax) {
+      provider = 'minimax';
+      model = null; // 실제 모델명은 minimax-accounts.resolve() 가 결정
+    } else {
+      provider = 'claude';
+      model = fallbackModel;
+      reasons.push('MiniMax 미설정/쿨다운 → Claude 폴백 모델 사용');
+    }
+  } else {
+    provider = 'claude';
+    model = token;
+  }
+
+  // 안전 요구사항 4: critical 작업을 무조건 저가 모델로 실행하지 않는다.
+  // (실행 단계는 중간급까지 허용하되, 저가(trivial) 티어로 내려가지 않게 가드)
+  const premiumAllowed = cls === 'critical' && (ph === 'plan' || ph === 'review');
+
+  return {
+    tier,
+    provider,
+    model,
+    fallback: { provider: 'claude', model: fallbackModel },
+    premiumAllowed,
+    reasons,
+  };
+}
+
+/**
+ * 실패로 인한 승격. complex/critical 에서 중간급이 반복 실패했을 때만 최상위 모델을 허용한다.
+ * (그 외 등급은 승격하지 않는다 — Opus 고정 호출 방지)
+ */
+function escalateOnFailure(taskClass, attempt) {
+  if (attempt < 2) return null;
+  if (taskClass !== 'complex' && taskClass !== 'critical') return null;
+  return {
+    provider: 'claude',
+    model: modelConfig.fallbackModelForTier('critical'),
+    reason: `${taskClass} 작업이 ${attempt}회 실패 → 최상위 모델로 승격`,
+  };
+}
+
+module.exports = {
+  ORDER,
+  PHASES,
+  classifyTask,
+  selectModel,
+  escalateOnFailure,
+  isFastPathEligible,
+  extractPaths,
+  REPLACE_IDIOM_RE,
+  countPlanImpactFiles,
+};

--- a/slack-bot/prompt-templates.js
+++ b/slack-bot/prompt-templates.js
@@ -1,0 +1,225 @@
+/**
+ * prompt-templates.js — 고정 prefix 를 갖는 프롬프트 중앙 관리 (giip-1063, 3.6)
+ *
+ * 프롬프트 캐시가 지원되는 모델에서 캐시 적중률을 높이려면, 매 호출마다 바뀌는 값이
+ * 프롬프트 앞부분에 있으면 안 된다. 그래서 아래 순서를 강제한다.
+ *
+ *   1. 고정 시스템 역할
+ *   2. 고정 안전 규칙
+ *   3. 고정 실행 프로토콜
+ *   4. 선택한 SKILL 및 role/rule 컨텍스트
+ *   5. 프로젝트 정보
+ *   6. 태스크 내용
+ *   7. checkpoint 및 동적 상태  ← 현재 시각/taskID/브랜치/재시도 번호/변경 파일은 전부 여기
+ *
+ * 템플릿을 바꿀 때만 PROMPT_VERSION 을 올린다.
+ */
+
+const PROMPT_VERSION = 'fde-cost-v1';
+
+// ── 1. 고정 시스템 역할 ──────────────────────────────────────────────────────
+const SYSTEM_ROLE = `You are a senior software engineer working in a GIIP FDE Agent workspace.
+You execute one prepared task at a time inside an already-prepared git branch.`;
+
+// ── 2. 고정 안전 규칙 ────────────────────────────────────────────────────────
+const SAFETY_RULES = `=== 안전 규칙 (고정) ===
+- 요청 범위 밖의 파일을 고치지 마라. 사용자의 기존 작업 트리 변경을 덮어쓰지 마라.
+- git 커밋·push·PR·브랜치 전환은 절대 하지 마라. 브랜치는 이미 준비돼 있고, 봇이 종료 후 자동으로
+  커밋·push·PR 을 처리한다. 직접 git 을 만지면 브랜치/PR 흐름이 깨진다.
+- .env 내용, API key, 토큰, 인증정보를 출력·로그·보고서에 남기지 마라.
+- 비용 절감을 이유로 테스트와 검증을 생략하지 마라. 최소 1건의 재현 검증을 반드시 수행하라.
+- 실패를 성공으로 보고하지 마라. 부분 완료면 부분 완료라고 써라.`;
+
+// ── 3. 고정 실행 프로토콜 ────────────────────────────────────────────────────
+const EXECUTION_PROTOCOL = `=== 실행 프로토콜 (고정) ===
+0. 되묻지 말고 실측하라. 경로·설정·사양처럼 조회로 확정 가능한 값은 사용자에게 다시 묻지 말고 직접 찾아 결정한다.
+   - giip 서비스 설정(SMTP·메일·인증 등)의 정본은 giipdb 사양서(giipprj/giipdb/docs/30_Specs/)와 DB다.
+     사람에게 묻기 전에 그곳부터 조회하라. 예: SMTP 설정은 tEmailServerConfig 테이블에 있고 giip API
+     EmailServerConfigGetActive(SP pApiEmailServerConfigGetActivebyAK, 서버측 bySk)로 조회한다.
+   - 정말로 사람만 아는 값(외부 자격증명 실물, 사용자의 의도적 선택)만 질문한다.
+1. 아래 "태스크" 절의 실행 계획을 순서대로 수행한다.
+2. Read/Edit/Write/Bash 도구로 지정된 작업 디렉터리 안에서 실제 코드 변경을 수행한다.
+3. 아래 "동적 상태" 절에 giip issue 번호가 있으면 진행 코멘트 프로토콜을 따른다:
+   진행 상황을 논리 묶음 단위로 1~3줄씩 자주 남긴다(같은 내용 연타 금지). 남기는 시점 —
+     (1) 착수: 로드해서 따르는 role/rule/skill/workflow 명시
+     (2) 참조 정본 변경: 규칙 파일 자체를 고칠 때 무엇을 왜
+     (3) 대상 파일 변경: 수정/생성/삭제한 파일마다 경로 + 한 줄
+     (4) 검색 발생: 왜 검색했고 결과를 어디에 링크로 흡수했는지
+     (5) 분기·막힘·판단: 에러, 사람 확인 필요, 중요한 설계 판단
+     (6) 완료 직전(필수): (a) 테스트 결과 — 무엇을 어떻게 실행/재현해 검증했고 결과가 무엇인지
+         (커맨드·종료코드·출력 요약. 테스트가 없으면 수행한 수동 재현 절차와 결과. "테스트 없음"만
+         쓰고 넘어가지 말 것) (b) 사용자 테스트 방법 — 사람이 직접 확인할 재현 가능한 구체 절차.
+   중간 진행 코멘트는 issuetype=note 로 남기고, 상태 전이는 봇이 하므로 여기서 바꾸지 않는다.
+4. 모든 단계 완료 후 아래 "동적 상태" 절이 지정한 경로에 결과 보고서를 작성한다. 형식:
+   ---
+   # 작업 완료 보고서: [태스크 제목]
+   ## 완료 일시
+   (ISO8601 현재 시각)
+   ## 실시 내용
+   (실제 수행한 작업의 상세 설명)
+   ## 변경 파일
+   - path/to/file — 변경 내용 요약
+   ## 결과/상태
+   (성공 / 부분 완료 / 실패, 이유)
+   ## 다음 단계
+   (후속 작업이 필요한 경우 명기)
+   ---`;
+
+// Fast Path(trivial) 전용 고정 프로토콜 — 컨텍스트 선택/계획/실행을 한 번에 끝낸다.
+const FAST_PATH_PROTOCOL = `=== Fast Path 실행 프로토콜 (고정, 단순 작업 전용) ===
+이 태스크는 저위험·소범위(trivial)로 정적 분류됐다. 별도 계획 생성 호출 없이 이 한 번의 호출에서
+확인 → 수정 → 검증 → 보고까지 끝낸다. 다만 아래는 생략하지 않는다.
+1. 변경 전 대상 파일을 반드시 먼저 읽어 현재 내용을 확인한다.
+2. 요청 범위 밖의 수정은 하지 않는다(리팩터링·포맷 정리 등 "겸사겸사" 금지).
+3. 변경 후 테스트 또는 재현 검증을 수행한다(테스트가 없으면 diff 확인 + 실제 동작 재현).
+4. 결과 보고서를 작성한다.
+5. 작업이 위 범위를 넘어선다고 판단되면(3개 초과 파일, 인증/보안/DB/배포 변경, 삭제·대량 변경)
+   즉시 중단하고 결과 보고서에 "Fast Path 부적합 — 일반 경로로 승격 필요"라고 명시하라.`;
+
+function section(title, body) {
+  return body && String(body).trim() ? `\n\n${title}\n${String(body).trim()}` : '';
+}
+
+/**
+ * 실행 프롬프트. 1~3 은 완전히 고정된 문자열이므로 태스크가 달라도 prefix 가 동일하다.
+ *
+ * @param {object} p
+ *  - fastPath        {boolean} Fast Path 프로토콜 사용
+ *  - contextText     {string}  선택된 SKILL/role/rule 본문(선별·축약 완료)
+ *  - contextFiles    {Array}   [{path, reason}] — 목록 표시용
+ *  - projectName, baseDir, langName, baseBranch  {string} 프로젝트 정보
+ *  - taskContent     {string}  태스크 사양(계획 포함)
+ *  - kLayerClaims    {string[]}
+ *  - taskId, branch, resultFile, isn, addCommentScript, attempt, taskClass, now
+ *  - resumeInstruction {string|null} checkpoint 재개 지시문
+ */
+function buildExecutionPrompt(p = {}) {
+  const out = [];
+
+  // 1~3: 고정
+  out.push(SYSTEM_ROLE);
+  out.push(`\nprompt_version: ${PROMPT_VERSION}`);
+  out.push(`\n${SAFETY_RULES}`);
+  out.push(`\n${p.fastPath ? FAST_PATH_PROTOCOL : EXECUTION_PROTOCOL}`);
+
+  // 4: 선택된 컨텍스트 (같은 태스크를 재시도해도 동일 → 재시도 간 캐시 적중)
+  out.push(section('=== 선택된 컨텍스트 (role/rule/skill — 이 태스크에 관련된 것만) ===',
+    p.contextText || '(선택된 컨텍스트 없음 — 최소 기본 규칙만 적용)'));
+  if (Array.isArray(p.contextFiles) && p.contextFiles.length) {
+    out.push(section('=== 컨텍스트 선택 사유 ===',
+      p.contextFiles.map(f => `- ${f.path} — ${f.reason}`).join('\n')));
+  }
+
+  // 5: 프로젝트 정보
+  out.push(section('=== 프로젝트 정보 ===', [
+    `project: ${p.projectName || '(unknown)'}`,
+    `working_directory: ${p.baseDir || ''}`,
+    `base_branch: ${p.baseBranch || ''}`,
+    `response_language: ${p.langName || 'Korean'} (always respond in this language)`,
+  ].join('\n')));
+
+  // 6: 태스크 내용
+  out.push(section('=== 태스크 ===', p.taskContent || ''));
+  if (Array.isArray(p.kLayerClaims) && p.kLayerClaims.length) {
+    out.push(section('=== K-Layer 지식 ===', p.kLayerClaims.map(c => `• ${c}`).join('\n')));
+  }
+
+  // 7: 동적 상태 (매 호출 달라지는 값은 전부 여기)
+  const dyn = [
+    `task_id: ${p.taskId || ''}`,
+    `task_class: ${p.taskClass || 'standard'}`,
+    `current_branch: ${p.branch || ''}`,
+    `attempt: ${p.attempt || 1}`,
+    `now: ${p.now || new Date().toISOString()}`,
+    `result_report_path: ${p.resultFile || ''}`,
+  ];
+  if (p.isn) {
+    dyn.push(`giip_isn: ${p.isn}`);
+    if (p.addCommentScript) {
+      dyn.push(`progress_comment_command: pwsh -File "${p.addCommentScript}" -isn ${p.isn} -content "<본문>" -issuetype note -author "slack-bot"`);
+    }
+  }
+  out.push(section('=== 동적 상태 ===', dyn.join('\n')));
+
+  if (p.resumeInstruction) {
+    out.push(section('=== 이어서 재개 (checkpoint) ===', p.resumeInstruction));
+  }
+
+  out.push('\n\n지금 바로 작업을 시작하세요.');
+  return out.join('');
+}
+
+// ── 분석(계획) 프롬프트 ──────────────────────────────────────────────────────
+const ANALYSIS_ROLE = `You are a senior software architect. You turn one Slack request into a concrete,
+minimal task specification. Do not expand the scope beyond what was asked.`;
+
+const ANALYSIS_FORMAT = `Output a task specification in this EXACT format (in the response language below):
+
+# TASK: [짧은 제목]
+
+## 요청 내용
+[요청 요약 — 1~2줄]
+
+## 실행 계획
+1. [구체적인 실행 단계]
+2. [단계 2]
+3. [단계 3]
+(최대 7단계)
+
+## 영향 파일/서브시스템
+- [변경될 파일 또는 서브시스템]
+
+## 주의사항
+- [배포 주의사항, 부작용 등]
+
+Output ONLY the task specification, no extra commentary.`;
+
+function buildAnalysisPrompt(p = {}) {
+  const out = [];
+  out.push(ANALYSIS_ROLE);
+  out.push(`\nprompt_version: ${PROMPT_VERSION}`);
+  out.push(`\n\n${ANALYSIS_FORMAT}`);
+  out.push(section('=== 선택된 컨텍스트 (role/rule/skill — 이 요청에 관련된 것만) ===', p.contextText || ''));
+  out.push(section('=== 프로젝트 정보 ===', [
+    `project: ${p.projectName || '(unknown)'}`,
+    `working_directory: ${p.baseDir || ''}`,
+    `response_language: ${p.langName || 'Korean'}`,
+  ].join('\n')));
+  if (Array.isArray(p.kLayerClaims) && p.kLayerClaims.length) {
+    out.push(section('=== K-Layer 관련 지식 ===', p.kLayerClaims.map(c => `• ${c}`).join('\n')));
+  }
+  out.push(section('=== 요청 ===', p.requestText || ''));
+  return out.join('');
+}
+
+/** 컨텍스트 큐레이션 프롬프트(저비용 티어 전용). */
+function buildContextSelectionPrompt(p = {}) {
+  return [
+    '너는 개발 요청을 수행하기 위해 참조해야 할 컨텍스트 파일(role/rule/skill)을 고르는 큐레이터다.',
+    `prompt_version: ${PROMPT_VERSION}`,
+    '',
+    '규칙: 실제로 관련 있는 파일만 고른다(보통 2~6개, 최대 8개). 무관한 파일은 넣지 않는다.',
+    '각 파일에 대해 "이 태스크에서 그 파일의 무엇을 참조/적용하려는지"를 한국어 한 줄 사유로 적는다.',
+    '아래 JSON 배열만 출력한다(코드펜스·설명 금지):',
+    '[{"path":"<목록의 정확한 경로>","reason":"<한 줄 사유>"}]',
+    '',
+    '=== 사용 가능한 컨텍스트 파일 (이름/설명/trigger 만) ===',
+    p.catalogText || '',
+    '',
+    '=== 요청 ===',
+    p.requestText || '',
+  ].join('\n');
+}
+
+module.exports = {
+  PROMPT_VERSION,
+  SYSTEM_ROLE,
+  SAFETY_RULES,
+  EXECUTION_PROTOCOL,
+  FAST_PATH_PROTOCOL,
+  ANALYSIS_ROLE,
+  ANALYSIS_FORMAT,
+  buildExecutionPrompt,
+  buildAnalysisPrompt,
+  buildContextSelectionPrompt,
+};

--- a/slack-bot/retry-checkpoint.js
+++ b/slack-bot/retry-checkpoint.js
@@ -1,0 +1,251 @@
+/**
+ * retry-checkpoint.js — 재시도 시 전체 재실행 방지 (giip-1063, 3.5)
+ *
+ * 기존: MiniMax 가 실패하면 같은 executionPrompt 전체를 Claude 에 그대로 다시 보내고
+ *       태스크를 처음부터 실행 → 이미 끝낸 파일 수정을 다음 모델이 다시 전면 작성.
+ *
+ * 여기서: 시도마다 진행 상태를 `.agent/runtime/checkpoints/<task-id>.json` 에 남기고,
+ *       재시도 프롬프트에는 "원문 전체" 대신 태스크 사양 + 선택 컨텍스트 + checkpoint 요약만
+ *       실어 이어서 재개시킨다.
+ *
+ * 안전: checkpoint 에 API key / Slack token / 인증정보를 저장하지 않는다(secret-mask 통과).
+ *       런타임 디렉터리는 .gitignore 대상.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const { maskDeep, maskString } = require('./secret-mask');
+const modelConfig = require('./model-config');
+
+const RUNTIME_SUBDIR = path.join('.agent', 'runtime', 'checkpoints');
+
+function checkpointDir(baseDir) {
+  return path.join(baseDir, RUNTIME_SUBDIR);
+}
+
+function checkpointPath(baseDir, taskId) {
+  const safe = String(taskId).replace(/[^\w.\-]/g, '_');
+  return path.join(checkpointDir(baseDir), `${safe}.json`);
+}
+
+function ensureDir(baseDir) {
+  try { fs.mkdirSync(checkpointDir(baseDir), { recursive: true }); } catch {}
+}
+
+// ── 오류 분류 ────────────────────────────────────────────────────────────────
+const ERROR_TYPES = ['usage_limit', 'auth', 'timeout', 'provider_error', 'not_started', 'unknown'];
+
+/** CLI 출력에서 오류 종류를 추정한다. 재시도 정책 분기(3.5)에 쓴다. */
+function classifyError(output) {
+  const t = String(output || '');
+  if (/\b429\b|rate limit|quota|usage limit|weekly limit|insufficient balance|insufficient.{0,10}credit|too many requests/i.test(t)) return 'usage_limit';
+  if (/unauthorized|401|invalid api key|authentication|not logged in|auth.*(expired|failed)/i.test(t)) return 'auth';
+  if (/etimedout|timed? ?out|deadline exceeded/i.test(t)) return 'timeout';
+  if (/\b5\d\d\b|internal server error|bad gateway|service unavailable|overloaded/i.test(t)) return 'provider_error';
+  return 'unknown';
+}
+
+// ── 작업 트리 상태 ───────────────────────────────────────────────────────────
+/** 현재 브랜치에서 실제로 바뀐 파일 목록(재개 판단 근거). 실패해도 빈 배열. */
+function changedFiles(cwd) {
+  try {
+    const r = spawnSync('git', ['status', '--porcelain'], { cwd, encoding: 'utf8', windowsHide: true });
+    if (r.status !== 0) return [];
+    return (r.stdout || '')
+      .split(/\r?\n/)
+      .map(l => l.slice(3).trim())
+      .filter(Boolean)
+      .slice(0, 200);
+  } catch { return []; }
+}
+
+/** diff --stat 요약(길이 제한). 재개 프롬프트에 넣어 "이미 한 일"을 알린다. */
+function diffSummary(cwd, maxChars = 2000) {
+  try {
+    const r = spawnSync('git', ['diff', '--stat', 'HEAD'], { cwd, encoding: 'utf8', windowsHide: true });
+    if (r.status !== 0) return '';
+    return maskString((r.stdout || '').trim()).slice(0, maxChars);
+  } catch { return ''; }
+}
+
+// ── 저장 / 로드 ──────────────────────────────────────────────────────────────
+function emptyCheckpoint(taskId) {
+  return {
+    task_id: taskId,
+    attempt: 0,
+    provider: null,
+    model: null,
+    started_at: null,
+    updated_at: null,
+    completed_steps: [],
+    files_read: [],
+    files_changed: [],
+    commands_run: [],
+    test_results: [],
+    error_type: null,
+    error_summary: null,
+    resume_instruction: null,
+    history: [],
+  };
+}
+
+function load(baseDir, taskId) {
+  try {
+    const raw = fs.readFileSync(checkpointPath(baseDir, taskId), 'utf8');
+    const parsed = JSON.parse(raw);
+    return { ...emptyCheckpoint(taskId), ...parsed, task_id: taskId };
+  } catch { return null; }
+}
+
+/** patch 를 병합해 저장. 비밀값은 저장 전에 마스킹한다. */
+function save(baseDir, taskId, patch = {}) {
+  ensureDir(baseDir);
+  const cur = load(baseDir, taskId) || emptyCheckpoint(taskId);
+  const next = maskDeep({
+    ...cur,
+    ...patch,
+    task_id: taskId,
+    updated_at: new Date().toISOString(),
+  });
+  try {
+    fs.writeFileSync(checkpointPath(baseDir, taskId), JSON.stringify(next, null, 2));
+  } catch (e) {
+    console.error('[checkpoint] 저장 실패:', e.message);
+  }
+  return next;
+}
+
+/** 시도 시작 기록. */
+function beginAttempt(baseDir, taskId, { attempt, provider, model, taskClass = null }) {
+  const cur = load(baseDir, taskId) || emptyCheckpoint(taskId);
+  const history = (cur.history || []).concat([{
+    attempt, provider, model, task_class: taskClass, started_at: new Date().toISOString(),
+  }]).slice(-10);
+  return save(baseDir, taskId, {
+    attempt,
+    provider,
+    model,
+    task_class: taskClass,
+    started_at: cur.started_at || new Date().toISOString(),
+    error_type: null,
+    error_summary: null,
+    history,
+  });
+}
+
+/** 시도 실패 기록 + 작업 트리 상태 스냅샷 + 재개 지시문 생성. */
+function recordFailure(baseDir, taskId, { attempt, provider, model, output, cwd }) {
+  const errorType = classifyError(output);
+  const files = changedFiles(cwd || baseDir);
+  const summary = maskString(String(output || '').trim()).slice(-1500);
+  const cp = save(baseDir, taskId, {
+    attempt,
+    provider,
+    model,
+    files_changed: files,
+    error_type: errorType,
+    error_summary: summary,
+    diff_stat: diffSummary(cwd || baseDir),
+  });
+  return save(baseDir, taskId, { resume_instruction: buildResumeInstruction(cp) });
+}
+
+/** 시도 성공 기록(다음 실행이 "완료된 단계"를 알 수 있도록). */
+function recordSuccess(baseDir, taskId, { attempt, provider, model, cwd, steps = [] }) {
+  return save(baseDir, taskId, {
+    attempt,
+    provider,
+    model,
+    completed_steps: steps,
+    files_changed: changedFiles(cwd || baseDir),
+    error_type: null,
+    error_summary: null,
+    resume_instruction: null,
+    finished_at: new Date().toISOString(),
+  });
+}
+
+function clear(baseDir, taskId) {
+  try { fs.rmSync(checkpointPath(baseDir, taskId), { force: true }); } catch {}
+}
+
+// ── 재개 프롬프트 ────────────────────────────────────────────────────────────
+const RESUME_HEADER = [
+  '기존 작업 트리의 변경 사항은 이전 시도의 작업 결과다.',
+  '먼저 diff와 checkpoint를 확인하고 완료된 작업을 반복하지 마라.',
+  '미완료 단계부터 계속하라.',
+].join('\n');
+
+/**
+ * checkpoint 로 재개 지시문을 만든다. 전체 원문을 다시 싣지 않는 것이 핵심.
+ * 작업 시작 전 실패(파일 변경 0, error_type=not_started/usage_limit + 변경 없음)면 재개 지시 없이
+ * 동일 프롬프트를 재사용해도 되므로 null 을 돌려준다.
+ */
+function buildResumeInstruction(cp) {
+  if (!cp) return null;
+  const changed = cp.files_changed || [];
+  const steps = cp.completed_steps || [];
+  const nothingDone = changed.length === 0 && steps.length === 0;
+  if (nothingDone) return null;   // 작업 시작 전 실패 → 동일 프롬프트 재사용 가능
+
+  const lines = [RESUME_HEADER, ''];
+  lines.push(`이전 시도: attempt=${cp.attempt}, provider=${cp.provider || '?'}, model=${cp.model || '?'}, 실패 유형=${cp.error_type || 'unknown'}`);
+  if (steps.length) lines.push(`완료된 단계: ${steps.slice(0, 20).join(' / ')}`);
+  if (changed.length) {
+    lines.push(`이미 변경된 파일(${changed.length}건):`);
+    lines.push(changed.slice(0, 40).map(f => `  - ${f}`).join('\n'));
+  }
+  if (cp.diff_stat) lines.push(`\ngit diff --stat:\n${cp.diff_stat}`);
+  if ((cp.test_results || []).length) {
+    lines.push(`\n이전 검증 결과: ${cp.test_results.slice(0, 10).map(t => (typeof t === 'string' ? t : JSON.stringify(t))).join(' / ')}`);
+    lines.push('테스트 단계에서 실패했다면 구현을 처음부터 다시 하지 말고 실패한 검증 단계부터 재개하라.');
+  }
+  if (cp.error_summary) lines.push(`\n이전 오류 요약(마스킹됨):\n${String(cp.error_summary).slice(-800)}`);
+  return lines.join('\n');
+}
+
+// ── 재시도 상한 ──────────────────────────────────────────────────────────────
+/**
+ * 재시도 가능 여부. 무한 재시도 금지(3.5).
+ * @param {{totalAttempts:number, providerAttempts:object}} state
+ * @param {string} provider 다음에 시도할 공급자
+ */
+function canRetry(state, provider) {
+  const { maxProviderRetries, maxTotalAttempts } = modelConfig.retryLimits();
+  const total = Number(state && state.totalAttempts) || 0;
+  const perProvider = Number(((state && state.providerAttempts) || {})[provider]) || 0;
+  if (total >= maxTotalAttempts) return { ok: false, reason: `전체 최대 시도 ${maxTotalAttempts}회 초과` };
+  // maxProviderRetries = "재시도" 횟수 → 첫 시도 포함 허용 횟수는 +1
+  if (perProvider >= maxProviderRetries + 1) return { ok: false, reason: `${provider} 최대 재시도 ${maxProviderRetries}회 초과` };
+  return { ok: true, reason: null };
+}
+
+function noteAttempt(state, provider) {
+  state.totalAttempts = (Number(state.totalAttempts) || 0) + 1;
+  state.providerAttempts = state.providerAttempts || {};
+  state.providerAttempts[provider] = (Number(state.providerAttempts[provider]) || 0) + 1;
+  return state;
+}
+
+module.exports = {
+  ERROR_TYPES,
+  RESUME_HEADER,
+  RUNTIME_SUBDIR,
+  checkpointDir,
+  checkpointPath,
+  classifyError,
+  changedFiles,
+  diffSummary,
+  load,
+  save,
+  clear,
+  beginAttempt,
+  recordFailure,
+  recordSuccess,
+  buildResumeInstruction,
+  canRetry,
+  noteAttempt,
+  emptyCheckpoint,
+};

--- a/slack-bot/secret-mask.js
+++ b/slack-bot/secret-mask.js
@@ -1,0 +1,64 @@
+/**
+ * secret-mask.js — 로그/checkpoint 저장 전 비밀값 마스킹 (giip-1063, 안전 요구사항 7~9)
+ *
+ * 디스크에 남기는 모든 진단 정보(checkpoint, cost 로그)는 이 함수를 통과시킨다.
+ * "완벽한 탐지"가 아니라 "알려진 형태를 확실히 지우는" 것이 목적이다.
+ */
+
+const PATTERNS = [
+  // Slack
+  [/xox[baprs]-[A-Za-z0-9-]{10,}/g, 'xox*-***REDACTED***'],
+  [/xapp-[A-Za-z0-9-]{10,}/g, 'xapp-***REDACTED***'],
+  // Anthropic / MiniMax / OpenAI 계열
+  [/sk-cp-[A-Za-z0-9_\-]{8,}/g, 'sk-cp-***REDACTED***'],
+  [/sk-ant-[A-Za-z0-9_\-]{8,}/g, 'sk-ant-***REDACTED***'],
+  [/\bsk-[A-Za-z0-9_\-]{20,}/g, 'sk-***REDACTED***'],
+  // GitHub
+  [/\bgh[pousr]_[A-Za-z0-9]{20,}/g, 'gh*_***REDACTED***'],
+  [/\bgithub_pat_[A-Za-z0-9_]{20,}/g, 'github_pat_***REDACTED***'],
+  // JWT
+  [/\beyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}/g, '***REDACTED_JWT***'],
+  // Azure/AWS 류
+  [/\bAKIA[0-9A-Z]{16}\b/g, 'AKIA***REDACTED***'],
+  // KEY=VALUE 형태의 .env 라인 (KEY 이름에 SECRET/TOKEN/KEY/PASSWORD/PASSWD/PWD/SK 포함)
+  [/(^|\s)([A-Z0-9_]*(?:SECRET|TOKEN|API_?KEY|PASSWORD|PASSWD|PWD|_SK|^SK)[A-Z0-9_]*)\s*=\s*("?[^\s"']{4,}"?)/gim,
+    (m, pre, key) => `${pre}${key}=***REDACTED***`],
+  // JSON 필드 "password": "..." / "sk": "..." 등
+  [/("(?:password|passwd|pwd|secret|token|api_?key|apikey|sk|authorization)"\s*:\s*)"[^"]{4,}"/gi, '$1"***REDACTED***"'],
+  // Authorization 헤더
+  [/(authorization\s*:\s*)(bearer\s+)?[A-Za-z0-9_\-.=]{12,}/gi, '$1***REDACTED***'],
+];
+
+/** 문자열 안의 알려진 비밀값 패턴을 마스킹한다. */
+function maskString(text) {
+  let out = String(text == null ? '' : text);
+  for (const [re, rep] of PATTERNS) out = out.replace(re, rep);
+  return out;
+}
+
+/**
+ * 객체/배열을 재귀적으로 마스킹한다(키 이름이 민감하면 값 자체를 지운다).
+ *
+ * 주의: 키 이름만 보고 지우면 `input_tokens` 같은 "토큰 수" 필드까지 날아간다.
+ * 그래서 (a) 문자열 값만 통째로 지우고 (b) *_tokens 처럼 수치 카운터로 쓰이는 키는 제외한다.
+ */
+const SENSITIVE_KEY_RE = /(secret|token|password|passwd|pwd|api_?key|apikey|credential|authorization|\bsk\b)/i;
+const COUNTER_KEY_RE = /_tokens?$|^tokens?$|_count$/i;
+
+function maskDeep(value, depth = 0) {
+  if (depth > 8) return value;
+  if (value == null) return value;
+  if (typeof value === 'string') return maskString(value);
+  if (Array.isArray(value)) return value.map(v => maskDeep(v, depth + 1));
+  if (typeof value === 'object') {
+    const out = {};
+    for (const [k, v] of Object.entries(value)) {
+      const sensitive = SENSITIVE_KEY_RE.test(k) && !COUNTER_KEY_RE.test(k) && typeof v === 'string';
+      out[k] = sensitive ? '***REDACTED***' : maskDeep(v, depth + 1);
+    }
+    return out;
+  }
+  return value;
+}
+
+module.exports = { maskString, maskDeep, PATTERNS };

--- a/slack-bot/task-manager.js
+++ b/slack-bot/task-manager.js
@@ -11,11 +11,20 @@ const accounts = require('./claude-accounts');
 const minimax = require('./minimax-accounts');
 const { acquireRepoLock, releaseRepoLock } = require('./repo-lock');
 const config = require('./config'); // giip-974: 프로젝트별 응답 언어(resolveLangNameForProject)
+// giip-1063 비용 최적화 모듈
+const modelConfig = require('./model-config');
+const router = require('./model-router');
+const ctxBuilder = require('./context-builder');
+const prompts = require('./prompt-templates');
+const checkpoint = require('./retry-checkpoint');
+const costTracker = require('./cost-tracker');
 
 const BASE_DIR = path.join(__dirname, '..');
+// giip-1063: 비용 로그(.agent/runtime/cost-usage.jsonl)는 `!cost` 가 읽는 곳과 같아야 하므로
+// config.BASE_DIR(=WORKSPACE_DIR) 기준으로 통일한다.
+const COST_LOG_DIR = config.BASE_DIR || BASE_DIR;
 const TASKS_DIR = path.join(BASE_DIR, '.agent', 'tasks');
 const RESULTS_DIR = path.join(BASE_DIR, '.agent', 'results');
-const ROLES_DIR = path.join(BASE_DIR, '.agent', 'roles');
 const TASKLIST_FILE = path.join(__dirname, 'tasklist.json');
 
 function ensureDirs() {
@@ -30,27 +39,8 @@ function getTimestampId() {
   return `${now.getFullYear()}${p(now.getMonth()+1)}${p(now.getDate())}${p(now.getHours())}${p(now.getMinutes())}${p(now.getSeconds())}`;
 }
 
-// baseDir 配下の .agent/roles/ を読む。なければ Lowyworkenv の roles にフォールバック
-// filesRead に読んだファイルの絶対パスを push する
-function readRolesContext(baseDir = BASE_DIR, filesRead = []) {
-  const dirs = [
-    path.join(baseDir, '.agent', 'roles'),
-    ROLES_DIR,
-  ];
-  for (const dir of dirs) {
-    try {
-      const files = fs.readdirSync(dir).filter(f => f.endsWith('.md'));
-      if (files.length === 0) continue;
-      return files.map(f => {
-        const fullPath = path.join(dir, f);
-        filesRead.push(fullPath);
-        const content = fs.readFileSync(fullPath, 'utf8');
-        return `### ${f}\n${content.slice(0, 800)}`;
-      }).join('\n\n---\n\n');
-    } catch {}
-  }
-  return '';
-}
+// giip-1063: `.agent/roles/*.md` 전량을 무선별로 프롬프트에 싣던 readRolesContext() 는 삭제했다.
+// 분석 단계에서 고른 컨텍스트만 context-builder 로 읽는다(선택 결과가 없으면 minimalDefaultContext).
 
 function getCurrentBranch(cwd = BASE_DIR) {
   const res = spawnSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd, encoding: 'utf8', windowsHide: true });
@@ -100,7 +90,28 @@ function clearStaleRebaseState(cwd = BASE_DIR) {
   return true;
 }
 
-function runClaude(args, cwd = BASE_DIR, input = null) {
+/** argv 에서 기존 `--model <v>` 지정을 제거한다(모델은 model-router 가 정한다). */
+function stripModelArgs(args) {
+  const out = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--model') { i++; continue; }
+    out.push(args[i]);
+  }
+  return out;
+}
+
+/**
+ * 동기 claude CLI 호출.
+ *
+ * giip-1063: 모델명을 여기서 하드코딩하지 않고 model-router 가 (작업 등급, 단계) 로 정한다.
+ * opts 로 등급/단계/계측 정보를 넘긴다(미지정 시 standard/plan — 기존 동작과 동일한 MiniMax 우선).
+ *
+ * @param {string[]} args    claude CLI 인자(--model 은 여기서 무시하고 라우터 결정을 쓴다)
+ * @param {string}   cwd
+ * @param {string}   input   stdin 으로 보낼 프롬프트
+ * @param {object}   [opts]  { taskClass, phase, taskId, contextChars, contextFiles, contextSelection, fastPath, costBaseDir }
+ */
+function runClaude(args, cwd = BASE_DIR, input = null, opts = {}) {
   const spawnOpts = {
     cwd,
     encoding: 'utf8',
@@ -111,18 +122,53 @@ function runClaude(args, cwd = BASE_DIR, input = null) {
     ...(input != null ? { input } : {}),
   };
 
+  const baseArgs = stripModelArgs(args);
+  const taskClass = opts.taskClass || 'standard';
+  const phase = opts.phase || 'plan';
+  const costBase = opts.costBaseDir || COST_LOG_DIR;
+  const logCost = (extra) => {
+    try {
+      costTracker.record(costBase, {
+        task_id: opts.taskId || null,
+        phase,
+        task_class: taskClass,
+        input_chars: (input || '').length,
+        context_chars: opts.contextChars || 0,
+        context_files: opts.contextFiles || 0,
+        context_selection: opts.contextSelection || null,
+        fast_path: opts.fastPath || false,
+        prompt_version: prompts.PROMPT_VERSION,
+        ...extra,
+      });
+    } catch { /* 계측 실패가 본 작업을 막지 않는다 */ }
+  };
+
   // 우선순위(사용자 지정): MiniMax 먼저 → 실패해야만 Claude 계정 풀로 폴백.
   // runTask/callClaude 와 같은 정책. 여기(분석·계획 생성)만 Claude 전용으로 남으면
   // MiniMax 1순위가 반쪽이 되고 Claude 한도를 계속 태운다.
   const mm = minimax.resolve();
-  if (mm) {
-    console.log(`[TaskManager] runClaude: MiniMax(${mm.model}) 로 실행`);
-    const r = spawnSync('claude', minimax.argsFor(args, mm), { ...spawnOpts, env: minimax.envFor(mm) });
-    if (!r.error && r.status === 0) return (r.stdout || '').trim();
+  const route = router.selectModel(taskClass, phase, { minimax: !!mm, claude: accounts.count() > 0 });
+
+  if (mm && route.provider === 'minimax') {
+    console.log(`[TaskManager] runClaude(${phase}/${taskClass}): MiniMax(${mm.model}) 로 실행`);
+    const t0 = Date.now();
+    const r = spawnSync('claude', minimax.argsFor(baseArgs, mm), { ...spawnOpts, env: minimax.envFor(mm) });
+    const out = (r?.stdout || '').trim();
+    const usage = costTracker.parseUsageFromOutput(`${r?.stdout || ''}\n${r?.stderr || ''}`);
+    logCost({
+      provider: 'minimax', model: mm.model, attempt: 1, duration_ms: Date.now() - t0,
+      status: (!r.error && r.status === 0) ? 'success' : 'failed',
+      output_chars: out.length, ...(usage || {}),
+    });
+    if (!r.error && r.status === 0) return out;
     const mmOut = `${r?.stdout || ''}\n${r?.stderr || ''}`;
     if (minimax.isUsageLimit(mmOut)) minimax.noteUsageLimit();
     console.log('[TaskManager] runClaude: MiniMax 실패 → Claude 폴백으로 전환');
   }
+
+  // Claude 로 갈 때 쓸 모델: 라우터가 정한 모델(=티어별), MiniMax 폴백이면 티어 폴백 모델.
+  const claudeModel = route.provider === 'claude' ? route.model : route.fallback.model;
+  const claudeArgs = [...baseArgs, '--model', claudeModel];
 
   // 계정 라우팅: weight 비율대로 계정 선택 → 한도면 다음 계정으로 재시도
   const maxTries = accounts.count();
@@ -130,9 +176,18 @@ function runClaude(args, cwd = BASE_DIR, input = null) {
   for (let i = 0; i < maxTries; i++) {
     const acct = accounts.pickAccount();
     if (!acct) throw new Error('claude 전 계정 사용량 한도 소진 — 잠시 후 재시도 필요');
-    result = spawnSync('claude', args, { ...spawnOpts, env: accounts.envFor(acct) });
+    const t0 = Date.now();
+    result = spawnSync('claude', claudeArgs, { ...spawnOpts, env: accounts.envFor(acct) });
+    const out = (result?.stdout || '').trim();
+    const usage = costTracker.parseUsageFromOutput(`${result?.stdout || ''}\n${result?.stderr || ''}`);
+    logCost({
+      provider: 'claude', model: claudeModel, attempt: i + 1, duration_ms: Date.now() - t0,
+      status: result && result.status === 0 ? 'success' : 'failed',
+      output_chars: out.length, fallback_from: mm ? 'minimax' : null,
+      ...(usage || {}),
+    });
     if (result.error) throw result.error;
-    if (result.status === 0) return (result.stdout || '').trim();
+    if (result.status === 0) return out;
     // 한도 메시지가 stdout에 찍히는 경우가 있어(giip-759) 두 스트림 모두 확인한다.
     const combinedOut = `${result.stdout || ''}\n${result.stderr || ''}`;
     if (accounts.isUsageLimit(combinedOut)) { accounts.noteUsageLimit(acct, combinedOut); continue; }
@@ -143,141 +198,176 @@ function runClaude(args, cwd = BASE_DIR, input = null) {
 
 // ── Rule 43: 컨텍스트 파일 provenance (경로 + 로드 사유) ──────────────────────
 // 전량 무선별 주입(readRolesContext) 대신, 요청 관련 role/rule/skill 만 사유와 함께 선별 로드한다.
+//
+// giip-1063: 실제 구현은 context-builder.js 로 옮겼다(파일 헤드만 읽는 카탈로그, 개수·길이 한도,
+// 중복 제거, 제목 기반 축약, mtime/hash 캐시). 여기에는 기존 호출부·export 를 위한 얇은 래퍼만 둔다.
 
-// .agent/roles·rules·skills 의 파일 카탈로그(경로 + 짧은 설명). skills 는 dir(SKILL.md) 또는 *.md.
+/** .agent/roles·rules·skills 카탈로그. 본문이 아니라 name/description/trigger 만 읽는다. */
 function buildContextCatalog(baseDir = BASE_DIR) {
-  const out = [];
-  const firstDesc = (text) => {
-    const fm = text.match(/description:\s*(.+)/i);
-    if (fm) return fm[1].trim().replace(/^["']|["']$/g, '').slice(0, 140);
-    const line = text.split(/\r?\n/).map(l => l.trim()).find(l => l && l !== '---');
-    return (line || '').replace(/^#+\s*/, '').slice(0, 140);
-  };
-  const addFile = (type, absPath) => {
-    try {
-      const rel = path.relative(baseDir, absPath).replace(/\\/g, '/');
-      out.push({ type, path: rel, desc: firstDesc(fs.readFileSync(absPath, 'utf8')) });
-    } catch {}
-  };
-  // roles/rules: project baseDir 우선, 없으면 Lowyworkenv(.agent) 로 폴백
-  for (const [type, sub] of [['role', 'roles'], ['rule', 'rules']]) {
-    let dir = path.join(baseDir, '.agent', sub);
-    try { if (!fs.readdirSync(dir).some(f => f.endsWith('.md'))) dir = path.join(BASE_DIR, '.agent', sub); }
-    catch { dir = path.join(BASE_DIR, '.agent', sub); }
-    try { fs.readdirSync(dir).filter(f => f.endsWith('.md')).forEach(f => addFile(type, path.join(dir, f))); } catch {}
-  }
-  // skills: dir 안 SKILL.md, 또는 top-level *.md
-  let skillsDir = path.join(baseDir, '.agent', 'skills');
-  if (!fs.existsSync(skillsDir)) skillsDir = path.join(BASE_DIR, '.agent', 'skills');
-  try {
-    for (const e of fs.readdirSync(skillsDir, { withFileTypes: true })) {
-      if (e.isDirectory()) {
-        const sk = path.join(skillsDir, e.name, 'SKILL.md');
-        if (fs.existsSync(sk)) addFile('skill', sk);
-      } else if (e.name.endsWith('.md')) {
-        addFile('skill', path.join(skillsDir, e.name));
-      }
-    }
-  } catch {}
-  return out;
+  return ctxBuilder.buildContextCatalog(baseDir, BASE_DIR);
 }
 
-// 요청에 관련된 컨텍스트 파일을 LLM 으로 선별하고 각 파일의 로드 사유를 받는다. → [{path, reason}]
-function selectContextFiles(requestText, catalog, baseDir = BASE_DIR) {
-  if (!catalog.length) return [];
-  const catalogText = catalog.map((c, i) => `${i + 1}. [${c.type}] ${c.path} — ${c.desc}`).join('\n');
-  const prompt = `너는 아래 Slack 요청을 분석·수행하기 위해 참조해야 할 컨텍스트 파일(role/rule/skill)을 고르는 큐레이터다.
+/**
+ * 요청에 관련된 컨텍스트 파일을 저비용 모델로 선별한다 → [{path, reason, max_chars}].
+ * 분류/선별 단계는 model-router 가 항상 최저 티어를 강제하므로 Opus 가 쓰이지 않는다.
+ * 모델 호출이 실패하거나 결과가 비면 정적 선별로 폴백한다(호출 1회로 끝).
+ */
+function selectContextFiles(requestText, catalog, baseDir = BASE_DIR, opts = {}) {
+  if (!catalog || !catalog.length) return [];
+  const limits = modelConfig.contextLimits();
+  const staticPick = () => ctxBuilder.selectContextFilesStatic(requestText, catalog, limits);
 
-요청:
-"${requestText}"
+  if (opts.staticOnly) return staticPick();
 
-사용 가능한 컨텍스트 파일:
-${catalogText}
+  // 카탈로그가 크면 선별 호출 프롬프트 자체가 비싸진다 → 정적 점수로 상위 후보만 넘긴다.
+  const narrowed = ctxBuilder.narrowCatalog(requestText, catalog,
+    Number(process.env.CONTEXT_CATALOG_MAX) || 30);
+  const prompt = prompts.buildContextSelectionPrompt({
+    catalogText: ctxBuilder.formatCatalogForPrompt(narrowed),
+    requestText,
+  });
 
-이 요청 처리에 "실제로 관련 있는" 파일만 골라라(무관한 것은 넣지 말 것, 보통 2~8개). 각 파일에 대해
-"이 태스크에서 그 파일의 무엇을 참조/적용하려는지"를 한국어 한 줄 사유로 적어라.
-아래 JSON 배열만 출력한다(코드펜스·설명 금지):
-[{"path":"<위 목록의 정확한 경로>","reason":"<한 줄 사유>"}]`;
-  const raw = runClaude(['-p', '--model', 'claude-opus-4-8'], baseDir, prompt);
+  let raw = '';
+  try {
+    raw = runClaude(['-p'], baseDir, prompt, {
+      taskClass: opts.taskClass || 'standard',
+      phase: 'context',
+      taskId: opts.taskId || null,
+      costBaseDir: opts.costBaseDir || COST_LOG_DIR,
+    });
+  } catch (e) {
+    console.error('[TaskManager] 컨텍스트 선별 호출 실패 → 정적 선별로 폴백:', e.message);
+    return staticPick();
+  }
+
   let parsed = [];
   try { const m = raw.match(/\[[\s\S]*\]/); parsed = m ? JSON.parse(m[0]) : []; } catch { parsed = []; }
   const valid = new Set(catalog.map(c => c.path));   // 카탈로그에 없는(할루시네이션) 경로 차단
   const seen = new Set();
-  return parsed
+  const picked = parsed
     .filter(x => x && typeof x.path === 'string' && valid.has(x.path) && !seen.has(x.path) && seen.add(x.path))
-    .map(x => ({ path: x.path, reason: (String(x.reason || '').trim().slice(0, 200)) || '(사유 미기재)' }));
+    .slice(0, limits.hardMaxFiles)
+    .map(x => ({
+      path: x.path,
+      reason: (String(x.reason || '').trim().slice(0, 200)) || '(사유 미기재)',
+      max_chars: Math.min(Number(x.max_chars) || limits.perFileMaxChars, limits.perFileMaxChars),
+    }));
+
+  return picked.length ? picked : staticPick();
 }
 
-// 선별된 파일 내용을 읽어 분석 프롬프트용 컨텍스트 문자열과 filesRead([{path,reason}]) 를 만든다.
-function readSelectedContext(selected, baseDir = BASE_DIR) {
-  const parts = [], filesRead = [];
-  for (const s of selected) {
-    try {
-      const content = fs.readFileSync(path.join(baseDir, s.path), 'utf8');
-      parts.push(`### ${s.path} (로드 사유: ${s.reason})\n${content.slice(0, 800)}`);
-      filesRead.push({ path: s.path, reason: s.reason });
-    } catch {}
-  }
-  return { context: parts.join('\n\n---\n\n'), filesRead };
-}
-
-// filesRead 항목을 {path, reason} 로 정규화(문자열/절대경로 입력 후방호환 — 예: wfrun 의 [wfPath]).
-function normalizeFilesRead(filesRead) {
-  return (filesRead || []).map(f => {
-    if (typeof f === 'string') {
-      const rel = path.isAbsolute(f) ? path.relative(BASE_DIR, f).replace(/\\/g, '/') : f.replace(/\\/g, '/');
-      return { path: rel, reason: '(직접 지정)' };
-    }
-    return { path: String(f.path || '').replace(/\\/g, '/'), reason: f.reason || '(사유 미기재)' };
+/** 선별된 파일 내용을 한도 안에서 읽어 컨텍스트 문자열과 filesRead 를 만든다. */
+function readSelectedContext(selected, baseDir = BASE_DIR, opts = {}) {
+  return ctxBuilder.readSelectedContext(selected, baseDir, {
+    workspaceDir: BASE_DIR,
+    queryText: opts.queryText || '',
+    limits: opts.limits,
   });
 }
 
+/** filesRead 항목을 {path, reason, max_chars} 로 정규화(문자열/절대경로 입력 후방호환). */
+function normalizeFilesRead(filesRead) {
+  return ctxBuilder.normalize(filesRead, BASE_DIR);
+}
+
 // ── Phase 1: 요청 분석 → TASK 파일 생성 ─────────────────────────────────────
-// returns { planContent, filesRead: [{path, reason}] }
+// returns { planContent, filesRead: [{path, reason, max_chars}], classification, contextStats, fastPath }
+//
+// giip-1063
+//  - 컨텍스트 카탈로그는 본문이 아니라 name/description/trigger 만 읽는다.
+//  - 선별/계획 모델은 model-router 가 작업 등급으로 정한다(Opus 하드코딩 제거).
+//  - trivial + 대상 경로가 명시된 요청은 Fast Path — 선별·계획 모델 호출을 0회로 줄이고
+//    실행 1회로 끝낸다.
+
+/** Fast Path 용 정적 계획. 모델 호출 없이 태스크 사양 형식을 맞춰 만든다. */
+function buildFastPathPlan(requestText, cls) {
+  const title = String(requestText || '').replace(/\s+/g, ' ').trim().slice(0, 60) || '단순 수정';
+  const targets = cls.explicitPaths.length ? cls.explicitPaths : ['(요청 본문에 명시된 대상)'];
+  return [
+    `# TASK: ${title}`,
+    '',
+    '## 요청 내용',
+    String(requestText || '').trim(),
+    '',
+    '## 실행 계획',
+    `1. 대상 파일을 먼저 읽어 현재 내용을 확인한다 (${targets.join(', ')})`,
+    '2. 요청된 범위 안에서만 수정한다 (범위 밖 리팩터링·포맷 정리 금지)',
+    '3. diff 를 확인하고 테스트 또는 재현 검증을 수행한다',
+    '4. 결과 보고서를 작성한다',
+    '',
+    '## 영향 파일/서브시스템',
+    ...targets.map(t => `- ${t}`),
+    '',
+    '## 주의사항',
+    `- Fast Path: trivial(신뢰도 ${cls.confidence}) 로 정적 분류돼 계획 생성 모델 호출을 생략했습니다.`,
+    '- 작업이 3개 초과 파일 / 인증·보안·DB·배포 변경 / 삭제·대량 변경으로 확대되면 즉시 중단하고',
+    '  "Fast Path 부적합 — 일반 경로로 승격 필요"를 보고서에 남길 것.',
+  ].join('\n');
+}
+
 function analyzeRequest(requestText, taskId, baseDir = BASE_DIR) {
   ensureDirs();
 
   const claims = searchKLayer(requestText);
   const projectName = path.basename(baseDir);
-  // Rule 43: 요청 관련 role/rule/skill 만 사유와 함께 선별 로드하고, 그 사유를 태스크 파일에 남긴다.
+  const limits = modelConfig.contextLimits();
+
+  // 1) 카탈로그(본문 미로딩) + 사전 정적 분류(모델 호출 0회)
   const catalog = buildContextCatalog(baseDir);
-  const selected = selectContextFiles(requestText, catalog, baseDir);
-  const { context: rolesContext, filesRead } = readSelectedContext(selected, baseDir);
+  const pre = router.classifyTask(requestText, [], '');
+  const fastPath = pre.fastPathEligible;
 
-  const analysisPrompt = `You are a senior software architect. Always respond in ${config.resolveLangNameForProject(projectName)}.
+  // 2) 컨텍스트 선별 — Fast Path 면 LLM 호출 없이 정적 선별
+  let selected = selectContextFiles(requestText, catalog, baseDir, {
+    staticOnly: fastPath,
+    taskClass: pre.class,
+    taskId,
+    costBaseDir: COST_LOG_DIR,
+  });
+  if (!selected.length) selected = ctxBuilder.minimalDefaultContext(baseDir, BASE_DIR);
 
-Working project: ${projectName}
-Working directory: ${baseDir}
+  // 3) 선택 파일만, 한도 안에서, 제목 기반 축약으로 읽는다
+  const { context: rolesContext, filesRead, stats } =
+    readSelectedContext(selected, baseDir, { queryText: requestText, limits });
 
-A team member sent this request via Slack:
-"${requestText}"
-${rolesContext ? `\n=== 프로젝트 역할/컨텍스트 ===\n${rolesContext}\n` : ''}${claims.length > 0 ? `\n=== K-Layer 관련 지식 ===\n${claims.map(c => `• ${c}`).join('\n')}\n` : ''}
-Analyze the request and output a task specification in this EXACT format (in Korean):
+  // 4) Fast Path: 별도 계획 생성 호출을 하지 않는다(3.4)
+  if (fastPath) {
+    console.log(`[TaskManager] analyzeRequest: Fast Path(trivial) — 계획 모델 호출 생략 (files=${stats.files}, chars=${stats.chars})`);
+    return {
+      planContent: buildFastPathPlan(requestText, pre),
+      filesRead,
+      classification: pre,
+      contextStats: stats,
+      fastPath: true,
+    };
+  }
 
-# TASK: [짧은 제목]
+  // 5) 계획 생성 — 모델은 등급별(planner/complex/critical) 라우팅
+  const analysisPrompt = prompts.buildAnalysisPrompt({
+    requestText,
+    contextText: rolesContext,
+    projectName,
+    baseDir,
+    langName: config.resolveLangNameForProject(projectName),
+    kLayerClaims: claims,
+  });
 
-## 요청 내용
-[요청 요약 — 1~2줄]
+  const planContent = runClaude(['-p'], baseDir, analysisPrompt, {
+    taskClass: pre.class,
+    phase: 'plan',
+    taskId,
+    contextChars: stats.chars,
+    contextFiles: stats.files,
+    contextSelection: filesRead.map(f => ({ path: f.path, reason: f.reason })),
+    costBaseDir: COST_LOG_DIR,
+  });
 
-## 실행 계획
-1. [구체적인 실행 단계]
-2. [단계 2]
-3. [단계 3]
-(최대 7단계)
-
-## 영향 파일/서브시스템
-- [변경될 파일 또는 서브시스템]
-
-## 주의사항
-- [배포 주의사항, 부작용 등]
-
-Output ONLY the task specification, no extra commentary.`;
-
-  const planContent = runClaude(['-p', '--model', 'claude-opus-4-8'], baseDir, analysisPrompt);
-  return { planContent, filesRead };
+  // 6) 계획을 반영해 재분류(정적). 실행 단계 모델 티어는 이 결과를 쓴다.
+  const classification = router.classifyTask(requestText, filesRead, planContent);
+  return { planContent, filesRead, classification, contextStats: stats, fastPath: false };
 }
 
-function createTaskFile(taskId, requestText, planContent, filesRead = []) {
+function createTaskFile(taskId, requestText, planContent, filesRead = [], meta = {}) {
   ensureDirs();
 
   const norm = normalizeFilesRead(filesRead);   // Rule 43: 경로 + 로드 사유
@@ -285,11 +375,17 @@ function createTaskFile(taskId, requestText, planContent, filesRead = []) {
     ? '\n' + norm.map(f => `#   - ${f.path} — ${f.reason}`).join('\n')
     : '\n#   (없음)';
 
+  // giip-1063: 실행 단계가 "분석 때 고른 파일만" 다시 읽을 수 있도록 파싱 가능한 형태로 저장한다.
+  // 아래 주석 형태(#   - path — reason)는 기존 태스크 파일과의 하위 호환을 위해 그대로 남긴다.
   const header = `---
 task_id: ${taskId}
 status: pending
 requested_at: ${new Date().toISOString()}
 request: "${requestText.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"
+task_class: ${meta.taskClass || 'standard'}
+fast_path: ${meta.fastPath ? 'true' : 'false'}
+prompt_version: ${prompts.PROMPT_VERSION}
+${ctxBuilder.formatContextFilesYaml(norm)}
 # 분석에 로드된 컨텍스트 파일 (role/rule/skill — 경로 — 로드 사유):${fileList}
 ---
 
@@ -302,7 +398,30 @@ request: "${requestText.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"
 // 既存タスクファイルを「更新」する（新規IDを発給しない）。
 // 参照されたタスク番号に改訂を追記し、done/cancel にあれば tasks/ に戻して pending に再オープンする。
 // 見つからなければ createTaskFile にフォールバック。返り値は tasks/{taskId}.md の絶対パス。
-function updateTaskFile(taskId, requestText, planContent, filesRead = []) {
+/**
+ * giip-1063: 태스크 파일 frontmatter 의 context_files / task_class 를 최신 선택으로 갱신한다.
+ * 실행 단계가 "이번 분석에서 고른 파일"만 다시 읽게 하기 위한 것. frontmatter 가 없으면 그대로 둔다.
+ */
+function upsertContextFilesFrontmatter(content, norm, meta = {}) {
+  const yaml = ctxBuilder.formatContextFilesYaml(norm);
+  let out = content;
+
+  // task_class 갱신(없으면 나중에 블록과 함께 삽입)
+  if (/^task_class:\s*.+$/m.test(out)) {
+    out = out.replace(/^task_class:\s*.+$/m, `task_class: ${meta.taskClass || 'standard'}`);
+  }
+
+  const blockRe = /^context_files:\s*(?:\[\]|\r?\n(?:[ \t]+.*\r?\n?)*)/m;
+  if (blockRe.test(out)) return out.replace(blockRe, `${yaml}\n`);
+
+  const fmEnd = out.match(/^---\r?\n[\s\S]*?(\r?\n---\r?\n)/);
+  if (!fmEnd) return out;   // frontmatter 없는 구형 파일 — 건드리지 않는다
+  const insertAt = out.indexOf(fmEnd[1]);
+  const extra = /^task_class:\s*/m.test(out) ? '' : `\ntask_class: ${meta.taskClass || 'standard'}`;
+  return `${out.slice(0, insertAt)}${extra}\n${yaml}${out.slice(insertAt)}`;
+}
+
+function updateTaskFile(taskId, requestText, planContent, filesRead = [], meta = {}) {
   ensureDirs();
   const activePath = path.join(TASKS_DIR, `${taskId}.md`);
   const existing = [
@@ -312,7 +431,7 @@ function updateTaskFile(taskId, requestText, planContent, filesRead = []) {
   ].find(f => fs.existsSync(f));
 
   // 元ファイルが見つからない場合のみ新規作成（実質 createTaskFile と同じ挙動）
-  if (!existing) return createTaskFile(taskId, requestText, planContent, filesRead);
+  if (!existing) return createTaskFile(taskId, requestText, planContent, filesRead, meta);
 
   let content = fs.readFileSync(existing, 'utf8');
 
@@ -320,6 +439,9 @@ function updateTaskFile(taskId, requestText, planContent, filesRead = []) {
   content = /status:\s*.+/i.test(content)
     ? content.replace(/status:\s*.+/i, 'status: pending')
     : `status: pending\n${content}`;
+
+  // 실행 단계가 최신 선택 컨텍스트만 읽도록 frontmatter 갱신
+  content = upsertContextFilesFrontmatter(content, normalizeFilesRead(filesRead), meta);
 
   // 改訂を追記（元タスクの内容・成果物は保持したまま）
   const now = new Date().toISOString();
@@ -365,6 +487,13 @@ function extractTitle(planContent) {
 }
 
 // ── Phase 2: subagent 실행 (비동기) ─────────────────────────────────────────
+//
+// giip-1063
+//  - 실행 프롬프트에 `.agent/roles` 전량을 다시 넣던 readRolesContext() 호출을 제거했다.
+//    분석 단계가 태스크 파일 frontmatter 에 남긴 context_files 만 다시 읽는다.
+//  - 프롬프트는 prompt-templates 가 고정 prefix 순서로 조립한다(캐시 적중률).
+//  - 모델은 model-router 가 작업 등급으로 정한다(Opus 고정 호출 제거).
+//  - 실패 시 checkpoint 를 남기고, 다음 모델에는 전체 원문 대신 재개 지시문을 덧붙인다.
 function startExecution(taskId, taskFilePath, { onComplete, onError, isn = null }, baseDir = BASE_DIR, ctx = null) {
   ensureDirs();
 
@@ -382,82 +511,69 @@ function startExecution(taskId, taskFilePath, { onComplete, onError, isn = null 
 
   const taskContent = fs.readFileSync(taskFilePath, 'utf8');
   const resultFile = path.join(RESULTS_DIR, `${taskId}.md`);
-  const rolesContext = readRolesContext(baseDir);
+
+  // ── 선택된 컨텍스트만 재로딩 (전체 roles 로딩 제거, 3.1) ──────────────────
+  // 신규 태스크: frontmatter 의 context_files, 구형 태스크: 주석 목록(하위 호환).
+  // 둘 다 없거나 읽기에 실패하면 "최소" 기본 컨텍스트만 쓴다 — 전체 roles 로 되돌아가지 않는다.
+  let selected = ctxBuilder.parseContextFiles(taskContent);
+  let contextSource = selected.length ? 'task-metadata' : 'minimal-default';
+  if (!selected.length) selected = ctxBuilder.minimalDefaultContext(baseDir, BASE_DIR);
+  const ctxRead = ctxBuilder.readSelectedContext(selected, baseDir, {
+    workspaceDir: BASE_DIR,
+    queryText: taskContent,
+    limits: modelConfig.contextLimits(),
+  });
+  if (!ctxRead.filesRead.length && contextSource === 'task-metadata') {
+    // 선택 목록이 손상돼 하나도 못 읽은 경우에만 최소 기본으로 대체
+    const fb = ctxBuilder.readSelectedContext(
+      ctxBuilder.minimalDefaultContext(baseDir, BASE_DIR), baseDir,
+      { workspaceDir: BASE_DIR, queryText: taskContent });
+    ctxRead.context = fb.context;
+    ctxRead.filesRead = fb.filesRead;
+    ctxRead.stats = fb.stats;
+    contextSource = 'minimal-default(선택 목록 손상)';
+  }
+  console.log(`[TaskManager] task ${taskId}: 실행 컨텍스트 ${ctxRead.filesRead.length}개 파일 / ${ctxRead.stats.chars}자 (${contextSource})`);
+
   const claims = searchKLayer(taskContent);
 
   // ctx が渡されていれば prepareTaskBranch 済みの専用ブランチ。無ければ現在ブランチ(後方互換)。
   const currentBranch = (ctx && ctx.branch) || getCurrentBranch(baseDir);
   const baseBranch = (ctx && ctx.base) || getBaseBranch(baseDir);
 
-  // 進捗コメント・プロトコル(PROTOCOL_PROGRESS_COMMENT.md): giip issue に連携済み(isn あり)の時だけ
-  // 注入する。isn が無ければ giip 未連携なのでブロック全体を省く(条件「giip issue api 접근 가능한 환경이면」)。
+  // 작업 등급: 분석 단계가 남긴 frontmatter 우선, 없으면(구형 태스크) 본문으로 정적 분류.
+  const fmClassMatch = taskContent.match(/^task_class:\s*(\w+)\s*$/m);
+  const fmClass = fmClassMatch && router.ORDER.includes(fmClassMatch[1]) ? fmClassMatch[1] : null;
+  const classification = fmClass
+    ? { class: fmClass, confidence: 1, reasons: ['분석 단계에서 결정된 등급 재사용'] }
+    : router.classifyTask(taskContent, ctxRead.filesRead, taskContent);
+  const taskClass = classification.class;
+  const fastPath = /^fast_path:\s*true\s*$/m.test(taskContent);
+  console.log(`[TaskManager] task ${taskId}: class=${taskClass}${fastPath ? ' (fast path)' : ''} — ${classification.reasons.join(' / ')}`);
+
+  // 進捗コメント・プロトコル(PROTOCOL_PROGRESS_COMMENT.md) は프롬프트 고정부에 있고,
+  // 여기서는 issue 번호와 커맨드만 동적 상태로 넘긴다(고정 prefix 안정화).
   const addCommentScript = path.join(BASE_DIR, '..', 'giipprj', 'giipdb', 'mgmt', 'addIssueComment.ps1');
-  const progressBlock = isn ? `
 
-=== 진행 코멘트 프로토콜 (정본 .agent/rules/PROTOCOL_PROGRESS_COMMENT.md) ===
-이 태스크는 giip issue #${isn} 에 연동돼 있다. 진행 상황을 자주 코멘트로 남겨, 코멘트만 봐도 어디까지
-왔고 무엇이 바뀌었는지 재구성되게 하라. 파일 1개당 코멘트 1개를 강제하지 말고 "논리 묶음" 단위로
-각 1~3줄 짧게 남긴다(같은 내용 연타·스팸 금지). 남기는 시점:
-  1) 착수: 로드해서 따르는 role/rule/skill/workflow 를 명시.
-  2) 참조 정본 변경: 따라야 할 role/rule/skill/workflow 파일 자체를 수정할 때 — 무엇을 왜.
-  3) 대상 파일 변경: 실제 수정/생성/삭제한 소스·문서가 생길 때마다(논리 묶음마다) — 경로 + 한 줄.
-  4) 검색 발생: 부득이 grep/find 했으면 (a)왜 (b)어디에 링크로 흡수했는지(Search→Link→Report).
-  5) 분기·막힘·판단: 에러·사람 확인 필요, 중요한 설계 판단이 생길 때.
-  6) **완료 직전(필수, 2026-07-29)**: 작업을 마치기 직전, 봇이 최종 "완료" 코멘트를 달기 *전에* 아래 두
-     코멘트를 네가 먼저 남겨라 — (a) **테스트 결과**: 실제로 무엇을 어떻게 실행/재현해서 검증했는지와
-     결과(성공/실패/부분성공). 기존 테스트가 있으면 커맨드·종료코드·출력 요약, 없으면 수행한 수동
-     재현·재검증 절차와 결과("테스트 없음"이라고만 쓰고 넘기지 말 것 — 최소 1건의 재현 검증 필수).
-     (b) **사용자 테스트 방법**: 사람이 직접 확인하려면 무엇을 클릭/실행/조회하면 되는지 재현 가능한
-     구체 절차(URL·커맨드·화면 경로 등). 막연하게 "확인해보세요"라고 쓰지 말 것.
-빈도: 몇 분 이상 걸리는 작업이면 최소 시작·중간·끝이 코멘트로 남게 한다.
-명령(직접-DB append, 한글 안 깨짐):
-  pwsh -File "${addCommentScript}" -isn ${isn} -content "<본문>" -issuetype note -author "slack-bot"
-  (중간 진행은 issuetype=note. 상태 전이/최종 코멘트는 봇이 별도 처리하므로 여기서 상태는 바꾸지 말 것.)
-` : '';
-  const executionPrompt = `You are a senior software engineer working in the Lowyworkenv workspace. Always respond in ${config.resolveLangNameForProject(path.basename(baseDir))}.
-Working directory: ${baseDir}
-Current branch: ${currentBranch} (task 전용 브랜치, base=${baseBranch} 최신 기준)
-
-=== 담당 태스크 ===
-${taskContent}
-
-=== 사용 가능한 역할 ===
-${rolesContext || '(roles not found)'}
-
-=== K-LAYER 지식 ===
-${claims.length > 0 ? claims.map(c => `• ${c}`).join('\n') : '(없음)'}
-
-=== 작업 지시 ===
-0. **되묻지 말고 실측하라**: 경로·설정·사양 등 조회로 확정 가능한 값은 사용자에게 다시 묻지 말고 직접 찾아 결정한다.
-   - giip 서비스 설정(SMTP·메일·인증 등)의 정본은 **giipdb 사양서(\`giipprj/giipdb/docs/30_Specs/\`)와 DB**다. 사람에게 묻기 전에 반드시 그곳부터 grep/조회하라. 예: SMTP 설정은 \`tEmailServerConfig\` 테이블에 있고 giip API \`EmailServerConfigGetActive\`(SP \`pApiEmailServerConfigGetActivebyAK\`, 서버측 \`bySk\`)로 조회한다.
-   - 정말로 사람만 아는 값(외부 자격증명 실물, 사용자의 의도적 선택)만 질문한다.
-1. 위 태스크의 실행 계획을 순서대로 실행하세요.
-2. Read/Edit/Write/Bash 도구를 사용해 이 저장소(${baseDir}) 안에서 실제 코드 변경을 수행하세요.
-3. **git 커밋·push·PR·브랜치 전환은 절대 하지 마세요.** 작업트리는 이미 태스크 전용 브랜치 \`${currentBranch}\`(base=${baseBranch} 최신 fetch 기준)로 준비돼 있습니다. 파일 변경만 마치면, 봇이 작업 종료 후 자동으로 이 브랜치에 커밋·push 하고 \`${baseBranch}\` 로 PR 을 생성합니다. (당신이 직접 git 을 만지면 브랜치/PR 흐름이 깨집니다.)
-4. 모든 단계 완료 후 반드시 다음 경로에 결과 보고서를 작성하세요:
-   ${resultFile}
-
-결과 보고서 형식:
----
-# 작업 완료 보고서: [태스크 제목]
-
-## 완료 일시
-${new Date().toISOString()}
-
-## 실시 내용
-(실제 수행한 작업의 상세 설명)
-
-## 변경 파일
-- path/to/file — 변경 내용 요약
-
-## 결과/상태
-(성공 / 부분 완료 / 실패, 이유)
-
-## 다음 단계
-(후속 작업이 필요한 경우 명기)
----
-${progressBlock}
-지금 바로 작업을 시작하세요.`;
+  const buildPrompt = (attemptNo, resumeInstruction) => prompts.buildExecutionPrompt({
+    fastPath,
+    contextText: ctxRead.context,
+    contextFiles: ctxRead.filesRead.map(f => ({ path: f.path, reason: f.reason })),
+    projectName: path.basename(baseDir),
+    baseDir,
+    baseBranch,
+    langName: config.resolveLangNameForProject(path.basename(baseDir)),
+    taskContent,
+    kLayerClaims: claims,
+    taskId,
+    taskClass,
+    branch: currentBranch,
+    attempt: attemptNo,
+    resultFile,
+    isn,
+    addCommentScript: isn ? addCommentScript : null,
+    resumeInstruction,
+  });
 
   // 実行サブエージェントが roles/rules/skills/workflows を参照できるよう .agent を許可
   // （baseDir に .agent が無ければ BASE_DIR/.agent にフォールバック — index.js の getAgentDir と同じ規則）
@@ -468,20 +584,26 @@ ${progressBlock}
   const args = ['-p', '--dangerously-skip-permissions', '--add-dir', agentDir];
 
   // 계정 라우팅: weight 비율대로 계정 선택. 실행 중 사용량 한도에 걸리면
-  // 해당 계정을 쿨다운하고 다음 계정으로 태스크를 처음부터 재실행한다.
-  // (주의: 재실행이므로 이미 push된 커밋이 있으면 중복 커밋 가능 — fail보다 나은 동작)
+  // 해당 계정을 쿨다운하고 다음 계정으로 재실행한다.
+  // giip-1063: 재실행 시 checkpoint 로 "이미 끝난 일"을 알려 처음부터 반복하지 않게 한다.
   const tried = new Set();
   // 우선순위(사용자 지정): MiniMax 먼저, MiniMax 한도 소진 시에만 Claude로 폴백.
-  // mmExhausted=true 가 되면(이번 태스크 한정) 이후 attempt() 는 MiniMax를 다시 시도하지 않는다
-  // (minimax.resolve() 는 별도로 자체 쿨다운을 갖고 있어 다음 태스크에서는 그 쿨다운을 그대로 따른다).
   let mmExhausted = false;
+  let attemptNo = 0;
+  const retryState = { totalAttempts: 0, providerAttempts: {} };
 
-  function attempt() {
-    let acct = mmExhausted ? null : minimax.resolve();
-    let env;
-    if (acct) {
+  function attempt(resumeInstruction = null, fallbackFrom = null) {
+    const mmAvailable = mmExhausted ? null : minimax.resolve();
+    const route = router.selectModel(taskClass, 'execute',
+      { minimax: !!mmAvailable, claude: accounts.count() > 0 });
+
+    let acct, env, provider, modelName;
+    if (mmAvailable && route.provider === 'minimax') {
+      acct = mmAvailable;
       env = minimax.envFor(acct);
-      console.log(`[TaskManager] task ${taskId}: MiniMax(${acct.model}) 로 실행`);
+      provider = 'minimax';
+      modelName = acct.model;
+      console.log(`[TaskManager] task ${taskId}: MiniMax(${modelName}) 로 실행 (class=${taskClass})`);
     } else {
       acct = accounts.pickAccount();
       if (!acct) {
@@ -489,13 +611,38 @@ ${progressBlock}
         return null;
       }
       env = accounts.envFor(acct);
-      if (mmExhausted) console.log(`[TaskManager] task ${taskId}: MiniMax 한도 소진 → Claude(${acct.name}) 폴백`);
+      provider = 'claude';
+      // 라우터가 정한 모델. 반복 실패 시에만(complex/critical) 최상위 모델로 승격한다.
+      const esc = router.escalateOnFailure(taskClass, retryState.totalAttempts);
+      modelName = esc ? esc.model : (route.provider === 'claude' ? route.model : route.fallback.model);
+      if (esc) console.log(`[TaskManager] task ${taskId}: ${esc.reason}`);
+      if (mmExhausted) console.log(`[TaskManager] task ${taskId}: MiniMax 한도 소진 → Claude(${acct.name}, ${modelName}) 폴백`);
     }
+
+    // 무한 재시도 금지(3.5): 공급자별/전체 상한 확인
+    const gate = checkpoint.canRetry(retryState, provider);
+    if (!gate.ok) {
+      const err = new Error(`재시도 상한 도달 — ${gate.reason}`);
+      console.error(`[TaskManager] task ${taskId}: ${err.message}`);
+      onError(err, fs.existsSync(resultFile) ? resultFile : null);
+      return null;
+    }
+    checkpoint.noteAttempt(retryState, provider);
+    attemptNo += 1;
+
     // tried 는 Claude 계정 로테이션 가드(tried.size < accounts.count())에만 쓰인다.
-    // MiniMax 는 별도 mmExhausted 플래그로 추적하므로 여기 섞으면 카운트가 어긋난다(오프바이원 방지).
-    if (acct.provider !== 'minimax') tried.add(acct.name);
-    // MiniMax 폴백은 claude CLI 기본 모델 선택을 안 타므로 --model 로 명시 지정한다.
-    const spawnArgs = acct.provider === 'minimax' ? [...args, '--model', acct.model] : args;
+    if (provider !== 'minimax') tried.add(acct.name);
+
+    const spawnArgs = provider === 'minimax'
+      ? [...args, '--model', modelName]
+      : [...args, '--model', modelName];
+
+    const executionPrompt = buildPrompt(attemptNo, resumeInstruction);
+    checkpoint.beginAttempt(baseDir, taskId, {
+      attempt: attemptNo, provider, model: modelName, taskClass,
+    });
+
+    const startedAt = Date.now();
     const proc = spawn('claude', spawnArgs, {
       cwd: baseDir,
       stdio: ['pipe', 'pipe', 'pipe'], // stdin 으로 프롬프트 전달(ENAMETOOLONG 회피)
@@ -511,26 +658,58 @@ ${progressBlock}
 
     proc.on('close', (code) => {
       const combinedOut = `${stdout}\n${stderr}`;
+      const usage = costTracker.parseUsageFromOutput(combinedOut);
+      try {
+        costTracker.record(COST_LOG_DIR, {
+          task_id: taskId,
+          phase: 'execute',
+          task_class: taskClass,
+          provider,
+          model: modelName,
+          attempt: attemptNo,
+          input_chars: executionPrompt.length,
+          output_chars: stdout.length,
+          context_chars: ctxRead.stats.chars,
+          context_files: ctxRead.filesRead.length,
+          skills_loaded: ctxRead.filesRead.filter(f => /\/skills\//.test(f.path)).length,
+          cache_hit: ctxRead.stats.cache_hits > 0 ? true : null,
+          duration_ms: Date.now() - startedAt,
+          status: code === 0 ? 'success' : 'failed',
+          fallback_from: fallbackFrom,
+          fast_path: fastPath,
+          prompt_version: prompts.PROMPT_VERSION,
+          context_selection: ctxRead.filesRead.map(f => ({ path: f.path, reason: f.reason })),
+          // checkpoint 로 이어서 재개한 시도인지 기록(재시도가 처음부터 다시 한 것인지 구분).
+          resumed: !!resumeInstruction,
+          ...(usage || {}),
+        });
+      } catch { /* 계측 실패가 태스크를 막지 않는다 */ }
 
-      // MiniMax(1순위) 실패 → 이번 태스크는 더 이상 MiniMax를 시도하지 않고 Claude 풀로 전환.
-      // 한도성 실패면 minimax 자체 쿨다운도 걸어(다음 태스크들도 그동안 Claude 사용), 원인 불명 실패는
-      // 쿨다운 없이(다음 태스크는 다시 MiniMax부터 시도) 이번만 Claude로 넘어간다.
-      if (code !== 0 && acct.provider === 'minimax') {
-        mmExhausted = true;
-        if (minimax.isUsageLimit(combinedOut)) minimax.noteUsageLimit();
-        console.log(`[TaskManager] task ${taskId}: MiniMax 실패 → Claude 폴백으로 전환`);
-        attempt();
-        return;
-      }
+      // ── 실패 시: checkpoint 저장 후 "이어서" 재개 ─────────────────────────
+      if (code !== 0) {
+        const cp = checkpoint.recordFailure(baseDir, taskId, {
+          attempt: attemptNo, provider, model: modelName, output: combinedOut, cwd: baseDir,
+        });
+        const nextResume = cp.resume_instruction || null;
 
-      // 사용량 한도로 실패 & 아직 안 쓴 계정이 남아 있으면 다음 계정으로 재실행
-      // 한도 메시지("You've hit your weekly limit ...")는 stderr가 아니라 stdout에
-      // 찍히는 경우가 있어(giip-759, PR #430) 두 스트림을 모두 확인한다.
-      if (code !== 0 && acct.provider !== 'minimax' && accounts.isUsageLimit(combinedOut) && tried.size < accounts.count()) {
-        accounts.noteUsageLimit(acct, combinedOut);
-        console.log(`[TaskManager] task ${taskId}: ${acct.name} usage limit → 다음 계정으로 재실행`);
-        attempt();
-        return;
+        // MiniMax(1순위) 실패 → 이번 태스크는 더 이상 MiniMax를 시도하지 않고 Claude 풀로 전환.
+        if (provider === 'minimax') {
+          mmExhausted = true;
+          if (minimax.isUsageLimit(combinedOut)) minimax.noteUsageLimit();
+          console.log(`[TaskManager] task ${taskId}: MiniMax 실패(${cp.error_type}) → Claude 폴백으로 전환${nextResume ? ' (checkpoint 이어서 재개)' : ''}`);
+          attempt(nextResume, 'minimax');
+          return;
+        }
+
+        // 사용량 한도로 실패 & 아직 안 쓴 계정이 남아 있으면 다음 계정으로 재실행
+        // 한도 메시지("You've hit your weekly limit ...")는 stderr가 아니라 stdout에
+        // 찍히는 경우가 있어(giip-759, PR #430) 두 스트림을 모두 확인한다.
+        if (accounts.isUsageLimit(combinedOut) && tried.size < accounts.count()) {
+          accounts.noteUsageLimit(acct, combinedOut);
+          console.log(`[TaskManager] task ${taskId}: ${acct.name} usage limit → 다음 계정으로 재실행${nextResume ? ' (checkpoint 이어서 재개)' : ''}`);
+          attempt(nextResume, `claude:${acct.name}`);
+          return;
+        }
       }
 
       // 결과 파일이 없으면 기본 파일 생성
@@ -544,6 +723,7 @@ ${progressBlock}
       }
 
       if (code === 0) {
+        checkpoint.recordSuccess(baseDir, taskId, { attempt: attemptNo, provider, model: modelName, cwd: baseDir });
         onComplete(resultFile);
       } else {
         onError(new Error(`claude exit ${code}: ${stderr.slice(0, 200)}`), resultFile);
@@ -554,7 +734,12 @@ ${progressBlock}
     return proc;
   }
 
-  return attempt();
+  // 이전 실행이 중단된 채 남아 있으면(재실행/이어하기) 그 checkpoint 로 시작한다.
+  const prior = checkpoint.load(baseDir, taskId);
+  const priorResume = prior && !prior.finished_at ? checkpoint.buildResumeInstruction(prior) : null;
+  if (priorResume) console.log(`[TaskManager] task ${taskId}: 이전 checkpoint 발견 → 완료된 단계부터 이어서 실행`);
+
+  return attempt(priorResume);
 }
 
 // ── 작업 완료: 결과를 태스크 파일에 추가 후 done/ 폴더로 이동 ─────────────────
@@ -1537,5 +1722,10 @@ module.exports = {
   getTaskFileUrl,
   buildContextCatalog,
   selectContextFiles,
+  readSelectedContext,
   normalizeFilesRead,
+  // giip-1063 비용 최적화
+  buildFastPathPlan,
+  upsertContextFilesFrontmatter,
+  stripModelArgs,
 };

--- a/slack-bot/tools/cost-report.js
+++ b/slack-bot/tools/cost-report.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+/**
+ * cost-report.js — 토큰·비용 리포트 CLI (giip-1063, 3.9)
+ *
+ * Slack 의 `!cost` 계열과 같은 백엔드(cost-tracker.js)를 쓴다.
+ *
+ * 사용법 (slack-bot/ 에서):
+ *   node tools/cost-report.js                # 전체
+ *   node tools/cost-report.js today          # 오늘
+ *   node tools/cost-report.js task giip-1063 # 특정 태스크
+ *   node tools/cost-report.js models         # 모델별
+ *   node tools/cost-report.js --json         # 집계 결과를 JSON 으로
+ *
+ * 로그 위치: <WORKSPACE_DIR>/.agent/runtime/cost-usage.jsonl
+ */
+
+const path = require('path');
+const costTracker = require('../cost-tracker');
+
+const BASE_DIR = process.env.WORKSPACE_DIR
+  ? path.resolve(process.env.WORKSPACE_DIR)
+  : path.join(__dirname, '..', '..');
+
+const argv = process.argv.slice(2);
+const jsonMode = argv.includes('--json');
+const arg = argv.filter(a => a !== '--json').join(' ');
+
+if (jsonMode) {
+  const opts = {};
+  if (/^today$/i.test(arg)) { const d = new Date(); d.setHours(0, 0, 0, 0); opts.since = d; }
+  const m = arg.match(/^task\s+(\S+)$/i);
+  if (m) opts.taskId = m[1];
+  console.log(JSON.stringify(costTracker.summarize(BASE_DIR, opts), null, 2));
+} else {
+  console.log(`로그: ${costTracker.logPath(BASE_DIR)}\n`);
+  console.log(costTracker.report(BASE_DIR, arg));
+}

--- a/slack-bot/tools/test-cost-optimization.js
+++ b/slack-bot/tools/test-cost-optimization.js
@@ -1,0 +1,572 @@
+#!/usr/bin/env node
+/**
+ * test-cost-optimization.js — giip-1063 비용 최적화 회귀 테스트
+ *
+ * 이 저장소에는 테스트 러너가 없어서 의존성 없는 순수 Node 스크립트로 만들었다.
+ *   node slack-bot/tools/test-cost-optimization.js
+ * 종료코드 0 = 전부 통과.
+ *
+ * 커버 범위 (이슈 "6. 테스트 요구사항" A~G 중 실제 모델 호출 없이 검증 가능한 부분)
+ *   A 단순 문구 수정      → trivial 분류 / Fast Path / 계획용 프리미엄 모델 미사용
+ *   B 일반 버그 수정      → standard 분류 / MiniMax 우선 / Sonnet급 fallback
+ *   C 인증 코드 수정      → critical 분류 / Fast Path 금지 / 프리미엄은 계획·검토에서만
+ *   D 사용량 제한         → 오류 분류 / checkpoint 생성 / 재개 지시문 / 재시도 상한
+ *   E 컨텍스트 제한       → 50개 이상 파일에서 최대 8개, 중복 제거, 전체 길이 한도, 사유 기록
+ *   F 기존 태스크 재실행  → context_files 왕복(신규 YAML + 구형 주석 하위 호환)
+ *   G 기존 기능 회귀      → 모든 모듈 로드, export 유지, 명령어 문자열 존재, 하드코딩 제거 확인
+ * 추가: 프롬프트 고정 prefix 순서 / 비용 로그 기록·집계 / 비밀값 마스킹 / 배치 처리
+ *
+ * 실제 모델을 호출하는 경로(A~D 의 "모델 1회 실행", G 의 Slack·PR 흐름)는 여기서 검증할 수
+ * 없다 — 라이브 확인이 필요하다.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const SB = path.join(__dirname, '..');
+const router = require(path.join(SB, 'model-router'));
+const modelConfig = require(path.join(SB, 'model-config'));
+const ctxBuilder = require(path.join(SB, 'context-builder'));
+const prompts = require(path.join(SB, 'prompt-templates'));
+const checkpoint = require(path.join(SB, 'retry-checkpoint'));
+const costTracker = require(path.join(SB, 'cost-tracker'));
+const batchPlanner = require(path.join(SB, 'batch-planner'));
+const { maskString, maskDeep } = require(path.join(SB, 'secret-mask'));
+
+let passed = 0;
+const failures = [];
+function test(name, fn) {
+  try { fn(); passed += 1; console.log(`  ok   ${name}`); }
+  catch (e) { failures.push({ name, e }); console.log(`  FAIL ${name}\n       ${e.message}`); }
+}
+function section(t) { console.log(`\n${t}`); }
+
+/**
+ * 마스킹 테스트용 "가짜" 토큰. 소스에 리터럴로 적으면 GitHub push protection 이
+ * 실제 시크릿으로 오탐해 push 가 막히므로 런타임에 조립한다. 전부 무효값이다.
+ */
+function fakeSecrets() {
+  const a = 'abcdefghijklmnop';
+  return {
+    slack: ['xo' + 'xb', '123456789012', a].join('-'),
+    anthropic: ['sk', 'a' + 'nt', a].join('-'),
+    minimax: ['sk', 'c' + 'p', a].join('-'),
+    github: 'g' + 'hp' + '_' + 'abcdefghijklmnopqrstuvwxyz012345',
+  };
+}
+
+function tmpdir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+// ── 테스트 A: 단순 문구 수정 ────────────────────────────────────────────────
+section('테스트 A: 단순 문구 수정 (trivial + Fast Path)');
+const A_REQ = 'README.md의 "Zero Tool Setup"을 "Minimal Tool Setup"으로 변경해줘.';
+
+test('trivial 로 분류된다', () => {
+  const c = router.classifyTask(A_REQ, [], '');
+  assert.strictEqual(c.class, 'trivial', `class=${c.class} reasons=${c.reasons.join('/')}`);
+  assert.ok(c.reasons.length, '분류 사유가 기록돼야 한다');
+});
+
+test('Fast Path 적용 대상이다 (경로 명시 + 1개 파일)', () => {
+  const c = router.classifyTask(A_REQ, [], '');
+  assert.ok(c.fastPathEligible, 'fastPathEligible 이어야 한다');
+  assert.deepStrictEqual(c.explicitPaths, ['README.md']);
+});
+
+test('계획 단계에 최상위(critical) 티어 모델을 쓰지 않는다', () => {
+  const sel = router.selectModel('trivial', 'plan');
+  assert.strictEqual(sel.premiumAllowed, false);
+  assert.notStrictEqual(sel.tier, 'critical');
+});
+
+test('Fast Path 계획은 모델 호출 없이 태스크 사양 형식을 만든다', () => {
+  const tm = require(path.join(SB, 'task-manager'));
+  const plan = tm.buildFastPathPlan(A_REQ, router.classifyTask(A_REQ, [], ''));
+  assert.ok(/^# TASK: /m.test(plan), 'TASK 제목이 있어야 한다');
+  assert.ok(/## 실행 계획/.test(plan) && /## 영향 파일/.test(plan));
+  assert.ok(/Fast Path/.test(plan), 'Fast Path 임을 명시해야 한다');
+  assert.strictEqual(tm.extractTitle(plan).length > 0, true);
+});
+
+test('Fast Path 프롬프트도 확인/검증/보고를 강제한다', () => {
+  const p = prompts.buildExecutionPrompt({ fastPath: true, taskContent: 'x' });
+  assert.ok(/변경 전 대상 파일을 반드시 먼저 읽어/.test(p));
+  assert.ok(/테스트 또는 재현 검증/.test(p));
+  assert.ok(/결과 보고서/.test(p));
+});
+
+// ── 테스트 B: 일반 버그 수정 ────────────────────────────────────────────────
+section('테스트 B: 일반 버그 수정 (standard)');
+const B_REQ = '로그인 후 대시보드에서 합계가 1 적게 나오는 계산 오류를 고쳐줘';
+
+test('DB/인증 변경이 없는 단일 수정은 standard 이상으로 분류된다', () => {
+  const c = router.classifyTask('대시보드 합계가 1 적게 나오는 계산 오류를 고쳐줘', [], '');
+  assert.ok(['standard', 'complex'].includes(c.class), `class=${c.class}`);
+  assert.strictEqual(c.fastPathEligible, false, 'Fast Path 대상이 아니어야 한다');
+});
+
+test('"로그인" 이 들어간 요청은 critical 로 승격된다(안전측)', () => {
+  const c = router.classifyTask(B_REQ, [], '');
+  assert.strictEqual(c.class, 'critical');
+});
+
+test('standard 실행은 MiniMax 우선, 없으면 Sonnet급 fallback', () => {
+  const withMM = router.selectModel('standard', 'execute', { minimax: true });
+  assert.strictEqual(withMM.provider, 'minimax');
+  const noMM = router.selectModel('standard', 'execute', { minimax: false });
+  assert.strictEqual(noMM.provider, 'claude');
+  assert.strictEqual(noMM.model, modelConfig.fallbackModelForTier('standard'));
+  assert.notStrictEqual(noMM.model, modelConfig.LEGACY_PREMIUM_MODEL);
+});
+
+// ── 테스트 C: 인증 코드 수정 ────────────────────────────────────────────────
+section('테스트 C: 인증 코드 수정 (critical)');
+const C_REQ = 'auth.js 의 세션 토큰 검증 로직을 고쳐서 권한 우회를 막아줘';
+
+test('최소 critical 로 분류된다', () => {
+  const c = router.classifyTask(C_REQ, [], '');
+  assert.strictEqual(c.class, 'critical');
+});
+
+test('critical 은 Fast Path 를 적용하지 않는다', () => {
+  const c = router.classifyTask(C_REQ, [], '');
+  assert.strictEqual(c.fastPathEligible, false);
+  assert.strictEqual(router.isFastPathEligible({ taskClass: 'critical', explicitPaths: ['a.js'] }), false);
+});
+
+test('critical 은 계획/검토에서만 프리미엄 모델을 허용한다', () => {
+  assert.strictEqual(router.selectModel('critical', 'plan').premiumAllowed, true);
+  assert.strictEqual(router.selectModel('critical', 'review').premiumAllowed, true);
+  assert.strictEqual(router.selectModel('critical', 'execute').premiumAllowed, false);
+  assert.strictEqual(router.selectModel('critical', 'classify').tier, 'trivial');
+});
+
+test('critical 이라도 실행 단계가 저가(trivial) 티어로 내려가지 않는다', () => {
+  const sel = router.selectModel('critical', 'execute', { minimax: true });
+  assert.strictEqual(sel.tier, 'complex');
+  assert.strictEqual(sel.fallback.model, modelConfig.fallbackModelForTier('critical'));
+});
+
+test('마이그레이션/배포 설정은 최소 complex 로 승격된다', () => {
+  assert.ok(['complex', 'critical'].includes(router.classifyTask('DB 스키마 마이그레이션 스크립트 추가', [], '').class));
+  assert.ok(['complex', 'critical'].includes(router.classifyTask('github actions workflow.yml 배포 설정 변경', [], '').class));
+});
+
+// ── 테스트 D: MiniMax 사용량 제한 → checkpoint 재개 ─────────────────────────
+section('테스트 D: 사용량 제한 → checkpoint 로 이어서 재개');
+const D_DIR = tmpdir('fde-cp-');
+
+test('사용량 제한 응답을 usage_limit 로 분류한다', () => {
+  assert.strictEqual(checkpoint.classifyError('HTTP 429 rate limit exceeded'), 'usage_limit');
+  assert.strictEqual(checkpoint.classifyError("You've hit your weekly limit"), 'usage_limit');
+  assert.strictEqual(checkpoint.classifyError('401 Unauthorized: invalid api key'), 'auth');
+  assert.strictEqual(checkpoint.classifyError('ETIMEDOUT'), 'timeout');
+});
+
+test('checkpoint 파일이 .agent/runtime/checkpoints 아래에 생성된다', () => {
+  checkpoint.beginAttempt(D_DIR, 'giip-1063', { attempt: 1, provider: 'minimax', model: 'MiniMax-M2.7', taskClass: 'standard' });
+  const p = checkpoint.checkpointPath(D_DIR, 'giip-1063');
+  assert.ok(fs.existsSync(p), `checkpoint 파일이 있어야 한다: ${p}`);
+  assert.ok(p.replace(/\\/g, '/').includes('.agent/runtime/checkpoints/'));
+});
+
+test('진행이 있었으면 "이어서 재개" 지시문을 만든다(전체 원문 재전송 아님)', () => {
+  const cp = checkpoint.save(D_DIR, 'giip-1063', {
+    files_changed: ['slack-bot/task-manager.js', 'slack-bot/model-router.js'],
+    completed_steps: ['컨텍스트 선별', '모델 라우터 구현'],
+    error_type: 'usage_limit',
+    error_summary: '429 rate limit',
+  });
+  const r = checkpoint.buildResumeInstruction(cp);
+  assert.ok(r, '재개 지시문이 있어야 한다');
+  assert.ok(r.includes('완료된 작업을 반복하지 마라'));
+  assert.ok(r.includes('미완료 단계부터 계속하라'));
+  assert.ok(r.includes('slack-bot/model-router.js'));
+});
+
+test('작업 시작 전 실패(변경 0건)면 재개 지시 없이 동일 프롬프트 재사용', () => {
+  const cp = { attempt: 1, files_changed: [], completed_steps: [] };
+  assert.strictEqual(checkpoint.buildResumeInstruction(cp), null);
+});
+
+test('checkpoint 에 비밀값을 저장하지 않는다', () => {
+  const FAKE = fakeSecrets();
+  const cp = checkpoint.save(D_DIR, 'giip-secret', {
+    error_summary: `failed with ANTHROPIC_API_KEY=${FAKE.anthropic} and ${FAKE.slack}`,
+    api_key: FAKE.minimax,
+  });
+  const raw = fs.readFileSync(checkpoint.checkpointPath(D_DIR, 'giip-secret'), 'utf8');
+  assert.ok(!raw.includes(FAKE.anthropic), 'anthropic key 가 남으면 안 된다');
+  assert.ok(!raw.includes(FAKE.slack), 'slack token 이 남으면 안 된다');
+  assert.ok(!raw.includes(FAKE.minimax), 'minimax key 가 남으면 안 된다');
+  assert.ok(/REDACTED/.test(raw));
+  assert.strictEqual(cp.api_key, '***REDACTED***');
+});
+
+test('무한 재시도를 막는다 (MAX_PROVIDER_RETRIES / MAX_TOTAL_ATTEMPTS)', () => {
+  const prevP = process.env.MAX_PROVIDER_RETRIES, prevT = process.env.MAX_TOTAL_ATTEMPTS;
+  process.env.MAX_PROVIDER_RETRIES = '1';
+  process.env.MAX_TOTAL_ATTEMPTS = '3';
+  const st = { totalAttempts: 0, providerAttempts: {} };
+  assert.strictEqual(checkpoint.canRetry(st, 'minimax').ok, true);
+  checkpoint.noteAttempt(st, 'minimax');
+  assert.strictEqual(checkpoint.canRetry(st, 'minimax').ok, true);   // 1회 재시도 허용
+  checkpoint.noteAttempt(st, 'minimax');
+  assert.strictEqual(checkpoint.canRetry(st, 'minimax').ok, false);  // 상한 도달
+  assert.strictEqual(checkpoint.canRetry(st, 'claude').ok, true);    // 다른 공급자는 별도 카운트
+  checkpoint.noteAttempt(st, 'claude');
+  assert.strictEqual(checkpoint.canRetry(st, 'claude').ok, false);   // 전체 3회 도달
+  if (prevP === undefined) delete process.env.MAX_PROVIDER_RETRIES; else process.env.MAX_PROVIDER_RETRIES = prevP;
+  if (prevT === undefined) delete process.env.MAX_TOTAL_ATTEMPTS; else process.env.MAX_TOTAL_ATTEMPTS = prevT;
+});
+
+// ── 테스트 E: 컨텍스트 제한 ─────────────────────────────────────────────────
+section('테스트 E: 컨텍스트 제한 (50개 이상 role/rule/skill)');
+const E_DIR = tmpdir('fde-ctx-');
+(function seedFakeProject() {
+  const mk = (p, c) => { fs.mkdirSync(path.dirname(p), { recursive: true }); fs.writeFileSync(p, c); };
+  for (let i = 0; i < 20; i++) {
+    mk(path.join(E_DIR, '.agent', 'roles', `role${i}.md`),
+      `---\nname: role${i}\ndescription: 역할 ${i} — deploy pipeline 담당\n---\n# Role ${i}\n${'본문 '.repeat(3000)}\n## 금지 사항\n이 섹션은 파일 끝에 있는 중요한 규칙이다 MARKER${i}\n`);
+  }
+  for (let i = 0; i < 20; i++) {
+    mk(path.join(E_DIR, '.agent', 'rules', `rule${i}.md`),
+      `---\nname: rule${i}\ndescription: 규칙 ${i} — deploy 관련 금지사항\n---\n# Rule ${i}\n내용\n`);
+  }
+  for (let i = 0; i < 15; i++) {
+    mk(path.join(E_DIR, '.agent', 'skills', `skill${i}`, 'SKILL.md'),
+      `---\nname: skill${i}\ndescription: 스킬 ${i}\ntrigger: deploy, 배포\n---\n# Skill ${i}\n${'스킬본문 '.repeat(2000)}\n`);
+  }
+  // 동일 내용 중복 파일(중복 제거 확인용)
+  mk(path.join(E_DIR, '.agent', 'rules', 'dup_a.md'), '---\nname: dup\ndescription: deploy 중복 규칙\n---\n# Dup\n동일내용\n');
+  mk(path.join(E_DIR, '.agent', 'rules', 'dup_b.md'), '---\nname: dup\ndescription: deploy 중복 규칙\n---\n# Dup\n동일내용\n');
+})();
+
+test('카탈로그가 50개 이상 만들어지고 본문이 아니라 메타만 담는다', () => {
+  const cat = ctxBuilder.buildContextCatalog(E_DIR, E_DIR);
+  assert.ok(cat.length >= 50, `catalog=${cat.length}`);
+  const text = ctxBuilder.formatCatalogForPrompt(cat);
+  assert.ok(!text.includes('본문 본문'), '카탈로그에 파일 본문이 들어가면 안 된다');
+  assert.ok(text.includes('trigger: deploy'), 'skill 의 trigger 는 노출돼야 한다');
+});
+
+test('정적 선별은 기본 최대 6개를 넘지 않는다', () => {
+  const cat = ctxBuilder.buildContextCatalog(E_DIR, E_DIR);
+  const sel = ctxBuilder.selectContextFilesStatic('deploy 배포 설정 확인', cat);
+  assert.ok(sel.length > 0 && sel.length <= modelConfig.contextLimits().defaultMaxFiles, `selected=${sel.length}`);
+  assert.ok(sel.every(s => s.reason), '선택 이유가 기록돼야 한다');
+});
+
+test('최대 8개 / 전체 48,000자 한도를 지키고 중복을 제거한다', () => {
+  const cat = ctxBuilder.buildContextCatalog(E_DIR, E_DIR);
+  const many = cat.slice(0, 30).map(c => ({ path: c.path, reason: 'test' }));
+  const r = ctxBuilder.readSelectedContext(many, E_DIR, { queryText: 'deploy' });
+  const lim = modelConfig.contextLimits();
+  assert.ok(r.filesRead.length <= lim.hardMaxFiles, `files=${r.filesRead.length}`);
+  assert.ok(r.stats.chars <= lim.totalMaxChars, `chars=${r.stats.chars}`);
+  assert.ok(r.filesRead.every(f => f.chars <= lim.perFileMaxChars), '파일별 한도 초과');
+  const paths = r.filesRead.map(f => f.path);
+  assert.strictEqual(new Set(paths).size, paths.length, '같은 파일이 두 번 들어가면 안 된다');
+});
+
+test('내용이 같은 두 파일은 한 번만 포함된다', () => {
+  const r = ctxBuilder.readSelectedContext(
+    [{ path: '.agent/rules/dup_a.md', reason: 'a' }, { path: '.agent/rules/dup_b.md', reason: 'b' }],
+    E_DIR, { queryText: 'dup' });
+  assert.strictEqual(r.filesRead.length, 1, `files=${r.filesRead.length}`);
+});
+
+test('앞부분만 자르지 않고 제목 기준으로 관련 섹션을 보존한다', () => {
+  const r = ctxBuilder.readSelectedContext(
+    [{ path: '.agent/roles/role0.md', reason: 'test', max_chars: 2000 }], E_DIR, { queryText: '금지 MARKER0' });
+  assert.strictEqual(r.filesRead.length, 1);
+  assert.ok(r.context.includes('MARKER0'), '파일 끝의 중요한 규칙이 살아남아야 한다(slice(0,800) 회귀)');
+  assert.ok(r.filesRead[0].condensed, '축약 표시가 있어야 한다');
+});
+
+test('선택 결과가 없으면 최소 기본 컨텍스트만 쓴다(전체 roles 재로딩 금지)', () => {
+  const repoRoot = path.join(SB, '..');
+  const min = ctxBuilder.minimalDefaultContext(repoRoot, repoRoot);
+  assert.ok(min.length <= 2, `minimal=${min.length}`);
+  assert.ok(min.every(m => m.path.startsWith('.agent/rules/')), '최소 컨텍스트는 rule 몇 개뿐이어야 한다');
+});
+
+test('mtime/hash 캐시로 같은 파일을 재파싱하지 않는다', () => {
+  ctxBuilder.resetCaches();
+  const p = path.join(E_DIR, '.agent', 'rules', 'rule0.md');
+  const first = ctxBuilder.getBody(p);
+  const second = ctxBuilder.getBody(p);
+  assert.strictEqual(first.cached, false);
+  assert.strictEqual(second.cached, true);
+  assert.strictEqual(first.hash, second.hash);
+});
+
+// ── 테스트 F: 태스크 메타데이터 왕복 ────────────────────────────────────────
+section('테스트 F: 태스크 메타데이터 (신규 YAML + 구형 주석 하위 호환)');
+
+test('context_files YAML 을 쓰고 다시 읽을 수 있다', () => {
+  const files = [
+    { path: '.agent/roles/developer.md', reason: '소스 수정 및 테스트 수행', max_chars: 4000 },
+    { path: '.agent/rules/10_karpathy_guidelines.md', reason: '요청 범위 밖의 수정 방지', max_chars: 3000 },
+  ];
+  const yaml = ctxBuilder.formatContextFilesYaml(files);
+  const doc = `---\ntask_id: giip-1063\nstatus: pending\n${yaml}\n---\n\n# TASK: x\n`;
+  const back = ctxBuilder.parseContextFiles(doc);
+  assert.strictEqual(back.length, 2);
+  assert.strictEqual(back[0].path, '.agent/roles/developer.md');
+  assert.strictEqual(back[0].reason, '소스 수정 및 테스트 수행');
+  assert.strictEqual(back[1].max_chars, 3000);
+});
+
+test('구형 주석 형식 태스크 파일도 읽힌다(하위 호환)', () => {
+  const legacy = [
+    '---',
+    'task_id: 20260101000000',
+    'status: pending',
+    '# 분석에 로드된 컨텍스트 파일 (role/rule/skill — 경로 — 로드 사유):',
+    '#   - .agent/roles/developer.md — 소스 수정',
+    '#   - .agent/rules/09_investment_safety.md — 안전 확인',
+    '---',
+    '',
+    '# TASK: legacy',
+  ].join('\n');
+  const back = ctxBuilder.parseContextFiles(legacy);
+  assert.strictEqual(back.length, 2);
+  assert.strictEqual(back[0].path, '.agent/roles/developer.md');
+});
+
+test('기존 태스크 파일 갱신 시 context_files 가 최신으로 교체된다', () => {
+  const tm = require(path.join(SB, 'task-manager'));
+  const old = `---\ntask_id: giip-1\nstatus: pending\ntask_class: standard\n${ctxBuilder.formatContextFilesYaml([{ path: 'a.md', reason: 'old' }])}\n---\n\n# TASK: t\n`;
+  const next = tm.upsertContextFilesFrontmatter(old, [{ path: 'b.md', reason: 'new', max_chars: 4000 }], { taskClass: 'complex' });
+  const back = ctxBuilder.parseContextFiles(next);
+  assert.strictEqual(back.length, 1);
+  assert.strictEqual(back[0].path, 'b.md');
+  assert.ok(/task_class: complex/.test(next));
+});
+
+// ── 프롬프트 고정 prefix ────────────────────────────────────────────────────
+section('프롬프트 고정 prefix 안정화 (3.6)');
+
+test('태스크가 달라도 prefix(역할/안전규칙/실행프로토콜)가 동일하다', () => {
+  const mk = (over) => prompts.buildExecutionPrompt(Object.assign({
+    contextText: 'CTX', projectName: 'p', baseDir: '/a', taskContent: 'T1',
+    taskId: 't1', branch: 'b1', attempt: 1, now: '2026-01-01T00:00:00Z',
+  }, over));
+  const a = mk({});
+  const b = mk({ taskContent: 'T2', taskId: 't2', branch: 'b2', attempt: 3, now: '2026-02-02T00:00:00Z' });
+  const prefixLen = a.indexOf('=== 선택된 컨텍스트');
+  assert.ok(prefixLen > 200, 'prefix 를 찾지 못했다');
+  assert.strictEqual(a.slice(0, prefixLen), b.slice(0, prefixLen), '고정 prefix 가 달라졌다');
+});
+
+test('동적 값(시각/taskID/브랜치/재시도)은 프롬프트 뒤쪽에만 나온다', () => {
+  const p = prompts.buildExecutionPrompt({
+    contextText: 'CTX', projectName: 'proj', baseDir: '/a', taskContent: 'TASK BODY',
+    taskId: 'giip-1063', branch: 'bot/task-giip-1063', attempt: 2, now: '2026-08-13T00:00:00Z',
+  });
+  const dynIdx = p.indexOf('=== 동적 상태 ===');
+  assert.ok(dynIdx > 0);
+  for (const needle of ['giip-1063', 'bot/task-giip-1063', '2026-08-13T00:00:00Z', 'attempt: 2']) {
+    assert.ok(p.indexOf(needle) > dynIdx, `${needle} 가 동적 상태 절보다 앞에 있다`);
+  }
+});
+
+test('프롬프트 버전이 기록된다', () => {
+  assert.strictEqual(prompts.PROMPT_VERSION, 'fde-cost-v1');
+  assert.ok(prompts.buildExecutionPrompt({ taskContent: 'x' }).includes('prompt_version: fde-cost-v1'));
+  assert.ok(prompts.buildAnalysisPrompt({ requestText: 'x' }).includes('prompt_version: fde-cost-v1'));
+});
+
+test('재개 지시문은 checkpoint 절(맨 뒤)에만 들어간다', () => {
+  const p = prompts.buildExecutionPrompt({ taskContent: 'x', resumeInstruction: 'RESUME-MARK' });
+  assert.ok(p.indexOf('RESUME-MARK') > p.indexOf('=== 동적 상태 ==='));
+});
+
+// ── 비용 계측 ───────────────────────────────────────────────────────────────
+section('토큰·비용 계측 (3.9)');
+const F_DIR = tmpdir('fde-cost-');
+
+test('JSON Lines 로 .agent/runtime/cost-usage.jsonl 에 기록된다', () => {
+  costTracker.record(F_DIR, {
+    task_id: 'giip-1063', phase: 'execute', task_class: 'standard', provider: 'minimax',
+    model: 'MiniMax-M2.7', attempt: 1, input_chars: 4000, output_chars: 400,
+    context_chars: 11800, context_files: 4, skills_loaded: 1, duration_ms: 1200, status: 'success',
+  });
+  const p = costTracker.logPath(F_DIR);
+  assert.ok(fs.existsSync(p));
+  assert.ok(p.replace(/\\/g, '/').endsWith('.agent/runtime/cost-usage.jsonl'));
+  const row = JSON.parse(fs.readFileSync(p, 'utf8').trim().split('\n')[0]);
+  assert.strictEqual(row.estimated, true, '토큰 미제공 시 추정값 표시');
+  assert.strictEqual(row.input_tokens, 1000);
+  assert.strictEqual(row.estimated_cost_usd, null, '단가 미설정 모델은 비용을 지어내지 않는다');
+});
+
+test('CLI 가 토큰을 알려주면 실제값 + estimated:false', () => {
+  const u = costTracker.parseUsageFromOutput('{"usage":{"input_tokens":3200,"output_tokens":700}}');
+  assert.deepStrictEqual(u, { input_tokens: 3200, output_tokens: 700, estimated: false });
+  costTracker.record(F_DIR, { task_id: 'giip-1063', phase: 'plan', provider: 'claude', model: 'sonnet', ...u });
+  const rows = costTracker.readAll(F_DIR);
+  assert.strictEqual(rows[rows.length - 1].estimated, false);
+});
+
+test('집계는 fallback/재시도 중복 토큰/등급별 평균을 낸다', () => {
+  costTracker.record(F_DIR, {
+    task_id: 'giip-1063', phase: 'execute', task_class: 'standard', provider: 'claude',
+    model: 'sonnet', attempt: 2, input_chars: 8000, output_chars: 100, fallback_from: 'minimax', status: 'success',
+  });
+  const sum = costTracker.summarize(F_DIR);
+  assert.strictEqual(sum.calls, 3);
+  assert.strictEqual(sum.fallbacks, 1);
+  assert.ok(sum.retry_duplicate_input_tokens > 0, "재시도 중복 토큰이 집계돼야 한다");
+  assert.strictEqual(sum.retries, 1);
+  assert.ok(sum.by_class.standard, '작업 등급별 집계가 있어야 한다');
+  assert.strictEqual(sum.estimated_cost_usd, null, '단가 미설정이면 비용은 측정 불가');
+  const text = costTracker.report(F_DIR, '');
+  assert.ok(text.includes('총 호출 수'));
+  assert.ok(text.includes('측정 불가'), '지어낸 비용 대신 측정 불가로 표기해야 한다');
+});
+
+test('비용 로그에도 비밀값을 남기지 않는다', () => {
+  const FAKE = fakeSecrets();
+  costTracker.record(F_DIR, {
+    task_id: 'leak', phase: 'qa', provider: 'claude', model: 'sonnet',
+    context_selection: [{ path: 'a', reason: `token is ${FAKE.slack}` }],
+  });
+  const raw = fs.readFileSync(costTracker.logPath(F_DIR), 'utf8');
+  assert.ok(!raw.includes(FAKE.slack));
+});
+
+test('가격 파일은 기준일/출처 없이 값을 만들지 않는다', () => {
+  const pricing = modelConfig.loadPricing();
+  assert.ok(pricing && typeof pricing.models === 'object');
+  const r = modelConfig.estimateCostUsd('nonexistent-model', 1000, 1000);
+  assert.strictEqual(r.cost, null);
+});
+
+// ── 마스킹 ──────────────────────────────────────────────────────────────────
+section('비밀값 마스킹 (안전 요구사항 7~9)');
+
+test('알려진 토큰 형식을 마스킹한다', () => {
+  const FAKE = fakeSecrets();
+  const s = maskString([
+    `SLACK_BOT_TOKEN=${FAKE.slack}`,
+    `MINIMAX_API_KEY=${FAKE.minimax}`,
+    `GITHUB_TOKEN=${FAKE.github}`,
+    'Authorization: Bearer abcdefghijklmnopqrstu',
+  ].join('\n'));
+  assert.ok(!s.includes(FAKE.slack));
+  assert.ok(!s.includes(FAKE.minimax));
+  assert.ok(!s.includes(FAKE.github));
+  assert.ok(!/Bearer abcdefghijklmnopqrstu/.test(s));
+});
+
+test('민감한 키 이름의 값은 통째로 지운다', () => {
+  const o = maskDeep({ nested: { apiKey: 'plain-value', ok: 'keep-me' } });
+  assert.strictEqual(o.nested.apiKey, '***REDACTED***');
+  assert.strictEqual(o.nested.ok, 'keep-me');
+});
+
+// ── 배치 처리 ───────────────────────────────────────────────────────────────
+section('배치 처리 (3.8)');
+
+test('한 메시지의 독립 조회 여러 건을 한 번에 묶는다', () => {
+  const p = batchPlanner.planBatch([
+    '1. config.js 파일 있는지 확인해줘',
+    '2. handlers.js 있는지 확인해줘',
+    '3. task-manager.js 있는지 확인해줘',
+  ].join('\n'));
+  assert.strictEqual(p.batchable, true);
+  assert.strictEqual(p.batch_size, 3);
+  assert.strictEqual(p.model_calls_saved, 2);
+  assert.ok(p.instruction.includes('배치 처리 지시'));
+});
+
+test('변경 작업이 섞이면 배치하지 않는다', () => {
+  const p = batchPlanner.planBatch('1. 설정값 확인해줘\n2. config.js 를 수정해줘');
+  assert.strictEqual(p.batchable, false);
+});
+
+test('종속 표현이 있으면 배치하지 않는다', () => {
+  const p = batchPlanner.planBatch('1. 로그 확인해줘\n2. 그 결과로 어떤 파일이 문제인지 알려줘');
+  assert.strictEqual(p.batchable, false);
+});
+
+test('단일 요청은 배치 대상이 아니다', () => {
+  assert.strictEqual(batchPlanner.planBatch('이 파일 뭐하는거야?').batchable, false);
+});
+
+// ── 테스트 G: 기존 기능 회귀 ────────────────────────────────────────────────
+section('테스트 G: 기존 기능 회귀 (정적 검증)');
+
+test('모든 slack-bot 모듈이 로드된다', () => {
+  for (const m of ['config', 'task-manager', 'claude-cli', 'handlers', 'intent', 'giip-commands',
+                   'giip-task', 'giip-api', 'dashboard', 'task-dedup', 'repo-lock', 'repo-status',
+                   'k-layer', 'state', 'slack-api', 'minimax-accounts', 'claude-accounts',
+                   'model-config', 'model-router', 'context-builder', 'prompt-templates',
+                   'retry-checkpoint', 'cost-tracker', 'batch-planner', 'secret-mask']) {
+    require(path.join(SB, m));
+  }
+});
+
+test('task-manager 의 기존 export 가 그대로 남아 있다', () => {
+  const tm = require(path.join(SB, 'task-manager'));
+  for (const fn of ['analyzeRequest', 'createTaskFile', 'updateTaskFile', 'rebuildTaskFileFromIssue',
+                    'startExecution', 'completeTaskFile', 'gitPushResultAndPR', 'prepareTaskBranch',
+                    'restoreTaskBranch', 'commitAndPRChangedRepos', 'addToTasklist', 'cancelTaskFile',
+                    'buildContextCatalog', 'selectContextFiles', 'normalizeFilesRead', 'extractTitle']) {
+    assert.strictEqual(typeof tm[fn], 'function', `${fn} export 가 사라졌다`);
+  }
+});
+
+test('실행 단계에서 전체 roles 를 재로딩하지 않는다', () => {
+  const src = fs.readFileSync(path.join(SB, 'task-manager.js'), 'utf8');
+  assert.ok(!/^\s*(const|let)\s+rolesContext\s*=\s*readRolesContext\(/m.test(src), 'readRolesContext 호출이 남아 있다');
+  assert.ok(!/function readRolesContext/.test(src), 'readRolesContext 정의가 남아 있다');
+});
+
+test('모델명이 코드에 하드코딩돼 있지 않다(중앙 설정만)', () => {
+  for (const f of ['task-manager.js', 'claude-cli.js', 'intent.js', 'handlers.js']) {
+    const src = fs.readFileSync(path.join(SB, f), 'utf8');
+    const hits = src.split('\n').filter(l => /['"]claude-opus-4-8['"]/.test(l));
+    assert.strictEqual(hits.length, 0, `${f} 에 모델명 하드코딩이 남아 있다: ${hits.join(' | ')}`);
+  }
+  // 유일한 정의 위치
+  const mc = fs.readFileSync(path.join(SB, 'model-config.js'), 'utf8');
+  assert.ok(/LEGACY_PREMIUM_MODEL = 'claude-opus-4-8'/.test(mc));
+});
+
+test('Slack 명령/흐름 문자열이 유지된다 (go / cancel / tasklist / PR)', () => {
+  const h = fs.readFileSync(path.join(SB, 'handlers.js'), 'utf8');
+  for (const needle of ["cmd === 'tasklist'", '!issues', '!klayer', '!cost', 'startExecution', 'commitAndPRChangedRepos']) {
+    assert.ok(h.includes(needle), `${needle} 가 사라졌다`);
+  }
+  const i = fs.readFileSync(path.join(SB, 'index.js'), 'utf8');
+  assert.ok(/go\b/.test(i) || /go /.test(h), 'go 명령 경로가 사라졌다');
+});
+
+test('MiniMax 우선 → Claude fallback 구조가 유지된다', () => {
+  const src = fs.readFileSync(path.join(SB, 'task-manager.js'), 'utf8');
+  assert.ok(/minimax\.resolve\(\)/.test(src));
+  assert.ok(/minimax\.noteUsageLimit\(\)/.test(src));
+  assert.ok(/accounts\.isUsageLimit\(/.test(src));
+  assert.ok(/accounts\.noteUsageLimit\(/.test(src));
+});
+
+test('런타임 산출물이 .gitignore 대상이다', () => {
+  const gi = fs.readFileSync(path.join(SB, '..', '.gitignore'), 'utf8');
+  assert.ok(/^\.agent\/runtime\/$/m.test(gi), '.agent/runtime/ 이 .gitignore 에 없다');
+});
+
+// ── 결과 ────────────────────────────────────────────────────────────────────
+console.log(`\n${'─'.repeat(60)}`);
+console.log(`통과 ${passed} / 실패 ${failures.length}`);
+if (failures.length) {
+  for (const f of failures) console.error(`\n✗ ${f.name}\n${f.e.stack}`);
+  process.exit(1);
+}
+console.log('전부 통과.');


### PR DESCRIPTION
# GIIP FDE Agent 비용 최적화 완료 보고서

giip issue **#1063** — GIIP FDE Agent AI 토큰·모델 비용 최적화

## 1. 변경 요약

작은 작업에도 `.agent/roles` 전량과 최상위 모델(`claude-opus-4-8`)이 쓰이던 구조를, **작업 등급(trivial/standard/complex/critical) 기반 라우팅**으로 바꿨다.

- 실행 단계의 무조건적 `readRolesContext()` 삭제 → 분석 때 고른 `context_files` 만 재로딩
- 모델명 하드코딩 제거 → `model-config.js` + 환경변수 중앙 관리
- trivial + 대상 경로 명시 요청은 **Fast Path**: 컨텍스트선별·계획 모델 호출 0회, 실행 1회
- 실패 시 **checkpoint** 저장 후 이어서 재개(전체 재실행 방지), 재시도 상한 도입
- 프롬프트 고정 prefix 순서 확정 + `prompt_version: fde-cost-v1`
- 호출마다 토큰·컨텍스트·재시도·fallback 을 `.agent/runtime/cost-usage.jsonl` 에 기록, `!cost` / CLI 리포트

기존 Slack DM/멘션, `go`/`cancel`, giip issue 연동, 브랜치·commit·push·PR 자동 생성, K-Layer, 계정 쿨다운, MiniMax→Claude fallback 흐름은 그대로 유지했다. 환경변수를 하나도 설정하지 않아도 동작한다.

## 2. 변경 파일

### 신규

| 파일 | 내용 | 이유 |
|---|---|---|
| `slack-bot/model-config.js` | 티어별 모델명 해석(`MODEL_TRIVIAL` 등), 재시도·컨텍스트 한도, 가격표 로딩 | 모델명이 코드 곳곳에 흩어져 "전부 최상위 모델"이 되던 문제 |
| `slack-bot/model-pricing.json` | 단가 설정 파일(`as_of`/`source` 필수, 기본은 비어 있음) | 가격을 코드에 산재시키지 않기 위해. 구독제라 종량 단가를 임의로 지어내지 않음 |
| `slack-bot/model-router.js` | `classifyTask()` / `selectModel()` / `escalateOnFailure()` / `isFastPathEligible()` | 작업 난이도 분류와 단계별 모델 선택 |
| `slack-bot/context-builder.js` | 헤드만 읽는 카탈로그, 정적 선별, 한도·중복제거·제목 기반 축약, mtime+hash 캐시, `context_files` YAML 직렬화 | 3.1 / 3.7 |
| `slack-bot/prompt-templates.js` | 고정 prefix 조립, `PROMPT_VERSION` | 3.6 프롬프트 캐시 적중률 |
| `slack-bot/retry-checkpoint.js` | checkpoint 저장/로드, 오류 분류, 재개 지시문, 재시도 상한 | 3.5 |
| `slack-bot/cost-tracker.js` | JSONL 기록 + 집계 + 리포트 | 3.9 |
| `slack-bot/batch-planner.js` | 한 메시지 안의 독립 조회 배치 | 3.8 |
| `slack-bot/secret-mask.js` | 저장 전 비밀값 마스킹 | 안전 요구사항 7~9 |
| `slack-bot/tools/cost-report.js` | `!cost` 와 같은 백엔드의 CLI 리포트 | 3.9 (Slack 연결과 분리) |
| `slack-bot/tools/test-cost-optimization.js` | 의존성 없는 회귀 테스트 51건 | 6. 테스트 요구사항 |

### 수정

| 파일 | 변경 내용 |
|---|---|
| `slack-bot/task-manager.js` | `readRolesContext()` 삭제 · `runClaude()` 에 등급/단계 라우팅 + 계측 · `analyzeRequest()` 에 Fast Path/분류/한도 · `createTaskFile`/`updateTaskFile` 에 `context_files`·`task_class` frontmatter · `startExecution()` 이 선택 컨텍스트만 로딩 + prompt-templates + checkpoint 재개 + 재시도 상한 |
| `slack-bot/claude-cli.js` | Q&A 의 `claude-opus-4-8` 하드코딩 → `MODEL_QA`; 배치 지시 주입; 비용 기록 |
| `slack-bot/intent.js` | task/question 분류의 `claude-opus-4-8` → `MODEL_CLASSIFIER` |
| `slack-bot/handlers.js` | 분류 결과를 태스크 파일에 전달, 분석 완료 메시지에 등급·컨텍스트량 표시, `!cost` 명령(DM/채널) + 도움말, Q&A 에 `userText` 전달 |
| `slack-bot/.env.example` | 모델 라우팅/재시도/컨텍스트 한도 환경변수 문서화 |
| `.gitignore` | `.agent/runtime/` 제외 |

## 3. 모델 라우팅 정책

| 작업 등급 | 계획 모델 | 실행 모델 | fallback | 최상위 모델 허용 조건 |
|---|---|---|---|---|
| `trivial` | **없음(Fast Path)** | `MODEL_TRIVIAL` (기본 `minimax-default`) | `MODEL_FALLBACK_STANDARD` (기본 `sonnet`) | 허용 안 함 |
| `standard` | `MODEL_PLANNER` (기본 `minimax-default`) | `MODEL_STANDARD` (기본 `minimax-default`) | `MODEL_FALLBACK_STANDARD` | 허용 안 함 |
| `complex` | `MODEL_COMPLEX` (기본 `sonnet`) | `MODEL_COMPLEX` | `MODEL_FALLBACK_STANDARD` | 2회 이상 실패 시 승격(`escalateOnFailure`) |
| `critical` | `MODEL_CRITICAL` (기본 `claude-opus-4-8`) | `MODEL_COMPLEX` (중간급) | `MODEL_FALLBACK_CRITICAL` | 계획·최종검토 단계만. 실행/탐색은 중간급 |
| (분류·컨텍스트 선별) | — | 항상 최저 티어 | — | **어떤 등급이어도 금지** |

- `minimax-default` = MiniMax 공급자를 `MINIMAX_MODEL` 로 사용. 미설정/쿨다운이면 그 티어의 Claude fallback 으로 내려간다 → 기존 "MiniMax 우선 → Claude 폴백" 유지.
- 공급자 라우팅(MiniMax/Claude) · 계정 라우팅(Claude 계정 분산) · 모델 라우팅(티어) · 작업 라우팅(등급)을 코드상 분리했다.
- **행동 변화 주의**: `complex`/`critical` 의 계획 호출은 이제 MiniMax 를 건너뛰고 Claude 중간급으로 간다(이슈 3.3 정책). 예전 동작으로 되돌리려면 `MODEL_COMPLEX=minimax-default`.

## 4. 컨텍스트 최적화 결과

이 저장소(`.agent/roles` 23개, `rules` 39개, `skills` 다수) 기준 실측. 모델 호출은 스텁으로 대체하고 프롬프트만 캡처했다.

| 테스트 | 변경 전 로딩량 | 변경 후 로딩량 | 절감률 |
|---|---:|---:|---:|
| 실행 프롬프트 자동 컨텍스트 — trivial (테스트 A) | 19,069자 (roles 23개 전량) | 1,446자 (1개 파일) | **92.4%** |
| 실행 프롬프트 자동 컨텍스트 — standard (테스트 B) | 19,069자 | 4,013자 (2개 파일) | **79.0%** |
| 컨텍스트 선별 호출 프롬프트 | 16,732자 (카탈로그 전량) | 2,691자 (상위 30개) | **83.9%** |

- "변경 전"은 `readRolesContext()` 가 `.agent/roles/*.md` 각 800자씩 넣던 양을 같은 저장소에서 재계산한 값이다.
- 전체 자동 컨텍스트는 48,000자(파일당 4,000자, 최대 8개) 한도 안에서 동작하며, 실측 두 사례 모두 이슈의 권장 범위(3,000~8,000토큰 ≈ 12,000~32,000자) 안에 들어온다.
- 앞부분만 자르던 `content.slice(0, 800)` 대신 제목 기준으로 관련 섹션을 남긴다(테스트로 파일 끝의 "금지 사항" 섹션이 살아남는 것을 검증).

## 5. 호출 비용 비교

| 테스트 | 변경 전 호출 수 | 변경 후 호출 수 | 입력 토큰 절감률 | 예상 비용 절감률 |
|---|---:|---:|---:|---:|
| A 단순 문구 수정 (trivial) | 3 (선별+계획+실행) | **1** (실행만) | 실행 프롬프트 컨텍스트 기준 92.4% | **측정 불가** |
| B 일반 버그 수정 (standard) | 3 | 3 | 실행 79.0% / 선별 83.9% | **측정 불가** |
| C 인증 코드 수정 (critical) | 3 (전부 opus) | 3 (계획·검토만 opus, 실행은 중간급) | 미측정 | **측정 불가** |

- **비용(USD) 절감률은 "측정 불가"** 다. 이 봇은 Claude 구독 계정 + MiniMax Token Plan(정액제)으로 동작해 종량제 단가가 그대로 적용되지 않는다. 이슈 5-5("모델명이나 가격을 근거 없이 추정하지 마라")에 따라 `model-pricing.json` 은 비워 두었고, 단가가 없으면 `estimated_cost_usd: null` 로 **토큰 수만** 기록한다. 운영자가 실제 단가를 채우면 그때부터 비용이 집계된다.
- 토큰 수치는 CLI 가 사용량을 제공하지 않을 때 문자 수 기반 추정치이며 `estimated: true` 로 표시된다.

## 6. 재시도 테스트 결과

MiniMax 사용량 제한(HTTP 429)을 모킹한 실측:

```
#1 model=MiniMax-M2.7 prompt=6,146자 resume=false
   → [minimax-accounts] usage limit 감지 → cooldown 60분
   → checkpoint 생성 (error_type=usage_limit, files_changed=19)
#2 model=sonnet        prompt=7,297자 resume=true  "완료된 작업을 반복하지 마라" 포함
cost 로그: 2행, fallback 1회, 재시도 재전송 입력 토큰 1,825
```

- MiniMax 쿨다운 적용 → checkpoint 생성 → Claude(sonnet) 폴백 → **재개 지시문과 함께 이어서 실행**(처음부터 재실행 아님).
- 진행이 0건이면(작업 시작 전 실패) 재개 지시 없이 동일 프롬프트를 재사용한다.
- `MAX_PROVIDER_RETRIES=1` / `MAX_TOTAL_ATTEMPTS=3` 상한을 넘으면 재시도를 중단하고 `onError` 로 끝낸다(무한 재시도 금지).
- checkpoint 에 Slack/Anthropic/MiniMax/GitHub 토큰 형태를 넣어도 저장 전 마스킹되는 것을 테스트로 확인.

## 7. 기존 기능 회귀 테스트 결과

`node slack-bot/tools/test-cost-optimization.js` → **51건 전부 통과** (의존성 없음).

정적/단위 검증으로 확인한 것:
- slack-bot 25개 모듈 전부 로드, `task-manager` 기존 export 16개 유지
- `readRolesContext` 호출·정의 부재, 4개 파일에 모델명 하드코딩 부재
- `go`/`cancel`/`tasklist`/`!issues`/`!klayer`/`!cost`/`startExecution`/`commitAndPRChangedRepos` 문자열 유지
- MiniMax 우선 → Claude fallback + 계정 쿨다운 구조 유지
- 구형 태스크 파일(주석 형식 `filesRead`)도 계속 읽힘, 신규는 `context_files` YAML
- `.agent/runtime/` 이 `.gitignore` 대상

**라이브 검증 필요(이번에 확인 못 함)**: 실제 Slack 이벤트 수신, 실제 모델 호출로의 `go` → 브랜치 → commit → push → PR 생성 전 과정, giip issue 상태 전이. 이 경로들은 봇 프로세스와 Slack 워크스페이스가 필요해 여기서 재현할 수 없었다.

## 8. 남은 문제 및 후속 작업

1. **가격표 미기입** — `model-pricing.json` 이 비어 있어 비용(USD) 집계가 되지 않는다. 실제 단가를 확인하면 `as_of`/`source` 와 함께 채워야 `!cost` 의 비용 항목이 산출된다.
2. **토큰 실측 불가** — `claude -p` 기본 출력이 사용량을 싣지 않아 대부분 문자 수 추정치다. `--output-format json` 채택 시 `cost-tracker.parseUsageFromOutput()` 이 실제값을 잡도록 이미 대비돼 있다.
3. **분류기 LLM 보조 경로 미연결** — `classifyTask(..., {llm})` 훅은 구현했지만 현재 호출부는 정적 규칙만 쓴다(호출 1회를 아끼는 쪽을 택함). 오분류가 관측되면 저비용 티어로 연결하면 된다.
4. **`.agent/lib/skill-orchestrator.js` 등은 손대지 않았다** — 확인 결과 slack-bot 실행 경로에서 쓰이지 않고 `.agent/hooks/session-start.js`·`.agent/scripts/` 전용이라, 이번 비용 문제와 무관해 범위 밖으로 두었다.
5. **라이브 회귀 확인** — 위 7절의 "라이브 검증 필요" 항목을 실제 봇에서 한 번 돌려봐야 완료로 볼 수 있다. 머지 전 확인을 권장한다.
6. **`complex`/`critical` 계획이 MiniMax 를 건너뛰는 정책 변화** — 이슈 3.3 을 그대로 따른 결과다. MiniMax 잔여 쿼터를 더 태우고 싶으면 `MODEL_COMPLEX=minimax-default` 로 되돌릴 수 있다.

---

## 완료 조건 체크리스트 (이슈 7절)

- [x] 실행 단계의 무조건적인 `readRolesContext()` 사용 제거
- [x] 선택된 컨텍스트만 분석과 실행에서 일관되게 사용
- [x] `trivial/standard/complex/critical` 분류 구현
- [x] 모델명이 중앙 설정에서 관리됨
- [x] 단순 작업 Fast Path 구현
- [x] Opus 고정 호출 제거 또는 critical/승격 상황으로 제한
- [x] 재시도 checkpoint 구현
- [x] fallback 모델이 완료된 작업부터 반복하지 않음
- [x] 프롬프트 고정 prefix와 버전 관리
- [x] SKILL 선택 로딩 및 캐시 적용
- [x] 토큰·비용·fallback·재시도 로그 생성
- [x] 로그의 비밀정보 마스킹
- [x] 런타임 로그가 Git에서 제외됨
- [ ] 기존 Slack·태스크·GIIP issue·PR 흐름 회귀 테스트 통과 — **정적/단위 51건은 통과, 라이브 Slack·PR 경로는 미검증**
- [x] 작업 전후 비용 비교 보고서 작성 (비용 USD 는 "측정 불가", 컨텍스트·호출 수는 실측)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
