### PR TITLE
task(giip-1068): 비용 최적화 2차 — 재개 프롬프트 분리/진행 이벤트/소스변경 판정/수치 정정

### DIFF
--- a/slack-bot/.env.example
+++ b/slack-bot/.env.example
@@ -55,8 +55,42 @@ WORKSPACE_DIR=/path/to/your/workspace
 # ── Auto-injected context limits (per task) ──────────────────────────────────
 # CONTEXT_DEFAULT_MAX_FILES=6
 # CONTEXT_HARD_MAX_FILES=8
+# Per-file cap. Default 4000, or 6000 for `critical` tasks.
 # CONTEXT_PER_FILE_MAX_CHARS=4000
-# CONTEXT_TOTAL_MAX_CHARS=48000
+# Total context cap. giip-1068: this is now decided PER TASK CLASS
+#   trivial 12000 / standard 24000 / complex 40000 / critical 64000
+# Setting this variable overrides the per-class table for every class.
+# CONTEXT_TOTAL_MAX_CHARS=
+
+# ── Prompt size caps (giip-1068 §2.1 / §2.2) ─────────────────────────────────
+# Token estimate = characters / 4. Defaults are per task class:
+#   initial  trivial 24000 / standard 48000 / complex 80000 / critical 120000
+#   resume   trivial 12000 / standard 24000 / complex 40000 / critical  64000
+# A fallback resume prompt must never exceed 60% of the initial prompt.
+# Set these to override the per-class table for every class.
+# PROMPT_INITIAL_MAX_CHARS=
+# PROMPT_RESUME_MAX_CHARS=
+
+# ── Resume (fallback) context limits (giip-1068 §4.5) ────────────────────────
+# Default 3 files / 3000 chars each / 8000 chars total.
+# `critical` tasks get 4 files / 4000 chars each / 14000 chars total.
+# RESUME_CONTEXT_MAX_FILES=3
+# RESUME_CONTEXT_PER_FILE_MAX_CHARS=3000
+# RESUME_CONTEXT_TOTAL_MAX_CHARS=8000
+
+# ── Checkpoint field caps (giip-1068 §5.6) ───────────────────────────────────
+# CHECKPOINT_MAX_STEPS=30
+# CHECKPOINT_MAX_FILES_READ=100
+# CHECKPOINT_MAX_FILES_CHANGED=100
+# CHECKPOINT_MAX_COMMANDS=50
+# CHECKPOINT_MAX_TEST_RESULTS=30
+
+# ── Central runtime root (giip-1068 §7) ──────────────────────────────────────
+# checkpoints/, progress/, cost-usage.jsonl and task-index.json all live here.
+# Default: <WORKSPACE_DIR>/.agent/runtime . Set an ABSOLUTE path to override.
+# Keeping both the checkpoint and the cost log under one root is what makes
+# `!cost` and the fallback-resume path agree on where state lives.
+# FDE_RUNTIME_DIR=
 
 # ── GitHub Integration (optional) ────────────────────────────────────────────
 # GitHub personal access token (repo scope)

--- a/slack-bot/batch-planner.js
+++ b/slack-bot/batch-planner.js
@@ -59,15 +59,33 @@ function splitItems(text) {
 /**
  * 한 메시지 안의 독립 조회를 묶을 수 있는지 판정한다.
  *
+ * giip-1068 (8): 절감 수치를 "실제"와 "가정"으로 분리한다.
+ *   기존 구조도 한 Slack 메시지를 한 번의 모델 호출로 처리했다. 따라서 배치 지시를 붙였다고 해서
+ *   모델 호출 수가 줄어드는 것은 아니다(actual_model_calls_saved = 0).
+ *   `hypothetical_separate_calls_avoided` 는 "항목마다 따로 물었다면 필요했을 호출 수 − 1" 이라는
+ *   가정값이며, 기본 `!cost` 보고서에 실제 절감으로 합산하지 않는다.
+ *
  * @returns {{
- *   batchable: boolean, batch_size: number, model_calls_saved: number,
+ *   batchable: boolean, batch_size: number,
+ *   hypothetical_separate_calls_avoided: number,
+ *   actual_model_calls_before: number, actual_model_calls_after: number,
+ *   actual_model_calls_saved: number, saving_is_estimated: boolean,
  *   items: string[], reason: string, instruction: string|null
  * }}
  */
 function planBatch(text) {
   const items = splitItems(text);
   const none = (reason) => ({
-    batchable: false, batch_size: items.length || 1, model_calls_saved: 0, items, reason, instruction: null,
+    batchable: false,
+    batch_size: items.length || 1,
+    hypothetical_separate_calls_avoided: 0,
+    actual_model_calls_before: 1,
+    actual_model_calls_after: 1,
+    actual_model_calls_saved: 0,
+    saving_is_estimated: false,
+    items,
+    reason,
+    instruction: null,
   });
 
   if (items.length < 2) return none('단일 요청');
@@ -85,10 +103,15 @@ function planBatch(text) {
   return {
     batchable: true,
     batch_size: items.length,
-    // 항목마다 따로 물었다면 items.length 회 호출이 필요했을 것 → 1회로 처리하므로 n-1 절약
-    model_calls_saved: items.length - 1,
+    // 가정값: 항목마다 따로 물었다면 items.length 회가 필요했을 것 → n-1. 실제 절감이 아니다.
+    hypothetical_separate_calls_avoided: items.length - 1,
+    // 실측: 배치 지시 유무와 무관하게 한 메시지는 예전에도 지금도 모델 호출 1회다.
+    actual_model_calls_before: 1,
+    actual_model_calls_after: 1,
+    actual_model_calls_saved: 0,
+    saving_is_estimated: false,   // 실제 절감값(0)은 추정이 아니라 실측 구조에서 나온 값
     items,
-    reason: '한 메시지 안의 독립 read/search/status 요청',
+    reason: '한 메시지 안의 독립 read/search/status 요청 — 항목별 되묻기(추가 왕복)를 막는 효과는 있으나 모델 호출 수 절감은 0',
     instruction: buildBatchInstruction(items),
   };
 }

--- a/slack-bot/claude-cli.js
+++ b/slack-bot/claude-cli.js
@@ -88,13 +88,19 @@ async function reAuthClaude(account = null) {
 async function callClaude(prompt, workDir = BASE_DIR, opts = {}) {
   const agentDir = getAgentDir(workDir);
   // 3.8 배치: 한 메시지 안의 독립 read/search/status 요청만 묶는다(대기시켜 강제 배치하지 않음).
-  let batch = { batchable: false, batch_size: 1, model_calls_saved: 0 };
+  let batch = {
+    batchable: false, batch_size: 1,
+    actual_model_calls_saved: 0, hypothetical_separate_calls_avoided: 0, saving_is_estimated: false,
+  };
   if (opts.userText) {
     try {
       batch = batchPlanner.planBatch(opts.userText);
       if (batch.batchable && batch.instruction) {
         prompt = `${prompt}\n\n${batch.instruction}`;
-        console.log(`[Bot] 배치 처리: ${batch.batch_size}개 독립 조회 → 모델 호출 ${batch.model_calls_saved}회 절약`);
+        // giip-1068 8.1: 실제 절감(0)과 가정 절감을 구분해 로그한다. 가상 수치를 절감으로 부르지 않는다.
+        console.log(`[Bot] 배치 처리: ${batch.batch_size}개 독립 조회를 한 응답으로 처리`
+          + ` (실제 절감 모델 호출 ${batch.actual_model_calls_saved}회,`
+          + ` 개별 호출 가정 시 피한 호출 ${batch.hypothetical_separate_calls_avoided}회 — 가정값)`);
       }
     } catch { /* 배치 판정 실패는 무시 */ }
   }
@@ -106,7 +112,9 @@ async function callClaude(prompt, workDir = BASE_DIR, opts = {}) {
         task_class: 'standard',
         input_chars: prompt.length,
         batch_size: batch.batch_size,
-        model_calls_saved: batch.model_calls_saved,
+        actual_model_calls_saved: batch.actual_model_calls_saved,
+        hypothetical_separate_calls_avoided: batch.hypothetical_separate_calls_avoided,
+        saving_is_estimated: batch.saving_is_estimated,
         ...extra,
       });
     } catch { /* 계측 실패가 응답을 막지 않는다 */ }

--- a/slack-bot/cost-tracker.js
+++ b/slack-bot/cost-tracker.js
@@ -14,13 +14,15 @@ const fs = require('fs');
 const path = require('path');
 
 const modelConfig = require('./model-config');
+const runtimePaths = require('./runtime-paths');
 const { maskDeep } = require('./secret-mask');
 
 const RUNTIME_SUBDIR = path.join('.agent', 'runtime');
 const LOG_BASENAME = 'cost-usage.jsonl';
 
+/** giip-1068 7: checkpoint 와 같은 중앙 runtime root 를 쓴다. */
 function logPath(baseDir) {
-  return path.join(baseDir, RUNTIME_SUBDIR, LOG_BASENAME);
+  return runtimePaths.costLogPath(baseDir);
 }
 
 /**
@@ -74,6 +76,26 @@ function record(baseDir, entry = {}) {
 
   const priced = modelConfig.estimateCostUsd(entry.model, inputTokens, outputTokens);
 
+  // ── giip-1068 13: 프롬프트 축약 계측 ────────────────────────────────────────
+  const initialChars = Number(entry.initial_prompt_chars);
+  const currentChars = Number.isFinite(Number(entry.current_prompt_chars))
+    ? Number(entry.current_prompt_chars)
+    : Number(entry.input_chars);
+  let reductionChars = null;
+  let reductionRatio = null;
+  if (Number.isFinite(initialChars) && initialChars > 0 && Number.isFinite(currentChars)) {
+    reductionChars = initialChars - currentChars;
+    reductionRatio = Math.round((reductionChars / initialChars) * 1e4) / 1e4;
+  }
+  const promptType = entry.prompt_type === 'resume' ? 'resume'
+    : (entry.prompt_type === 'initial' ? 'initial' : null);
+  if (promptType === 'resume' && reductionRatio !== null
+      && reductionRatio < modelConfig.RESUME_REDUCTION_WARN_RATIO) {
+    console.warn('[CostOptimizationWarning]\nResume prompt reduced input by less than 40%.'
+      + ` (task=${entry.task_id || '?'}, initial=${initialChars}자, current=${currentChars}자,`
+      + ` ratio=${reductionRatio})`);
+  }
+
   const row = maskDeep({
     timestamp: new Date().toISOString(),
     task_id: entry.task_id || null,
@@ -98,15 +120,37 @@ function record(baseDir, entry = {}) {
     prompt_version: entry.prompt_version || null,
     fast_path: entry.fast_path === undefined ? null : !!entry.fast_path,
     batch_size: entry.batch_size === undefined ? null : Number(entry.batch_size),
-    model_calls_saved: entry.model_calls_saved === undefined ? null : Number(entry.model_calls_saved),
+    // ── giip-1068 8: 가상 절감과 실제 절감을 분리한다 ─────────────────────────
+    // 기존 `model_calls_saved` 는 "항목마다 따로 호출했다면 피했을 호출 수"라는 가정값이었다.
+    // 기존 구조도 한 메시지를 한 번의 모델 호출로 처리했으므로 실제 절감은 0이다.
+    actual_model_calls_saved: entry.actual_model_calls_saved === undefined
+      ? null : Number(entry.actual_model_calls_saved),
+    hypothetical_separate_calls_avoided: entry.hypothetical_separate_calls_avoided === undefined
+      ? null : Number(entry.hypothetical_separate_calls_avoided),
+    saving_is_estimated: entry.saving_is_estimated === undefined ? null : !!entry.saving_is_estimated,
     context_selection: entry.context_selection || null,   // [{path, reason}] — 선택 이유(3.7-7)
     // checkpoint 로 "이어서" 재개한 시도인지. false 인 재시도는 작업을 처음부터 다시 한 것.
     resumed: entry.resumed === undefined ? null : !!entry.resumed,
+    // ── giip-1068 13: 재개 프롬프트 축약 계측 ──────────────────────────────────
+    prompt_type: promptType,
+    initial_prompt_chars: Number.isFinite(initialChars) ? initialChars : null,
+    current_prompt_chars: Number.isFinite(currentChars) ? currentChars : null,
+    prompt_reduction_chars: reductionChars,
+    prompt_reduction_ratio: reductionRatio,
+    actual_source_files_changed: entry.actual_source_files_changed === undefined
+      ? null : Number(entry.actual_source_files_changed),
+    metadata_files_changed: entry.metadata_files_changed === undefined
+      ? null : Number(entry.metadata_files_changed),
+    checkpoint_used: entry.checkpoint_used === undefined ? null : !!entry.checkpoint_used,
+    progress_event_count: entry.progress_event_count === undefined
+      ? null : Number(entry.progress_event_count),
   });
 
   try {
-    fs.mkdirSync(path.join(baseDir, RUNTIME_SUBDIR), { recursive: true });
-    fs.appendFileSync(logPath(baseDir), `${JSON.stringify(row)}\n`, 'utf8');
+    // giip-1068 7: 디렉터리도 runtime root 기준으로 만든다(FDE_RUNTIME_DIR 존중).
+    const p = logPath(baseDir);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.appendFileSync(p, `${JSON.stringify(row)}\n`, 'utf8');
   } catch (e) {
     console.error('[cost-tracker] 기록 실패:', e.message);
     return null;
@@ -142,8 +186,11 @@ function summarize(baseDir, opts = {}) {
   const byModel = {};
   const byClass = {};
   let inputTokens = 0, outputTokens = 0, cost = 0, costKnown = 0;
-  let fallbacks = 0, retryDuplicateTokens = 0, fastPathCalls = 0, batchSaved = 0;
+  let fallbacks = 0, retryDuplicateTokens = 0, fastPathCalls = 0;
+  let batchActualSaved = 0, batchHypothetical = 0, batchMessages = 0;
   let retries = 0, resumedRetries = 0;
+  let resumePrompts = 0, resumeReductionSum = 0, resumeReductionCount = 0;
+  let resumeUnderTarget = 0;
   const fastPathTasks = new Set();
   let estimatedRows = 0;
 
@@ -160,7 +207,27 @@ function summarize(baseDir, opts = {}) {
       if (r.resumed) resumedRetries += 1;
     }
     if (r.fast_path) { fastPathCalls += 1; if (r.task_id) fastPathTasks.add(r.task_id); }
-    if (Number(r.model_calls_saved)) batchSaved += Number(r.model_calls_saved);
+
+    // 배치 수치(8.2). 구 로그의 `model_calls_saved` 는 가정값이었으므로 가정 쪽에 합산한다.
+    if (Number(r.batch_size) > 1) batchMessages += 1;
+    if (Number.isFinite(Number(r.actual_model_calls_saved))) {
+      batchActualSaved += Number(r.actual_model_calls_saved) || 0;
+    }
+    if (Number.isFinite(Number(r.hypothetical_separate_calls_avoided))) {
+      batchHypothetical += Number(r.hypothetical_separate_calls_avoided) || 0;
+    } else if (Number(r.model_calls_saved)) {
+      batchHypothetical += Number(r.model_calls_saved);   // 구 로그 하위 호환(= 가정값)
+    }
+
+    // 재개 프롬프트 축약(13)
+    if (r.prompt_type === 'resume') {
+      resumePrompts += 1;
+      if (typeof r.prompt_reduction_ratio === 'number') {
+        resumeReductionSum += r.prompt_reduction_ratio;
+        resumeReductionCount += 1;
+        if (r.prompt_reduction_ratio < modelConfig.RESUME_REDUCTION_WARN_RATIO) resumeUnderTarget += 1;
+      }
+    }
 
     const mk = `${r.provider || '?'}/${r.model || '?'}`;
     byModel[mk] = byModel[mk] || { calls: 0, input_tokens: 0, output_tokens: 0, cost: null };
@@ -210,16 +277,36 @@ function summarize(baseDir, opts = {}) {
     resumed_retries: resumedRetries,
     fast_path_calls: fastPathCalls,
     fast_path_tasks: fastPathTasks.size,
-    // 추정치: Fast Path 태스크 1건당 컨텍스트 선별 호출 1회 + 계획 생성 호출 1회를 생략한다.
+    // 8.4 Fast Path 절감은 "변경 전 로그"가 없으면 실측이 아니라 추정이다. 반드시 estimated 로 표시.
+    fast_path: {
+      actual_calls: fastPathCalls,
+      baseline_expected_calls: fastPathTasks.size * 3,   // 선별 1 + 계획 1 + 실행 1 (변경 전 가정)
+      estimated_calls_saved: fastPathTasks.size * 2,
+      saving_is_estimated: true,
+    },
+    // 하위 호환(구 필드명) — 값은 위 estimated 와 동일하다.
     fast_path_model_calls_saved_estimated: fastPathTasks.size * 2,
-    batch_model_calls_saved: batchSaved,
+    // 8.2/8.3: 실제 절감과 가정 절감을 절대 합치지 않는다.
+    batch_messages: batchMessages,
+    batch_actual_model_calls_saved: batchActualSaved,
+    batch_hypothetical_separate_calls_avoided: batchHypothetical,
+    // 13: 재개 프롬프트 축약
+    resume_prompts: resumePrompts,
+    resume_avg_reduction_ratio: resumeReductionCount
+      ? Math.round((resumeReductionSum / resumeReductionCount) * 1e4) / 1e4 : null,
+    resume_under_target: resumeUnderTarget,
     by_model: byModel,
     by_class: byClassOut,
   };
 }
 
-/** Slack/CLI 공용 텍스트 리포트. */
-function formatSummary(sum, title = '비용 요약') {
+/**
+ * Slack/CLI 공용 텍스트 리포트.
+ *
+ * giip-1068 8.3: 기본 보고서에는 "실제 절감"만 싣는다. 가상(가정) 절감값은 합산하지 않고
+ * `detailed:true`(= `!cost detail`)일 때만, 반드시 "가정값"이라고 명시해 보여준다.
+ */
+function formatSummary(sum, title = '비용 요약', detailed = false) {
   if (!sum.rows) return `${title}: 기록된 모델 호출이 없습니다 (.agent/runtime/${LOG_BASENAME}).`;
   const lines = [];
   lines.push(`*${title}*`);
@@ -231,8 +318,15 @@ function formatSummary(sum, title = '비용 요약') {
     : `• 추정 비용: $${sum.estimated_cost_usd} (단가 설정된 ${sum.priced_calls}건 기준)`);
   lines.push(`• fallback 횟수: ${sum.fallbacks}`);
   lines.push(`• 재시도 ${sum.retries}회 (그중 checkpoint 로 이어서 재개 ${sum.resumed_retries}회), 재전송된 입력 토큰: ${sum.retry_duplicate_input_tokens.toLocaleString()}`);
-  lines.push(`• Fast Path 태스크 ${sum.fast_path_tasks}건 → 생략된 모델 호출 ${sum.fast_path_model_calls_saved_estimated}회(추정: 선별 1 + 계획 1)`);
-  lines.push(`• 배치로 절약한 모델 호출: ${sum.batch_model_calls_saved}회`);
+  if (sum.resume_prompts) {
+    lines.push(`• 재개 프롬프트 ${sum.resume_prompts}회, 평균 입력 감소율 ${sum.resume_avg_reduction_ratio === null ? 'NOT_MEASURED' : `${Math.round(sum.resume_avg_reduction_ratio * 1000) / 10}%`}${sum.resume_under_target ? ` (40% 미만 ${sum.resume_under_target}회 — 경고)` : ''}`);
+  }
+  lines.push(`• Fast Path 태스크 ${sum.fast_path_tasks}건 → 생략된 모델 호출 ${sum.fast_path.estimated_calls_saved}회 (ESTIMATED — 변경 전 실측 로그 없음)`);
+  lines.push(`• 배치 처리 메시지: ${sum.batch_messages}건`);
+  lines.push(`• 실제 절감 호출: ${sum.batch_actual_model_calls_saved}회`);
+  if (detailed) {
+    lines.push(`• (가정값) 개별 호출로 처리했다고 가정했을 때 피한 호출: ${sum.batch_hypothetical_separate_calls_avoided}회 — 실제 절감에 합산하지 않음`);
+  }
   lines.push('');
   lines.push('*모델별*');
   for (const [k, v] of Object.entries(sum.by_model)) {
@@ -248,25 +342,33 @@ function formatSummary(sum, title = '비용 요약') {
 
 /** `!cost ...` 인자를 해석해 리포트 문자열을 만든다. Slack/CLI 공용. */
 function report(baseDir, arg = '') {
-  const a = String(arg || '').trim().toLowerCase();
+  // `!cost detail` / `!cost today detail` — 가정 절감값은 상세 보고서에만 나온다(8.3).
+  const DETAIL_RE = /(^|\s)(detail|details|상세)(\s|$)/i;
+  const rawArg = String(arg || '').trim();
+  const detailed = DETAIL_RE.test(rawArg);
+  const cleaned = (detailed ? rawArg.replace(DETAIL_RE, ' ') : rawArg).trim();
+  const a = cleaned.toLowerCase();
+
   if (a === 'today') {
     const d = new Date(); d.setHours(0, 0, 0, 0);
-    return formatSummary(summarize(baseDir, { since: d }), '비용 요약 (오늘)');
+    return formatSummary(summarize(baseDir, { since: d }), '비용 요약 (오늘)', detailed);
   }
   if (a.startsWith('task ')) {
-    const id = String(arg).trim().slice(5).trim();
-    return formatSummary(summarize(baseDir, { taskId: id }), `비용 요약 (task ${id})`);
+    const id = cleaned.slice(5).trim();   // 대소문자 보존
+    return formatSummary(summarize(baseDir, { taskId: id }), `비용 요약 (task ${id})`, detailed);
   }
-  if (a === 'models') {
-    const sum = summarize(baseDir);
-    if (!sum.rows) return '기록된 모델 호출이 없습니다.';
-    const lines = ['*모델별 사용량*'];
-    for (const [k, v] of Object.entries(sum.by_model)) {
-      lines.push(`• ${k}: ${v.calls}회, in ${v.input_tokens.toLocaleString()} / out ${v.output_tokens.toLocaleString()}${v.cost === null ? ' (단가 미설정 — 비용 측정 불가)' : `, $${Math.round(v.cost * 1e6) / 1e6}`}`);
-    }
-    return lines.join('\n');
+  if (a === 'models') return reportModels(baseDir);
+  return formatSummary(summarize(baseDir), '비용 요약 (전체)', detailed);
+}
+
+function reportModels(baseDir) {
+  const sum = summarize(baseDir);
+  if (!sum.rows) return '기록된 모델 호출이 없습니다.';
+  const lines = ['*모델별 사용량*'];
+  for (const [k, v] of Object.entries(sum.by_model)) {
+    lines.push(`• ${k}: ${v.calls}회, in ${v.input_tokens.toLocaleString()} / out ${v.output_tokens.toLocaleString()}${v.cost === null ? ' (단가 미설정 — 비용 측정 불가)' : `, $${Math.round(v.cost * 1e6) / 1e6}`}`);
   }
-  return formatSummary(summarize(baseDir), '비용 요약 (전체)');
+  return lines.join('\n');
 }
 
 module.exports = {
@@ -280,4 +382,5 @@ module.exports = {
   summarize,
   formatSummary,
   report,
+  reportModels,
 };

--- a/slack-bot/docs/BOT_VARIANTS.md
+++ b/slack-bot/docs/BOT_VARIANTS.md
@@ -1,0 +1,72 @@
+# slack-bot 변형(variant) 운영 경로 판정 — giip-1068 §9
+
+이 저장소에는 Slack 봇 폴더가 세 개 있다. giip-1063/1068 의 비용 최적화가 **어느 폴더에 적용되는지**와
+**왜 나머지는 대상이 아닌지**를 여기에 고정한다. (이슈 §9 "먼저 사용 여부 판정" 결과)
+
+## 1. 판정 결과 요약
+
+| 폴더 | 용도 | 대상 저장소(GITHUB_REPO) | giip-1063/1068 최적화 적용 |
+|---|---|---|---|
+| `slack-bot/` | 이 저장소(giip-fde-agent)의 실제 이슈 처리 봇 (base) | 사용처별 설정 (`.env.example` 은 플레이스홀더) | **적용** |
+| `slack-bot-minimax/` | 별개 다운스트림 프로젝트 **Vegetrade SmartOrder** 전용 독립 배포 | `LowyShin/smartorder-works` (고정값) | 미적용 (대상 아님) |
+| `slack-bot-openclaw/` | OpenClaw 게이트웨이 경유 변형 | — | 미적용 (별도 실행 모델) |
+
+## 2. `slack-bot-minimax` — §9.1 체크리스트 실측
+
+이슈 §9.1 이 요구한 다섯 항목을 실제로 확인했다.
+
+| 확인 항목 | 결과 |
+|---|---|
+| 실행 문서에서 실행을 안내하는가 | `slack-bot-openclaw/README.md` 가 "변형 중 하나"로 언급. 전용 실행 안내 문서는 별도로 있음 |
+| `register-startup.ps1` 이 있는가 | **있다** (`slack-bot-minimax/register-startup.ps1`) |
+| 독립 실행 진입점이 있는가 | **있다** (`index.js` + 독립 `package.json`, `npm start`) |
+| 최근 180일 내 기능 수정 커밋이 있는가 | **있다** (2026-07-30 `a437db9`, `f8c9df7`) |
+| `slack-bot` 과 기능이 중복되는가 | 코드 구조는 유사하지만 **대상 프로젝트가 다르다**(아래 §3) |
+
+→ §9.2 기준으로 "사용 가능 경로"다. **근거 없이 미사용으로 처리하지 않는다.**
+
+## 3. 결정: 현행 유지 (통합하지 않고 deprecated 처리도 하지 않는다)
+
+§9.3 은 "공통 모듈을 `slack-bot-core/` 로 분리" 또는 "최소안으로 deprecated 처리"를 권한다.
+그러나 이번 조사에서 **두 폴더가 같은 봇의 중복 복사본이 아니라는 결정적 근거**가 나왔다.
+
+```
+slack-bot-minimax/.env.example:12
+GITHUB_REPO=LowyShin/smartorder-works
+```
+
+* `slack-bot-minimax` 는 giip-fde-agent 자신의 이슈 큐를 처리하는 봇이 **아니다**.
+  완전히 별개의 다운스트림 프로젝트(Vegetrade SmartOrder, `smartorder-works` 저장소)를 위한
+  **독립 배포본**이다. 이 저장소 안에 같이 들어있을 뿐 기능 목적이 다르다.
+  (`check_stock_db.js`, `reset_password.js`, `giip-accounts.sample.json` 등 SmartOrder 전용 파일이
+  `slack-bot-minimax` 에만 있는 것도 같은 근거다.)
+* `slack-bot`(base)이 이 저장소의 실제 이슈 처리 봇이며, giip-1063/1068 이 수정하는 대상이다.
+* `minimax-accounts.js`(MiniMax 우선 → Claude 폴백)는 giip-780 대부터 있던 기존 사용자 지시사항이지
+  이번에 새로 생긴 구조가 아니다. 즉 `slack-bot` 도 이미 MiniMax 우선 라우팅을 쓴다.
+
+**사용자 결정(2026-08-13): 현행 유지.** 서로 다른 프로젝트를 위한 별개 배포이므로
+`slack-bot-core/` 강제 통합이나 `slack-bot-minimax` deprecated 표시는 불필요·부적절하다.
+
+이는 §9.2 가 금지한 "아무 조치 없이 방치"가 아니라, 체크리스트 실측 + 대상 저장소 확인 +
+사용자 결정에 근거한 **명시적 판단**이다.
+
+## 4. 따라서 이번 작업(giip-1068)의 적용 범위
+
+`slack-bot/`(base)에만 적용한다.
+
+* 재개 프롬프트 분리 (`prompt-templates.js`, `resume-context-builder.js`)
+* 진행 이벤트 (`progress-events.js`, `tools/progress-event.js`)
+* 실제 소스 변경 판정 (`retry-checkpoint.changedSourceFiles`)
+* 중앙 runtime 경로 (`runtime-paths.js`)
+* 배치/Fast Path 수치 정정 (`batch-planner.js`, `cost-tracker.js`)
+* read/write 위험도 분리 (`model-router.js`)
+
+`slack-bot-minimax/` 와 `slack-bot-openclaw/` 는 이번 변경에서 **수정하지 않는다**.
+
+## 5. 재검토 조건
+
+다음 중 하나라도 참이 되면 이 판정을 다시 해야 한다.
+
+* `slack-bot-minimax/.env.example` 의 `GITHUB_REPO` 가 이 저장소를 가리키게 바뀐다
+* `slack-bot-minimax` 가 giip-fde-agent 의 이슈 큐(`.agent/tasks/`)를 처리하기 시작한다
+* 두 봇의 **모델 라우팅 정책이 서로 달라진다**(§9.2 가 금지한 상태)

--- a/slack-bot/handlers.js
+++ b/slack-bot/handlers.js
@@ -209,7 +209,7 @@ async function handleDM({ channelId, ts, threadTs, text, conversations, workDir 
       '• `!issues` — GitHub Issue 一覧',
       '• `!issues refresh` — Issue 強制更新',
       '• `!klayer <キーワード>` — K-Layer 知識検索',
-      '• `!cost` / `!cost today` / `!cost task <id>` / `!cost models` — 토큰·비용 리포트',
+      '• `!cost` / `!cost today` / `!cost task <id>` / `!cost models` / `!cost detail` — 토큰·비용 리포트 (detail 은 가정 절감값까지 표시)',
       '• `!reset` — 会話履歴リセット',
       '',
       '*giip issue 連携:*',
@@ -820,7 +820,7 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
       '*情報:*',
       '• `!issues` — GitHub Issue 一覧',
       '• `!klayer <キーワード>` — K-Layer 検索',
-      '• `!cost` / `!cost today` / `!cost task <id>` / `!cost models` — 토큰·비용 리포트',
+      '• `!cost` / `!cost today` / `!cost task <id>` / `!cost models` / `!cost detail` — 토큰·비용 리포트 (detail 은 가정 절감값까지 표시)',
       '• `allowlist` — 허용된 user/channel 화이트리스트 표시',
       '• `!help` — ヘルプ',
     ].join('\n'), replyTs);
@@ -1426,8 +1426,11 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
     return;
   }
   // giip-1063: 분석에서 결정한 작업 등급/Fast Path 여부를 태스크 파일에 남겨 실행 단계가 재사용한다.
+  // giip-1068 10.2: 실행 등급(task_class)과 별개로 조작 종류/조회 위험도도 남긴다.
   const taskMeta = {
     taskClass: (classification && classification.class) || 'standard',
+    riskClass: (classification && classification.risk_class) || 'none',
+    operation: (classification && classification.operation) || 'write',
     fastPath: !!fastPath,
   };
 

--- a/slack-bot/model-config.js
+++ b/slack-bot/model-config.js
@@ -82,18 +82,91 @@ function retryLimits() {
   };
 }
 
-/** 컨텍스트 자동 주입 한도(3.1). */
-function contextLimits() {
-  const n = (name, def) => {
-    const v = Number(process.env[name]);
-    return Number.isFinite(v) && v > 0 ? v : def;
-  };
+function numEnv(name, def) {
+  const v = Number(process.env[name]);
+  return Number.isFinite(v) && v > 0 ? v : def;
+}
+
+function normTier(taskClass) {
+  return TIERS.includes(taskClass) ? taskClass : 'standard';
+}
+
+// ── 등급별 한도표 (giip-1068, 2.1~2.3) ────────────────────────────────────────
+// 1차 작업에서는 모든 등급에 48,000자를 일괄 적용했다. 등급별로 나눈다.
+const CONTEXT_TOTAL_BY_CLASS = { trivial: 12000, standard: 24000, complex: 40000, critical: 64000 };
+const PROMPT_INITIAL_BY_CLASS = { trivial: 24000, standard: 48000, complex: 80000, critical: 120000 };
+const PROMPT_RESUME_BY_CLASS = { trivial: 12000, standard: 24000, complex: 40000, critical: 64000 };
+
+/** 재개 프롬프트는 최초 프롬프트의 이 비율을 넘으면 안 된다(2.2). */
+const RESUME_PROMPT_MAX_RATIO = 0.60;
+/** 재개 프롬프트인데 감소율이 이 값보다 작으면 경고를 남긴다(13). */
+const RESUME_REDUCTION_WARN_RATIO = 0.40;
+/** 최초 프롬프트가 이 길이 이하면 60% 규칙 예외(동일 프롬프트 재사용 허용, 2.2). */
+const SMALL_PROMPT_EXEMPT_CHARS = 12000;
+
+/**
+ * 컨텍스트 자동 주입 한도(3.1 / giip-1068 2.3).
+ * @param {string} [taskClass] trivial|standard|complex|critical (미지정 시 standard)
+ */
+function contextLimits(taskClass) {
+  const tier = normTier(taskClass);
+  // 명시적 환경변수가 있으면 등급표보다 우선(운영에서 강제 조정 가능).
+  const total = Number(process.env.CONTEXT_TOTAL_MAX_CHARS);
+  const perFileDefault = tier === 'critical' ? 6000 : 4000;
   return {
-    minFiles: n('CONTEXT_MIN_FILES', 2),
-    defaultMaxFiles: n('CONTEXT_DEFAULT_MAX_FILES', 6),
-    hardMaxFiles: n('CONTEXT_HARD_MAX_FILES', 8),
-    perFileMaxChars: n('CONTEXT_PER_FILE_MAX_CHARS', 4000),
-    totalMaxChars: n('CONTEXT_TOTAL_MAX_CHARS', 48000),
+    taskClass: tier,
+    minFiles: numEnv('CONTEXT_MIN_FILES', 2),
+    defaultMaxFiles: numEnv('CONTEXT_DEFAULT_MAX_FILES', 6),
+    hardMaxFiles: numEnv('CONTEXT_HARD_MAX_FILES', 8),
+    perFileMaxChars: numEnv('CONTEXT_PER_FILE_MAX_CHARS', perFileDefault),
+    totalMaxChars: Number.isFinite(total) && total > 0 ? total : CONTEXT_TOTAL_BY_CLASS[tier],
+  };
+}
+
+/**
+ * 재개(fallback) 프롬프트에 실을 컨텍스트 한도(4.5).
+ * 일반: 3개 파일 / 파일당 3,000자 / 전체 8,000자
+ * critical: 4개 파일 / 파일당 4,000자 / 전체 14,000자
+ */
+function resumeContextLimits(taskClass) {
+  const tier = normTier(taskClass);
+  const critical = tier === 'critical';
+  return {
+    taskClass: tier,
+    maxFiles: numEnv('RESUME_CONTEXT_MAX_FILES', critical ? 4 : 3),
+    perFileMaxChars: numEnv('RESUME_CONTEXT_PER_FILE_MAX_CHARS', critical ? 4000 : 3000),
+    totalMaxChars: numEnv('RESUME_CONTEXT_TOTAL_MAX_CHARS', critical ? 14000 : 8000),
+  };
+}
+
+/**
+ * 프롬프트 전체 문자 수 상한(2.1 / 2.2). 토큰 추정은 문자 수 ÷ 4.
+ * @returns {{taskClass, initialMaxChars, resumeMaxChars, resumeMaxRatio,
+ *            initialMaxTokensEstimated, resumeMaxTokensEstimated}}
+ */
+function promptLimits(taskClass) {
+  const tier = normTier(taskClass);
+  const initial = numEnv('PROMPT_INITIAL_MAX_CHARS', PROMPT_INITIAL_BY_CLASS[tier]);
+  const resume = numEnv('PROMPT_RESUME_MAX_CHARS', PROMPT_RESUME_BY_CLASS[tier]);
+  return {
+    taskClass: tier,
+    initialMaxChars: initial,
+    resumeMaxChars: resume,
+    resumeMaxRatio: RESUME_PROMPT_MAX_RATIO,
+    smallPromptExemptChars: SMALL_PROMPT_EXEMPT_CHARS,
+    initialMaxTokensEstimated: Math.ceil(initial / 4),
+    resumeMaxTokensEstimated: Math.ceil(resume / 4),
+  };
+}
+
+/** checkpoint 에 저장할 항목 수 상한(5.6). */
+function checkpointLimits() {
+  return {
+    completed_steps: numEnv('CHECKPOINT_MAX_STEPS', 30),
+    files_read: numEnv('CHECKPOINT_MAX_FILES_READ', 100),
+    files_changed: numEnv('CHECKPOINT_MAX_FILES_CHANGED', 100),
+    commands_run: numEnv('CHECKPOINT_MAX_COMMANDS', 50),
+    test_results: numEnv('CHECKPOINT_MAX_TEST_RESULTS', 30),
   };
 }
 
@@ -149,7 +222,17 @@ module.exports = {
   isMiniMaxToken,
   retryLimits,
   contextLimits,
+  resumeContextLimits,
+  promptLimits,
+  checkpointLimits,
   loadPricing,
   estimateCostUsd,
   PRICING_FILE,
+  CONTEXT_TOTAL_BY_CLASS,
+  PROMPT_INITIAL_BY_CLASS,
+  PROMPT_RESUME_BY_CLASS,
+  RESUME_PROMPT_MAX_RATIO,
+  RESUME_REDUCTION_WARN_RATIO,
+  SMALL_PROMPT_EXEMPT_CHARS,
+  runtimeRoot: (...a) => require('./runtime-paths').runtimeRoot(...a),
 };

--- a/slack-bot/model-router.js
+++ b/slack-bot/model-router.js
@@ -76,6 +76,98 @@ const DESTRUCTIVE_RE = /(전부\s*삭제|모두\s*삭제|일괄\s*삭제|全削�
 
 function uniq(arr) { return Array.from(new Set(arr)); }
 
+// ── giip-1068 (10): 변경 위험과 조회 위험 분리 ───────────────────────────────
+// 1차 작업의 문제: "로그인 구조를 설명해줘" 처럼 읽기 전용 요청도 CRITICAL_RE 에 걸려
+// critical 실행 작업으로 오인되고 최상위 모델이 붙었다. operation 을 따로 판정한다.
+
+const OPERATIONS = ['read', 'write', 'delete', 'deploy', 'migrate'];
+
+// 조회 동사(읽기 전용 신호)
+const OP_READ_RE = new RegExp([
+  '알려\\s*(줘|주세요|다오)?', '보여\\s*(줘|주세요)?', '설명해', '설명\\s*(줘|해줘|부탁)', '어디\\s*(에|있)',
+  '있는지', '있나', '되어\\s*있는지', '돼\\s*있는지', '확인해', '조회해', '찾아\\s*(줘|봐)', '검색해',
+  '무엇인지', '뭔지', '어떤지', '읽기\\s*전용', '분석해\\s*(줘)?', '리뷰해', '목록', '리스트',
+  '教えて', '見せて', '説明して', 'どこ', '確認して', '検索して', '一覧',
+  '\\bexplain\\b', '\\bshow\\b', '\\blist\\b', '\\bwhere\\b', '\\bwhich\\b', '\\bwhat\\b',
+  '\\bfind\\b', '\\bsearch\\b', '\\bcheck\\b', '\\bread[- ]?only\\b', '\\breview\\b', '\\banaly[sz]e\\b',
+].join('|'), 'i');
+
+// 변경 동사
+const OP_WRITE_RE = new RegExp([
+  '수정', '변경', '바꿔', '고쳐', '고치', '추가', '생성', '작성', '만들', '구현', '적용',
+  '리팩터', '리팩토', '개선', '교체', '치환', '이름\\s*(변경|바꿔)', '리네임',
+  '修正', '変更', '追加', '作成', '実装', 'リファクタ',
+  '\\bfix\\b', '\\bchange\\b', '\\bupdate\\b', '\\badd\\b', '\\bcreate\\b', '\\bwrite\\b',
+  '\\bimplement\\b', '\\brefactor\\b', '\\brename\\b', '\\breplace\\b', '\\bedit\\b', '\\bpatch\\b',
+].join('|'), 'i');
+
+const OP_DELETE_RE = new RegExp([
+  '삭제', '지워', '제거', '없애', '드롭',
+  '削除', '除去',
+  '\\bdelete\\b', '\\bremove\\b', '\\bdrop\\s+table\\b', '\\btruncate\\b', '\\bpurge\\b', '\\bwipe\\b',
+  '\\brm\\s+-rf\\b', 'terraform\\s+destroy',
+].join('|'), 'i');
+
+const OP_DEPLOY_RE = new RegExp([
+  '배포해', '배포\\s*(하|해|를|좀)', '릴리스', '릴리즈', '롤아웃', '반영해\\s*(줘)?\\s*(운영|프로덕션)',
+  'デプロイ', 'リリース',
+  '\\bdeploy\\b', '\\brelease\\b', '\\brollout\\b', '\\bship\\s+to\\s+prod',
+].join('|'), 'i');
+
+const OP_MIGRATE_RE = new RegExp([
+  '마이그레이션', '마이그레이', '스키마\\s*(변경|수정|추가|적용)', '데이터\\s*이관', '이관해',
+  'マイグレーション',
+  '\\bmigrat(e|ion)\\b', '\\balter\\s+table\\b', '\\bddl\\b', '\\bbackfill\\b',
+].join('|'), 'i');
+
+// 운영/프로덕션 환경 신호(deploy 위험 판정용)
+const PRODUCTION_RE = /(운영\s*(환경|서버|디비|db)|프로덕션|프로덕숀|본番|本番|\bproduction\b|\bprod\b)/i;
+
+// 한국어/일본어는 주동사가 문장 끝에 온다. "결제 기능이 구현되어 있는지 확인해줘" 처럼
+// 문장 안에 변경 동사(구현)가 들어 있어도 끝맺음이 조회 동사면 읽기 전용 요청이다(10.1).
+const READ_TAIL_RE = new RegExp([
+  '(확인|조회|알려|보여|설명|검색|파악|검토|분석|리뷰|찾아|정리)\\s*'
+  + '(해|해줘|해주세요|줘|주세요|주라|봐|달라|드려|하라|하세요|해라|바랍니다|해봐|해 줘)?\\s*[.?!。？]*\\s*$',
+  '(어디|어느\\s*(파일|폴더|경로|테이블)|무엇|뭔가요|뭐야|있나요|있어|있습니까|なに|どこ)\\s*[.?!。？]*\\s*$',
+  '\\?\\s*$',
+].join('|'), 'i');
+
+function tailOf(text, chars = 40) {
+  const lines = String(text || '').trim().split(/\r?\n/).filter(l => l.trim());
+  const last = lines.length ? lines[lines.length - 1].trim() : '';
+  return last.slice(-chars);
+}
+
+/**
+ * 요청의 조작 종류를 판정한다(10.2).
+ * 우선순위: delete > deploy > migrate > write > read
+ * 변경 동사가 있어도 문장이 조회로 끝나면 read (10.1 오탐 방지).
+ */
+function detectOperation(text) {
+  const t = String(text || '');
+  if (OP_DELETE_RE.test(t)) return 'delete';
+  if (OP_DEPLOY_RE.test(t)) return 'deploy';
+  if (OP_MIGRATE_RE.test(t)) return 'migrate';
+  if (OP_WRITE_RE.test(t)) {
+    return READ_TAIL_RE.test(tailOf(t)) ? 'read' : 'write';
+  }
+  if (OP_READ_RE.test(t)) return 'read';
+  return 'read';   // 동사를 못 찾으면 가장 안전한 쪽(조회)으로 본다. 승격은 risk 규칙이 담당.
+}
+
+/**
+ * 조회 위험도(risk_class). 실행 등급(task_class)과 분리된 값이다.
+ *   critical — 보안/인증/결제/개인정보/운영DB/인프라 관련 주제
+ *   elevated — 스키마/배포설정/마이그레이션/대량 삭제 등
+ *   none     — 그 외
+ */
+function detectRiskClass(text) {
+  const t = String(text || '');
+  if (CRITICAL_RE.test(t)) return 'critical';
+  if (MIN_COMPLEX_RE.test(t) || DESTRUCTIVE_RE.test(t)) return 'elevated';
+  return 'none';
+}
+
 /** taskPlan(분석 결과 마크다운)에서 "영향 파일/서브시스템" 항목 수를 센다. */
 function countPlanImpactFiles(taskPlan) {
   if (!taskPlan) return 0;
@@ -119,7 +211,13 @@ function classifyTask(requestText, selectedContext = [], taskPlan = '', opts = {
   const hitTrivial = TRIVIAL_RE.test(text) || hitReplaceIdiom;
   const hitDestructive = DESTRUCTIVE_RE.test(text);
 
-  if (hitCritical) {
+  // giip-1068 (10.2): 조작 종류와 조회 위험도를 실행 등급과 분리해 먼저 판정한다.
+  // operation 은 사용자가 실제로 쓴 문장(requestText)으로 본다 — 계획서 본문의 동사에 끌려가지 않게.
+  const operation = detectOperation(requestText || text);
+  const riskClass = detectRiskClass(text);
+  const isReadOnly = operation === 'read';
+
+  if (hitCritical && !isReadOnly) {
     cls = 'critical';
     confidence = 0.9;
     reasons.push('보안/인증/결제/개인정보/운영DB/인프라 관련 키워드 검출 → 최소 critical');
@@ -136,21 +234,53 @@ function classifyTask(requestText, selectedContext = [], taskPlan = '', opts = {
     if (explicitPaths.length) reasons.push(`대상 파일 경로가 요청에 명시됨(${explicitPaths.length}개)`);
   } else {
     cls = 'standard';
-    confidence = 0.6;
+    confidence = isReadOnly && hitCritical ? 0.85 : 0.6;
     reasons.push(`변경 예상 파일 ${estimatedFiles}개`);
-    reasons.push('보안/인증/DB 변경 신호 없음');
-    reasons.push('기존 기능의 제한된 수정으로 판단');
+    reasons.push(isReadOnly && hitCritical
+      ? '위험 주제이지만 읽기 전용(조회/설명) 요청 — 실행 등급은 올리지 않는다'
+      : '보안/인증/DB 변경 신호 없음');
+    reasons.push(isReadOnly ? '조회/설명 요청으로 판단' : '기존 기능의 제한된 수정으로 판단');
   }
 
-  if (hitMinComplex) {
+  if (hitMinComplex && !isReadOnly) {
     const before = cls;
     cls = atLeast(cls, 'complex');
     if (cls !== before) reasons.push('마이그레이션/스키마/배포 설정 변경 → 최소 complex 로 승격');
   }
-  if (hitDestructive) {
+  if (hitDestructive && !isReadOnly) {
     const before = cls;
     cls = atLeast(cls, 'complex');
     if (cls !== before) reasons.push('대량 삭제 신호 → 최소 complex 로 승격');
+  }
+
+  // ── 10.2 operation × risk 규칙표 ────────────────────────────────────────────
+  //  read   / 위험 없음  → standard 이하
+  //  read   / 위험 있음  → standard 또는 complex
+  //  write  / 보안·인증·결제 → critical
+  //  delete / 주요 데이터·인프라 → critical
+  //  deploy / 운영 환경   → critical
+  //  migrate / 스키마·데이터 → complex 이상
+  if (operation === 'read') {
+    if (riskClass === 'none' && rank(cls) > rank('standard')) {
+      cls = 'standard';
+      reasons.push('읽기 전용 + 위험 신호 없음 → standard 이하로 제한(단순 조회에 프리미엄 모델 금지)');
+    } else if (riskClass !== 'none' && rank(cls) > rank('complex')) {
+      cls = 'complex';
+      reasons.push('읽기 전용 요청은 위험 주제라도 critical 실행 등급으로 올리지 않는다(최대 complex)');
+    }
+  } else if (operation === 'write' && riskClass === 'critical') {
+    if (cls !== 'critical') reasons.push('보안·인증·결제 영역의 변경(write) → critical');
+    cls = 'critical';
+  } else if (operation === 'delete' && (riskClass === 'critical' || hitDestructive)) {
+    if (cls !== 'critical') reasons.push('주요 데이터·인프라 삭제(delete) → critical');
+    cls = 'critical';
+  } else if (operation === 'deploy' && (riskClass === 'critical' || PRODUCTION_RE.test(text))) {
+    if (cls !== 'critical') reasons.push('운영 환경 배포(deploy) → critical');
+    cls = 'critical';
+  } else if (operation === 'migrate') {
+    const before = cls;
+    cls = riskClass === 'critical' ? 'critical' : atLeast(cls, 'complex');
+    if (cls !== before) reasons.push('스키마·데이터 마이그레이션(migrate) → 최소 complex');
   }
 
   // 애매한 경우에만 저비용 모델 1회. Opus 는 절대 쓰지 않는다(호출자가 티어를 강제).
@@ -185,16 +315,26 @@ function classifyTask(requestText, selectedContext = [], taskPlan = '', opts = {
     reasons.push(`신뢰도 낮음(${confidence.toFixed(2)}) → 한 단계 상향`);
   }
 
+  // 읽기 전용 요청은 어떤 승격 경로로도 critical 이 되지 않는다(10.1 오탐 방지).
+  if (isReadOnly && cls === 'critical') {
+    cls = 'complex';
+    reasons.push('읽기 전용 요청 — critical 실행 등급으로 승격하지 않음(Opus 라우팅 금지)');
+  }
+
   const fastPathEligible = isFastPathEligible({
     taskClass: cls,
     explicitPaths,
     estimatedFiles,
     destructive: hitDestructive,
+    operation,
     contextCount: (selectedContext || []).length,
   });
 
   return {
     class: cls,
+    task_class: cls,
+    risk_class: riskClass,
+    operation,
     confidence: Math.round(confidence * 100) / 100,
     reasons: uniq(reasons),
     method,
@@ -211,9 +351,11 @@ function classifyTask(requestText, selectedContext = [], taskPlan = '', opts = {
  *  - 인증/보안/결제/DB 스키마/배포 변경이 아님(= trivial 이면 이미 보장)
  *  - 삭제·대량 변경이 아님
  */
-function isFastPathEligible({ taskClass, explicitPaths = [], estimatedFiles = 1, destructive = false }) {
+function isFastPathEligible({ taskClass, explicitPaths = [], estimatedFiles = 1, destructive = false, operation = 'write' }) {
   if (taskClass !== 'trivial') return false;
   if (destructive) return false;
+  // giip-1068 10: 삭제/배포/마이그레이션은 등급과 무관하게 Fast Path 금지.
+  if (['delete', 'deploy', 'migrate'].includes(operation)) return false;
   if (!explicitPaths.length) return false;            // 요구사항이 "명확"하다는 정적 근거
   if (explicitPaths.length > 3) return false;
   if (estimatedFiles > 3) return false;
@@ -313,6 +455,9 @@ function escalateOnFailure(taskClass, attempt) {
 module.exports = {
   ORDER,
   PHASES,
+  OPERATIONS,
+  detectOperation,
+  detectRiskClass,
   classifyTask,
   selectModel,
   escalateOnFailure,

--- a/slack-bot/progress-events.js
+++ b/slack-bot/progress-events.js
@@ -1,0 +1,304 @@
+/**
+ * progress-events.js — 실행 중 진행 상황을 구조화해 남긴다 (giip-1068, 5)
+ *
+ * 1차 작업(giip-1063)의 남은 문제
+ *   checkpoint 의 `completed_steps` / `files_read` / `commands_run` / `test_results` 가 항상 빈 배열이었다.
+ *   실행 중에 아무도 채우지 않았기 때문이다. 그래서 fallback 재개 프롬프트가 "이미 한 일"을 알 수 없었다.
+ *
+ * 여기서
+ *   실행 중인 모델이 전용 CLI(`tools/progress-event.js`)로 이벤트를 남기고,
+ *   `retry-checkpoint.recordFailure()` 가 그 이벤트를 읽어 checkpoint 를 채운다.
+ *
+ * 저장 위치: `<runtimeRoot>/progress/<task-id>.jsonl` (JSON Lines)
+ * 안전: 기록 전 secret-mask 를 통과시킨다. 절대경로는 마스킹된 상대경로로 바꾼다.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const { maskString, maskDeep } = require('./secret-mask');
+const runtimePaths = require('./runtime-paths');
+
+// ── 5.2 허용 이벤트 종류 (이 8종만) ──────────────────────────────────────────
+const EVENT_TYPES = [
+  'step_started',
+  'step_completed',
+  'file_read',
+  'file_changed',
+  'command_run',
+  'test_result',
+  'decision',
+  'blocked',
+];
+
+// 정리(pruning) 대상에서 제외되는 종류 — 재개 판단의 근거라 지우지 않는다(5.4).
+const PROTECTED_TYPES = new Set(['step_completed', 'file_changed', 'test_result', 'blocked']);
+
+// ── 5.4 길이 제한 ────────────────────────────────────────────────────────────
+const LIMITS = {
+  summary: 500,
+  path: 500,
+  step_id: 200,
+  command: 1000,
+  output: 2000,
+  result: 2000,
+  status: 40,
+  maxEvents: 500,
+  maxBytes: 1024 * 1024,   // 1MB
+};
+
+function eventPath(baseDir, taskId) {
+  return path.join(runtimePaths.progressDir(baseDir), `${runtimePaths.safeTaskId(taskId)}.jsonl`);
+}
+
+function clip(value, max) {
+  if (value === undefined || value === null) return undefined;
+  const s = maskString(String(value));
+  return s.length > max ? `${s.slice(0, max - 1)}…` : s;
+}
+
+/**
+ * 절대경로를 로그에 남기지 않는다(7.2). baseDir 하위면 상대경로, 아니면 마스킹.
+ */
+function normalizePath(p, baseDir) {
+  if (!p) return undefined;
+  const raw = String(p);
+  if (path.isAbsolute(raw)) {
+    if (baseDir) {
+      const rel = path.relative(baseDir, raw);
+      if (rel && !rel.startsWith('..') && !path.isAbsolute(rel)) return rel.replace(/\\/g, '/');
+    }
+    return runtimePaths.maskWorkDir(raw);
+  }
+  return raw.replace(/\\/g, '/');
+}
+
+/**
+ * 이벤트를 검증·정규화한다. 허용되지 않는 종류면 null 을 돌려준다(호출측이 경고 로그).
+ * @returns {object|null}
+ */
+function normalizeEvent(event = {}, taskId = null, baseDir = null) {
+  const type = String(event.type || '').trim();
+  if (!EVENT_TYPES.includes(type)) return null;
+
+  const out = {
+    timestamp: event.timestamp && !Number.isNaN(Date.parse(event.timestamp))
+      ? new Date(event.timestamp).toISOString()
+      : new Date().toISOString(),
+    task_id: String(event.task_id || taskId || 'unknown'),
+    attempt: Number.isFinite(Number(event.attempt)) ? Number(event.attempt) : 1,
+    type,
+  };
+  const add = (k, v) => { if (v !== undefined && v !== '') out[k] = v; };
+  add('step_id', clip(event.step_id, LIMITS.step_id));
+  add('path', clip(normalizePath(event.path, baseDir), LIMITS.path));
+  add('summary', clip(event.summary, LIMITS.summary));
+  add('status', clip(event.status, LIMITS.status));
+  add('command', clip(event.command, LIMITS.command));
+  add('output', clip(event.output, LIMITS.output));
+  add('result', clip(event.result, LIMITS.result));
+
+  return maskDeep(out);
+}
+
+/** JSONL 한 줄씩 파싱. 깨진 줄은 건너뛴다. */
+function parseLines(raw) {
+  const out = [];
+  for (const line of String(raw || '').split(/\r?\n/)) {
+    const t = line.trim();
+    if (!t) continue;
+    try {
+      const o = JSON.parse(t);
+      if (o && EVENT_TYPES.includes(o.type)) out.push(o);
+    } catch { /* 깨진 줄 무시 */ }
+  }
+  return out;
+}
+
+/** 저장된 진행 이벤트 전부. 파일이 없으면 빈 배열. */
+function readProgressEvents(baseDir, taskId) {
+  try { return parseLines(fs.readFileSync(eventPath(baseDir, taskId), 'utf8')); }
+  catch { return []; }
+}
+
+/**
+ * 5.4 정리 규칙: 500개 또는 1MB 초과 시 "오래된 중복 file_read" 부터 지운다.
+ * step_completed / file_changed / test_result / blocked 는 절대 지우지 않는다.
+ */
+function pruneEvents(events) {
+  let list = events.slice();
+  const overflow = () =>
+    list.length > LIMITS.maxEvents
+    || Buffer.byteLength(list.map(e => JSON.stringify(e)).join('\n'), 'utf8') > LIMITS.maxBytes;
+
+  if (!overflow()) return { events: list, removed: 0 };
+
+  let removed = 0;
+
+  // 1) 오래된 중복 file_read 부터 (같은 경로가 여러 번 기록된 것 중 마지막만 남긴다)
+  const isDupRead = () => {
+    const last = new Map();
+    list.forEach((e, i) => { if (e.type === 'file_read' && e.path) last.set(e.path, i); });
+    return (e, i) => e.type === 'file_read' && e.path && last.get(e.path) !== i;
+  };
+  while (overflow()) {
+    const dup = isDupRead();
+    const i = list.findIndex((e, idx) => dup(e, idx));
+    if (i < 0) break;
+    list.splice(i, 1);
+    removed += 1;
+  }
+
+  // 2) 그래도 넘치면 보호 대상이 아닌 이벤트를 종류 우선순위대로, 오래된 것부터
+  for (const type of ['file_read', 'step_started', 'decision', 'command_run']) {
+    if (PROTECTED_TYPES.has(type)) continue;
+    while (overflow()) {
+      const i = list.findIndex(e => e.type === type);
+      if (i < 0) break;
+      list.splice(i, 1);
+      removed += 1;
+    }
+    if (!overflow()) break;
+  }
+
+  // 3) 최후: 보호 대상만 남았는데도 개수 상한을 넘으면 가장 오래된 것부터
+  while (list.length > LIMITS.maxEvents) { list.shift(); removed += 1; }
+
+  return { events: list, removed };
+}
+
+function writeAll(baseDir, taskId, events) {
+  const p = eventPath(baseDir, taskId);
+  runtimePaths.ensureDir(path.dirname(p));
+  fs.writeFileSync(p, events.map(e => JSON.stringify(e)).join('\n') + (events.length ? '\n' : ''), 'utf8');
+}
+
+/**
+ * 진행 이벤트 한 건 추가.
+ * @returns {{ok:boolean, event:object|null, reason:string|null, pruned:number}}
+ */
+function appendProgressEvent(baseDir, taskId, event = {}) {
+  const norm = normalizeEvent(event, taskId, baseDir);
+  if (!norm) {
+    const reason = `허용되지 않는 진행 이벤트 종류: ${JSON.stringify(String(event && event.type))}`;
+    console.warn(`[progress-events] ${reason} — 기록하지 않음 (허용: ${EVENT_TYPES.join(', ')})`);
+    return { ok: false, event: null, reason, pruned: 0 };
+  }
+
+  const p = eventPath(baseDir, taskId);
+  if (!runtimePaths.ensureDir(path.dirname(p))) {
+    return { ok: false, event: null, reason: '진행 이벤트 디렉터리 생성 실패', pruned: 0 };
+  }
+
+  try {
+    const existing = readProgressEvents(baseDir, taskId);
+    const { events, removed } = pruneEvents(existing.concat([norm]));
+    if (removed > 0) writeAll(baseDir, taskId, events);
+    else fs.appendFileSync(p, `${JSON.stringify(norm)}\n`, 'utf8');
+    return { ok: true, event: norm, reason: null, pruned: removed };
+  } catch (e) {
+    console.error('[progress-events] 기록 실패:', e.message);
+    return { ok: false, event: null, reason: e.message, pruned: 0 };
+  }
+}
+
+function clearProgressEvents(baseDir, taskId) {
+  try { fs.rmSync(eventPath(baseDir, taskId), { force: true }); return true; } catch { return false; }
+}
+
+// ── 5.6 checkpoint 채우기용 요약 ─────────────────────────────────────────────
+/**
+ * 이벤트 목록 → checkpoint 필드.
+ * 중복 제거 + 정렬(step: 완료 시각순 / file: 최초 발생 순 / command·test: 실행 시각순) + 개수 상한.
+ */
+function summarizeProgressEvents(events = [], limits = null) {
+  const lim = limits || require('./model-config').checkpointLimits();
+  const byTime = events.slice().sort(
+    (a, b) => Date.parse(a.timestamp || 0) - Date.parse(b.timestamp || 0));
+
+  const dedup = (arr) => {
+    const seen = new Set();
+    const out = [];
+    for (const v of arr) {
+      const key = typeof v === 'string' ? v : JSON.stringify(v);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push(v);
+    }
+    return out;
+  };
+
+  const completedSteps = [];
+  const startedSteps = [];
+  const filesRead = [];
+  const filesChanged = [];
+  const commandsRun = [];
+  const testResults = [];
+  const decisions = [];
+  const blocked = [];
+
+  for (const e of byTime) {
+    switch (e.type) {
+      case 'step_completed':
+        completedSteps.push(e.summary ? `${e.step_id || 'step'}: ${e.summary}` : (e.step_id || 'step'));
+        break;
+      case 'step_started':
+        startedSteps.push(e.step_id || 'step');
+        break;
+      case 'file_read':
+        if (e.path) filesRead.push(e.path);
+        break;
+      case 'file_changed':
+        if (e.path) filesChanged.push(e.path);
+        break;
+      case 'command_run':
+        commandsRun.push(e.command || e.summary || '(명령 미기재)');
+        break;
+      case 'test_result':
+        testResults.push({
+          command: e.command || null,
+          status: e.status || 'unknown',
+          summary: e.result || e.summary || '',
+        });
+        break;
+      case 'decision':
+        decisions.push(e.summary || '(판단 미기재)');
+        break;
+      case 'blocked':
+        blocked.push(e.summary || '(막힘 사유 미기재)');
+        break;
+      default:
+        break;
+    }
+  }
+
+  const completed = dedup(completedSteps).slice(-lim.completed_steps);
+  const completedIds = new Set(
+    completed.map(s => String(s).split(':')[0].trim()));
+
+  return {
+    completed_steps: completed,
+    // 시작했지만 완료 기록이 없는 단계 = 미완료 단계(재개 프롬프트의 "다음 할 일")
+    pending_steps: dedup(startedSteps).filter(s => !completedIds.has(s)).slice(0, lim.completed_steps),
+    files_read: dedup(filesRead).slice(0, lim.files_read),
+    files_changed: dedup(filesChanged).slice(0, lim.files_changed),
+    commands_run: dedup(commandsRun).slice(-lim.commands_run),
+    test_results: dedup(testResults).slice(-lim.test_results),
+    decisions: dedup(decisions).slice(-10),
+    blocked: dedup(blocked).slice(-10),
+    event_count: events.length,
+  };
+}
+
+module.exports = {
+  EVENT_TYPES,
+  PROTECTED_TYPES,
+  LIMITS,
+  eventPath,
+  appendProgressEvent,
+  readProgressEvents,
+  summarizeProgressEvents,
+  clearProgressEvents,
+  normalizeEvent,
+  pruneEvents,
+};

--- a/slack-bot/prompt-templates.js
+++ b/slack-bot/prompt-templates.js
@@ -1,5 +1,5 @@
 /**
- * prompt-templates.js — 고정 prefix 를 갖는 프롬프트 중앙 관리 (giip-1063, 3.6)
+ * prompt-templates.js — 고정 prefix 를 갖는 프롬프트 중앙 관리 (giip-1063 3.6 / giip-1068 4)
  *
  * 프롬프트 캐시가 지원되는 모델에서 캐시 적중률을 높이려면, 매 호출마다 바뀌는 값이
  * 프롬프트 앞부분에 있으면 안 된다. 그래서 아래 순서를 강제한다.
@@ -12,10 +12,17 @@
  *   6. 태스크 내용
  *   7. checkpoint 및 동적 상태  ← 현재 시각/taskID/브랜치/재시도 번호/변경 파일은 전부 여기
  *
+ * giip-1068: 최초 실행과 fallback 재개를 완전히 다른 함수로 분리했다.
+ *   buildInitialExecutionPrompt() — 전체 태스크 사양 + 선택 컨텍스트 전체
+ *   buildResumeExecutionPrompt()  — 태스크 "요약" + 재개 전용 컨텍스트(최대 3개) + 진행 상태
+ * 재개 프롬프트는 최초 프롬프트의 60% 를 넘지 않도록 조립 단계에서 잘라낸다.
+ *
  * 템플릿을 바꿀 때만 PROMPT_VERSION 을 올린다.
  */
 
-const PROMPT_VERSION = 'fde-cost-v1';
+const modelConfig = require('./model-config');
+
+const PROMPT_VERSION = 'fde-cost-v2';
 
 // ── 1. 고정 시스템 역할 ──────────────────────────────────────────────────────
 const SYSTEM_ROLE = `You are a senior software engineer working in a GIIP FDE Agent workspace.
@@ -29,6 +36,38 @@ const SAFETY_RULES = `=== 안전 규칙 (고정) ===
 - .env 내용, API key, 토큰, 인증정보를 출력·로그·보고서에 남기지 마라.
 - 비용 절감을 이유로 테스트와 검증을 생략하지 마라. 최소 1건의 재현 검증을 반드시 수행하라.
 - 실패를 성공으로 보고하지 마라. 부분 완료면 부분 완료라고 써라.`;
+
+// ── 재개 전용 안전 규칙 (giip-1068 4.4-2) ────────────────────────────────────
+const RESUME_SAFETY_RULES = `=== 재개 전용 안전 규칙 (고정) ===
+- 아래 "완료된 단계"를 다시 실행하지 마라. 완료 단계의 재실행은 0회여야 한다.
+- 아래 "이미 변경한 파일"을 전면 재작성하지 마라. 필요한 부분만 이어서 고쳐라.
+- 작업 트리의 기존 변경은 이전 시도의 결과다. 되돌리거나 덮어쓰지 마라.
+- 태스크 전체 사양이 아니라 아래 "태스크 요약"과 "미완료 단계"만 근거로 이어서 진행하라.
+  더 자세한 사양이 정말 필요하면 태스크 파일 경로를 직접 읽어라(프롬프트에 다시 싣지 않는다).
+- git 커밋·push·PR·브랜치 전환은 하지 마라. .env/API key/토큰을 출력하지 마라.
+- 실패를 성공으로 보고하지 마라.`;
+
+// ── 5.5 진행 이벤트 기록 규칙 (고정) ─────────────────────────────────────────
+const PROGRESS_EVENT_RULES = `=== 진행 이벤트 기록 (고정, 필수) ===
+각 중요 단계가 끝날 때 진행 이벤트를 기록하라. 이 기록이 없으면 중간에 실패했을 때 다음 모델이
+처음부터 다시 하게 되어 비용이 두 배로 든다.
+
+필수 기록 시점:
+1. 계획 단계 시작        → --type step_started
+2. 각 계획 단계 완료      → --type step_completed
+3. 파일을 처음 읽었을 때   → --type file_read
+4. 파일을 실제로 변경했을 때 → --type file_changed
+5. 명령이나 테스트를 실행했을 때 → --type command_run / --type test_result
+6. 중요한 판단을 했을 때   → --type decision
+7. 막힘이 발생했을 때     → --type blocked
+
+JSON 파일을 직접 편집하지 말고 반드시 아래 전용 CLI 를 써라(입력 검증·비밀값 마스킹이 들어 있다).
+
+  node <slack-bot>/tools/progress-event.js --task <task-id> --attempt <n> --type <type> \\
+    --step <step-id> --path <상대경로> --summary "<한 줄 요약>"
+
+정확한 명령은 아래 "동적 상태" 절의 progress_event_command 를 그대로 쓴다.
+--path 는 저장소 기준 상대경로로 적는다(절대경로 금지). --summary 는 500자 이내.`;
 
 // ── 3. 고정 실행 프로토콜 ────────────────────────────────────────────────────
 const EXECUTION_PROTOCOL = `=== 실행 프로토콜 (고정) ===
@@ -76,12 +115,129 @@ const FAST_PATH_PROTOCOL = `=== Fast Path 실행 프로토콜 (고정, 단순 �
 5. 작업이 위 범위를 넘어선다고 판단되면(3개 초과 파일, 인증/보안/DB/배포 변경, 삭제·대량 변경)
    즉시 중단하고 결과 보고서에 "Fast Path 부적합 — 일반 경로로 승격 필요"라고 명시하라.`;
 
+// 재개 전용 실행 프로토콜 — 전체 프로토콜을 다시 싣지 않는다(길이 절감).
+const RESUME_PROTOCOL = `=== 재개 실행 프로토콜 (고정) ===
+1. 아래 "미완료 단계"의 첫 항목부터 이어서 수행한다. 완료된 단계는 건너뛴다.
+2. "이미 변경한 파일"은 현재 작업 트리에 그대로 있다. 필요하면 읽어서 확인만 하고 다시 쓰지 마라.
+3. 테스트 단계에서 실패했다면 구현을 처음부터 다시 하지 말고 실패한 검증부터 처리한다.
+4. 진행 이벤트를 계속 기록한다(아래 progress_event_command).
+5. 완료되면 "동적 상태"의 result_report_path 에 결과 보고서를 작성한다. 이전 시도에서 이미
+   보고서가 있으면 새로 쓰지 말고 이어서 갱신한다.`;
+
 function section(title, body) {
   return body && String(body).trim() ? `\n\n${title}\n${String(body).trim()}` : '';
 }
 
+// ── 태스크 사양 축약 (4.4) ───────────────────────────────────────────────────
+const TASK_SUMMARY_LIMITS = {
+  purposeChars: 500,
+  successConditions: 10,
+  impactTargets: 20,
+  prohibitions: 10,
+  totalChars: 3000,
+};
+
+function bulletItems(block, max) {
+  if (!block) return [];
+  return String(block)
+    .split(/\r?\n/)
+    .map(l => l.trim())
+    .filter(l => /^(\d+[.)]|[-*•])\s+\S/.test(l))
+    .map(l => l.replace(/^(\d+[.)]|[-*•])\s+/, '').trim())
+    .filter(Boolean)
+    .slice(0, max);
+}
+
+function sectionBody(text, headingRe) {
+  const m = String(text || '').match(headingRe);
+  return m ? m[1] : '';
+}
+
 /**
- * 실행 프롬프트. 1~3 은 완전히 고정된 문자열이므로 태스크가 달라도 prefix 가 동일하다.
+ * 전체 태스크 사양 → 재개 프롬프트용 요약(4.4).
+ * 전체 taskContent 를 그대로 싣지 않기 위한 핵심 함수. 전체 상한 3,000자.
+ */
+function summarizeTaskSpec(taskContent, opts = {}) {
+  const lim = { ...TASK_SUMMARY_LIMITS, ...(opts.limits || {}) };
+  const text = String(taskContent || '');
+  // frontmatter 는 재개에 필요 없다(경로/등급은 동적 상태 절에 따로 들어간다).
+  const body = text.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n/, '');
+
+  const title = (body.match(/^#\s*TASK:\s*(.+)$/m) || body.match(/^#\s+(.+)$/m) || [, ''])[1] || '';
+
+  let purpose = sectionBody(body, /##\s*(?:요청\s*내용|목적|概要|Request)[^\n]*\n([\s\S]*?)(?=\n##\s|$)/i).trim();
+  if (!purpose) {
+    purpose = body.replace(/^#[^\n]*\n/, '').split(/\n##\s/)[0].trim();
+  }
+  purpose = `${title ? `${title} — ` : ''}${purpose}`.replace(/\s+/g, ' ').trim().slice(0, lim.purposeChars);
+
+  const success = bulletItems(
+    sectionBody(body, /##\s*(?:실행\s*계획|성공\s*조건|완료\s*조건|Steps?|Plan)[^\n]*\n([\s\S]*?)(?=\n##\s|$)/i),
+    lim.successConditions);
+  const impact = bulletItems(
+    sectionBody(body, /##\s*(?:영향\s*파일[^\n]*|영향\s*대상|대상\s*파일|Impact)[^\n]*\n([\s\S]*?)(?=\n##\s|$)/i),
+    lim.impactTargets);
+  const prohibitions = bulletItems(
+    sectionBody(body, /##\s*(?:주의사항|금지사항|제약|Notes?|Caution)[^\n]*\n([\s\S]*?)(?=\n##\s|$)/i),
+    lim.prohibitions);
+
+  const lines = ['## 태스크 요약'];
+  lines.push(`- 목적: ${purpose || '(태스크 파일 참조)'}`);
+  if (success.length) {
+    lines.push('- 성공 조건:');
+    success.forEach((s, i) => lines.push(`  ${i + 1}. ${s.slice(0, 200)}`));
+  }
+  if (impact.length) {
+    lines.push('- 영향 대상:');
+    impact.forEach(s => lines.push(`  - ${s.slice(0, 200)}`));
+  }
+  if (prohibitions.length) {
+    lines.push('- 금지사항:');
+    prohibitions.forEach(s => lines.push(`  - ${s.slice(0, 200)}`));
+  }
+
+  let out = lines.join('\n');
+  if (out.length > lim.totalChars) out = `${out.slice(0, lim.totalChars - 20)}\n…(요약 상한 초과)`;
+  return out;
+}
+
+// ── 길이 상한 적용 ───────────────────────────────────────────────────────────
+/**
+ * 조립된 파트들을 예산 안으로 줄인다. 우선순위가 낮은 파트부터 잘라낸다.
+ * 고정 파트(역할/안전규칙/프로토콜/동적 상태)는 자르지 않는다.
+ */
+const MIN_RESUME_PROMPT_CHARS = 3000;
+
+const RESUME_TRIM_ORDER = [
+  'resume_context', 'diff_summary', 'files_read', 'prev_error',
+  'commands', 'test_results', 'decisions', 'task_summary', 'files_changed', 'completed_steps',
+];
+
+function joinParts(parts) {
+  return parts.filter(p => p.text && String(p.text).trim()).map(p => p.text).join('');
+}
+
+function fitParts(parts, budget, trimOrder) {
+  let out = joinParts(parts);
+  if (out.length <= budget) return { text: out, trimmed: [] };
+  const trimmed = [];
+  for (const name of trimOrder) {
+    if (out.length <= budget) break;
+    const p = parts.find(x => x.name === name && x.text && x.text.length > 0);
+    if (!p) continue;
+    const over = out.length - budget;
+    if (p.text.length <= over + 60) { p.text = ''; }
+    else { p.text = `${p.text.slice(0, p.text.length - over - 40)}\n…(길이 제한으로 생략)`; }
+    trimmed.push(name);
+    out = joinParts(parts);
+  }
+  if (out.length > budget) out = `${out.slice(0, budget - 30)}\n…(프롬프트 상한 초과分 생략)`;
+  return { text: out, trimmed };
+}
+
+// ── 최초 실행 프롬프트 (4.3) ─────────────────────────────────────────────────
+/**
+ * 최초 실행 프롬프트. 1~3 은 완전히 고정된 문자열이므로 태스크가 달라도 prefix 가 동일하다.
  *
  * @param {object} p
  *  - fastPath        {boolean} Fast Path 프로토콜 사용
@@ -91,27 +247,30 @@ function section(title, body) {
  *  - taskContent     {string}  태스크 사양(계획 포함)
  *  - kLayerClaims    {string[]}
  *  - taskId, branch, resultFile, isn, addCommentScript, attempt, taskClass, now
- *  - resumeInstruction {string|null} checkpoint 재개 지시문
+ *  - progressEventCommand {string|null}
+ *  - resumeInstruction {string|null} (하위 호환 — 재개는 buildResumeExecutionPrompt 를 쓸 것)
  */
-function buildExecutionPrompt(p = {}) {
-  const out = [];
+function buildInitialExecutionPrompt(p = {}) {
+  const parts = [];
+  const push = (name, text) => parts.push({ name, text });
 
   // 1~3: 고정
-  out.push(SYSTEM_ROLE);
-  out.push(`\nprompt_version: ${PROMPT_VERSION}`);
-  out.push(`\n${SAFETY_RULES}`);
-  out.push(`\n${p.fastPath ? FAST_PATH_PROTOCOL : EXECUTION_PROTOCOL}`);
+  push('role', SYSTEM_ROLE);
+  push('version', `\nprompt_version: ${PROMPT_VERSION}`);
+  push('safety', `\n${SAFETY_RULES}`);
+  push('protocol', `\n${p.fastPath ? FAST_PATH_PROTOCOL : EXECUTION_PROTOCOL}`);
+  push('progress_rules', `\n\n${PROGRESS_EVENT_RULES}`);
 
   // 4: 선택된 컨텍스트 (같은 태스크를 재시도해도 동일 → 재시도 간 캐시 적중)
-  out.push(section('=== 선택된 컨텍스트 (role/rule/skill — 이 태스크에 관련된 것만) ===',
+  push('context', section('=== 선택된 컨텍스트 (role/rule/skill — 이 태스크에 관련된 것만) ===',
     p.contextText || '(선택된 컨텍스트 없음 — 최소 기본 규칙만 적용)'));
   if (Array.isArray(p.contextFiles) && p.contextFiles.length) {
-    out.push(section('=== 컨텍스트 선택 사유 ===',
+    push('context_reasons', section('=== 컨텍스트 선택 사유 ===',
       p.contextFiles.map(f => `- ${f.path} — ${f.reason}`).join('\n')));
   }
 
   // 5: 프로젝트 정보
-  out.push(section('=== 프로젝트 정보 ===', [
+  push('project', section('=== 프로젝트 정보 ===', [
     `project: ${p.projectName || '(unknown)'}`,
     `working_directory: ${p.baseDir || ''}`,
     `base_branch: ${p.baseBranch || ''}`,
@@ -119,12 +278,31 @@ function buildExecutionPrompt(p = {}) {
   ].join('\n')));
 
   // 6: 태스크 내용
-  out.push(section('=== 태스크 ===', p.taskContent || ''));
+  push('task', section('=== 태스크 ===', p.taskContent || ''));
   if (Array.isArray(p.kLayerClaims) && p.kLayerClaims.length) {
-    out.push(section('=== K-Layer 지식 ===', p.kLayerClaims.map(c => `• ${c}`).join('\n')));
+    push('klayer', section('=== K-Layer 지식 ===', p.kLayerClaims.map(c => `• ${c}`).join('\n')));
   }
 
   // 7: 동적 상태 (매 호출 달라지는 값은 전부 여기)
+  push('dynamic', section('=== 동적 상태 ===', dynamicState(p).join('\n')));
+
+  if (p.resumeInstruction) {
+    push('resume_legacy', section('=== 이어서 재개 (checkpoint) ===', p.resumeInstruction));
+  }
+
+  push('tail', '\n\n지금 바로 작업을 시작하세요.');
+
+  const budget = (p.limits && p.limits.initialMaxChars)
+    || modelConfig.promptLimits(p.taskClass).initialMaxChars;
+  const { text, trimmed } = fitParts(parts, budget,
+    ['context', 'klayer', 'task', 'context_reasons']);
+  if (trimmed.length) {
+    console.warn(`[prompt] 최초 프롬프트가 ${p.taskClass || 'standard'} 상한(${budget}자)을 넘어 축약: ${trimmed.join(', ')}`);
+  }
+  return text;
+}
+
+function dynamicState(p) {
   const dyn = [
     `task_id: ${p.taskId || ''}`,
     `task_class: ${p.taskClass || 'standard'}`,
@@ -133,20 +311,124 @@ function buildExecutionPrompt(p = {}) {
     `now: ${p.now || new Date().toISOString()}`,
     `result_report_path: ${p.resultFile || ''}`,
   ];
+  if (p.progressEventCommand) dyn.push(`progress_event_command: ${p.progressEventCommand}`);
   if (p.isn) {
     dyn.push(`giip_isn: ${p.isn}`);
     if (p.addCommentScript) {
       dyn.push(`progress_comment_command: pwsh -File "${p.addCommentScript}" -isn ${p.isn} -content "<본문>" -issuetype note -author "slack-bot"`);
     }
   }
-  out.push(section('=== 동적 상태 ===', dyn.join('\n')));
+  return dyn;
+}
 
-  if (p.resumeInstruction) {
-    out.push(section('=== 이어서 재개 (checkpoint) ===', p.resumeInstruction));
+// ── 재개 프롬프트 (4.4) ──────────────────────────────────────────────────────
+function listBlock(items, max, prefix = '  - ') {
+  const list = (items || []).slice(0, max);
+  if (!list.length) return '';
+  const extra = (items || []).length > max ? `\n${prefix}…외 ${(items || []).length - max}건` : '';
+  return list.map(i => `${prefix}${typeof i === 'string' ? i : JSON.stringify(i)}`).join('\n') + extra;
+}
+
+/**
+ * fallback 재개 프롬프트. 전체 taskContent 와 최초 선택 컨텍스트 전체를 절대 싣지 않는다.
+ *
+ * @param {object} p
+ *  - taskSummary        {string}   summarizeTaskSpec() 결과 (없으면 taskContent 로부터 생성)
+ *  - taskContent        {string}   (taskSummary 미지정 시 축약용)
+ *  - completedSteps     {string[]}
+ *  - pendingSteps       {string[]}
+ *  - filesRead          {string[]}
+ *  - filesChanged       {string[]} 실제 소스 변경 파일(상대경로)
+ *  - diffSummary        {string}
+ *  - commandsRun        {string[]}
+ *  - testResults        {Array}
+ *  - decisions          {string[]}
+ *  - blocked            {string[]}
+ *  - errorSummary       {string}
+ *  - resumeContextText  {string}   resume-context-builder 결과 (최대 3~4개 파일)
+ *  - resumeContextFiles {Array}
+ *  - taskClass, taskId, branch, attempt, now, resultFile, isn, addCommentScript,
+ *    projectName, baseBranch, langName, progressEventCommand
+ *  - initialPromptChars {number}   최초 프롬프트 길이(60% 규칙 적용용)
+ */
+function buildResumeExecutionPrompt(p = {}) {
+  const parts = [];
+  const push = (name, text) => parts.push({ name, text });
+
+  // 1~2: 고정 역할 + 재개 전용 안전 규칙
+  push('role', SYSTEM_ROLE);
+  push('version', `\nprompt_version: ${PROMPT_VERSION} (resume)`);
+  push('safety', `\n${RESUME_SAFETY_RULES}`);
+  push('protocol', `\n\n${RESUME_PROTOCOL}`);
+
+  // 3: 태스크 요약 (전체 사양 아님)
+  const summary = p.taskSummary || summarizeTaskSpec(p.taskContent || '');
+  push('task_summary', section('=== 태스크 요약 (전체 사양 아님) ===', summary));
+
+  // 4~5: 완료 / 미완료 단계
+  push('completed_steps', section('=== 완료된 단계 (다시 하지 마라) ===',
+    listBlock(p.completedSteps, 30) || '(기록된 완료 단계 없음)'));
+  push('pending_steps', section('=== 미완료 단계 (여기부터 이어서) ===',
+    listBlock(p.pendingSteps, 30) || '(진행 이벤트에 미완료 단계 기록 없음 — 변경 파일과 오류로 판단하라)'));
+
+  // 6~7: 이미 읽은 파일 / 이미 변경한 파일
+  push('files_read', section('=== 이미 읽은 파일 (다시 통독하지 마라) ===', listBlock(p.filesRead, 40)));
+  push('files_changed', section('=== 이미 변경한 파일 (전면 재작성 금지) ===',
+    listBlock(p.filesChanged, 40) || '(실제 소스 변경 없음)'));
+
+  // 8: 변경 diff 요약
+  push('diff_summary', section('=== 변경 diff 요약 ===', p.diffSummary || ''));
+
+  // 9~10: 실행한 명령 / 테스트 결과
+  push('commands', section('=== 실행한 명령 ===', listBlock(p.commandsRun, 20)));
+  push('test_results', section('=== 테스트 결과 ===',
+    listBlock((p.testResults || []).map(t => (typeof t === 'string'
+      ? t
+      : `${t.command || '(명령 미기재)'} → ${t.status || 'unknown'}${t.summary ? ` — ${t.summary}` : ''}`)), 20)));
+  push('decisions', section('=== 이전 판단 / 막힘 ===',
+    [listBlock(p.decisions, 10), listBlock(p.blocked, 10, '  ! ')].filter(Boolean).join('\n')));
+
+  // 11: 이전 오류
+  push('prev_error', section('=== 이전 오류 (마스킹됨) ===',
+    p.errorSummary ? String(p.errorSummary).slice(-1200) : ''));
+
+  // 12: 재개에 필요한 컨텍스트만
+  push('resume_context', section('=== 재개 컨텍스트 (최초 선택 전체가 아니라 재개에 필요한 것만) ===',
+    p.resumeContextText || ''));
+  if (Array.isArray(p.resumeContextFiles) && p.resumeContextFiles.length) {
+    push('resume_context_reasons', section('=== 재개 컨텍스트 선택 사유 ===',
+      p.resumeContextFiles.map(f => `- ${f.path} — ${f.reason}`).join('\n')));
   }
 
-  out.push('\n\n지금 바로 작업을 시작하세요.');
-  return out.join('');
+  // 13: 현재 동적 상태
+  push('dynamic', section('=== 동적 상태 ===', [
+    ...dynamicState(p),
+    `prompt_type: resume`,
+    p.taskFilePath ? `task_spec_file: ${p.taskFilePath} (필요할 때만 직접 읽어라)` : '',
+  ].filter(Boolean).join('\n')));
+
+  push('tail', '\n\n미완료 단계부터 즉시 이어서 작업하세요.');
+
+  const limits = p.limits || modelConfig.promptLimits(p.taskClass);
+  let budget = limits.resumeMaxChars;
+  const initialChars = Number(p.initialPromptChars) || 0;
+  if (initialChars > 0) {
+    // 60% 규칙(2.2). 다만 고정 역할·안전규칙·프로토콜이 잘려나갈 정도로 작아지지는 않게 바닥을 둔다.
+    // 바닥(3,000자)이 실제로 걸리는 구간(최초 5,000자 미만)은 2.2 의 "12,000자 이하" 예외 구간이라
+    // 애초에 재개 프롬프트 대신 동일 프롬프트 재사용이 허용된다(판정은 task-manager).
+    budget = Math.max(MIN_RESUME_PROMPT_CHARS,
+      Math.min(budget, Math.floor(initialChars * limits.resumeMaxRatio)));
+  }
+  const { text, trimmed } = fitParts(parts, budget, RESUME_TRIM_ORDER);
+  if (trimmed.length) {
+    console.log(`[prompt] 재개 프롬프트를 ${budget}자 예산에 맞춰 축약: ${trimmed.join(', ')}`);
+  }
+  return text;
+}
+
+/** 하위 호환. 기존 호출부는 최초 실행 프롬프트를 만든다. */
+function buildExecutionPrompt(options) {
+  return buildInitialExecutionPrompt(options);
 }
 
 // ── 분석(계획) 프롬프트 ──────────────────────────────────────────────────────
@@ -215,10 +497,18 @@ module.exports = {
   PROMPT_VERSION,
   SYSTEM_ROLE,
   SAFETY_RULES,
+  RESUME_SAFETY_RULES,
+  PROGRESS_EVENT_RULES,
   EXECUTION_PROTOCOL,
+  RESUME_PROTOCOL,
   FAST_PATH_PROTOCOL,
   ANALYSIS_ROLE,
   ANALYSIS_FORMAT,
+  TASK_SUMMARY_LIMITS,
+  MIN_RESUME_PROMPT_CHARS,
+  summarizeTaskSpec,
+  buildInitialExecutionPrompt,
+  buildResumeExecutionPrompt,
   buildExecutionPrompt,
   buildAnalysisPrompt,
   buildContextSelectionPrompt,

--- a/slack-bot/resume-context-builder.js
+++ b/slack-bot/resume-context-builder.js
@@ -1,0 +1,127 @@
+/**
+ * resume-context-builder.js — fallback 재개 프롬프트에 실을 최소 컨텍스트 선택 (giip-1068, 4.5)
+ *
+ * 재개 프롬프트에는 최초 선택 컨텍스트 전체를 다시 넣지 않는다.
+ * 다음 우선순위로 최대 3개(critical 4개) 파일/섹션만 고른다.
+ *
+ *   1. 실패한 단계와 직접 연결된 rule/skill
+ *   2. 다음 미완료 단계에 필요한 role/skill
+ *   3. 실패한 파일과 직접 연결된 프로젝트 규칙
+ *
+ * 상한(일반 / critical)
+ *   파일 수      3 / 4
+ *   파일당 문자   3,000 / 4,000
+ *   전체 문자     8,000 / 14,000
+ */
+
+const path = require('path');
+
+const modelConfig = require('./model-config');
+const ctxBuilder = require('./context-builder');
+
+/** 파일 확장 없는 이름 토큰(경로 매칭용). */
+function baseTokens(p) {
+  const b = path.basename(String(p || '')).toLowerCase();
+  return [b, b.replace(/\.[^.]+$/, '')].filter(Boolean);
+}
+
+/**
+ * 재개에 필요한 컨텍스트 파일을 고른다.
+ *
+ * @param {object} p
+ *  - initialSelection {Array<{path,reason,max_chars}>} 최초 실행에서 선택했던 컨텍스트
+ *  - failedStep       {string}   실패한 단계 설명
+ *  - pendingSteps     {string[]} 미완료 단계
+ *  - changedFiles     {string[]} 이미 변경한 소스 파일
+ *  - errorSummary     {string}   이전 오류 요약
+ *  - taskClass        {string}
+ * @returns {Array<{path, reason, max_chars, priority}>}
+ */
+function selectResumeContext(p = {}) {
+  const limits = modelConfig.resumeContextLimits(p.taskClass);
+  const initial = (p.initialSelection || []).filter(f => f && f.path);
+  if (!initial.length) return [];
+
+  const failText = [p.failedStep || '', (p.pendingSteps || []).join(' '), p.errorSummary || '']
+    .join(' ').toLowerCase();
+  const failTerms = new Set(ctxBuilder.tokenize(failText));
+  const changed = (p.changedFiles || []).map(f => String(f).toLowerCase());
+  const changedTerms = new Set();
+  for (const f of changed) for (const t of baseTokens(f)) changedTerms.add(t);
+
+  const scored = initial.map((f, i) => {
+    const rel = String(f.path).replace(/\\/g, '/');
+    const low = rel.toLowerCase();
+    const isRule = /\/rules?\//.test(low) || /\brule/.test(low);
+    const isSkill = /\/skills?\//.test(low) || /skill\.md$/.test(low);
+    const isRole = /\/roles?\//.test(low);
+
+    const hay = new Set(ctxBuilder.tokenize(`${rel} ${f.reason || ''}`));
+    let overlap = 0;
+    for (const t of hay) if (failTerms.has(t)) overlap += 1;
+
+    let priority = 4;                       // 기본: 우선순위 밖
+    let reason = f.reason || '(사유 미기재)';
+    if (overlap > 0 && (isRule || isSkill)) {
+      priority = 1;
+      reason = `실패한 단계와 직접 연결된 ${isRule ? 'rule' : 'skill'} — ${reason}`;
+    } else if (overlap > 0 && (isRole || isSkill)) {
+      priority = 2;
+      reason = `다음 미완료 단계에 필요한 ${isRole ? 'role' : 'skill'} — ${reason}`;
+    } else {
+      let touches = 0;
+      for (const t of hay) if (changedTerms.has(t)) touches += 1;
+      if (touches > 0) {
+        priority = 3;
+        reason = `이미 변경한 파일과 직접 연결된 규칙 — ${reason}`;
+      } else if (isRule) {
+        // 실패와 직접 연결되진 않지만 "요청 범위 밖 수정 금지" 같은 공통 가드레일은 남긴다.
+        priority = 3.5;
+        reason = `재개 시에도 지켜야 할 공통 규칙 — ${reason}`;
+      }
+    }
+    return { f, i, priority, overlap, reason };
+  });
+
+  scored.sort((a, b) => a.priority - b.priority || b.overlap - a.overlap || a.i - b.i);
+
+  return scored
+    .filter(s => s.priority <= 3.5)
+    .slice(0, limits.maxFiles)
+    .map(s => ({
+      path: String(s.f.path).replace(/\\/g, '/'),
+      reason: s.reason,
+      max_chars: limits.perFileMaxChars,
+      priority: s.priority,
+    }));
+}
+
+/**
+ * 고른 파일을 실제로 읽어 재개 프롬프트용 문자열을 만든다.
+ * @returns {{context:string, filesRead:Array, stats:object, limits:object}}
+ */
+function readResumeContext(selected, baseDir, opts = {}) {
+  const limits = modelConfig.resumeContextLimits(opts.taskClass);
+  if (!selected || !selected.length) {
+    return { context: '', filesRead: [], stats: { files: 0, chars: 0 }, limits };
+  }
+  const r = ctxBuilder.readSelectedContext(selected.slice(0, limits.maxFiles), baseDir, {
+    workspaceDir: opts.workspaceDir || baseDir,
+    queryText: opts.queryText || '',
+    limits: {
+      minFiles: 0,
+      defaultMaxFiles: limits.maxFiles,
+      hardMaxFiles: limits.maxFiles,
+      perFileMaxChars: limits.perFileMaxChars,
+      totalMaxChars: limits.totalMaxChars,
+    },
+  });
+  // 상한을 1자라도 넘지 않도록 최종 방어 클립(테스트 F 기준).
+  let context = r.context;
+  if (context.length > limits.totalMaxChars) {
+    context = `${context.slice(0, limits.totalMaxChars - 30)}\n…(재개 컨텍스트 상한 초과分 생략)`;
+  }
+  return { context, filesRead: r.filesRead, stats: { ...r.stats, chars: context.length }, limits };
+}
+
+module.exports = { selectResumeContext, readResumeContext };

--- a/slack-bot/retry-checkpoint.js
+++ b/slack-bot/retry-checkpoint.js
@@ -1,15 +1,20 @@
 /**
- * retry-checkpoint.js — 재시도 시 전체 재실행 방지 (giip-1063, 3.5)
+ * retry-checkpoint.js — 재시도 시 전체 재실행 방지 (giip-1063 3.5 / giip-1068 3·6·7)
  *
  * 기존: MiniMax 가 실패하면 같은 executionPrompt 전체를 Claude 에 그대로 다시 보내고
  *       태스크를 처음부터 실행 → 이미 끝낸 파일 수정을 다음 모델이 다시 전면 작성.
  *
- * 여기서: 시도마다 진행 상태를 `.agent/runtime/checkpoints/<task-id>.json` 에 남기고,
- *       재시도 프롬프트에는 "원문 전체" 대신 태스크 사양 + 선택 컨텍스트 + checkpoint 요약만
- *       실어 이어서 재개시킨다.
+ * 여기서: 시도마다 진행 상태를 `<runtimeRoot>/checkpoints/<task-id>.json` 에 남기고,
+ *       재시도 프롬프트에는 "원문 전체" 대신 태스크 요약 + 진행 상태 + 재개 컨텍스트만 싣는다.
+ *
+ * giip-1068 추가
+ *   - `changedSourceFiles()`: 태스크/결과/런타임/봇상태 파일을 "실제 소스 변경"에서 제외한다.
+ *   - `recordFailure()` 가 progress-events 를 읽어 completed_steps / files_read / commands_run /
+ *     test_results 를 실제로 채운다(1차 작업에서는 항상 빈 배열이었다).
+ *   - checkpoint 저장 위치를 runtime-paths.runtimeRoot() 로 통일한다(비용 로그와 같은 루트).
  *
  * 안전: checkpoint 에 API key / Slack token / 인증정보를 저장하지 않는다(secret-mask 통과).
- *       런타임 디렉터리는 .gitignore 대상.
+ *       절대경로를 그대로 남기지 않는다(7.2). 런타임 디렉터리는 .gitignore 대상.
  */
 
 const fs = require('fs');
@@ -18,20 +23,22 @@ const { spawnSync } = require('child_process');
 
 const { maskDeep, maskString } = require('./secret-mask');
 const modelConfig = require('./model-config');
+const runtimePaths = require('./runtime-paths');
+const progressEvents = require('./progress-events');
 
+// 하위 호환용 상수(경로 문자열을 참조하는 테스트/스크립트가 있다).
 const RUNTIME_SUBDIR = path.join('.agent', 'runtime', 'checkpoints');
 
 function checkpointDir(baseDir) {
-  return path.join(baseDir, RUNTIME_SUBDIR);
+  return runtimePaths.checkpointsDir(baseDir);
 }
 
 function checkpointPath(baseDir, taskId) {
-  const safe = String(taskId).replace(/[^\w.\-]/g, '_');
-  return path.join(checkpointDir(baseDir), `${safe}.json`);
+  return path.join(checkpointDir(baseDir), `${runtimePaths.safeTaskId(taskId)}.json`);
 }
 
 function ensureDir(baseDir) {
-  try { fs.mkdirSync(checkpointDir(baseDir), { recursive: true }); } catch {}
+  runtimePaths.ensureDir(checkpointDir(baseDir));
 }
 
 // ── 오류 분류 ────────────────────────────────────────────────────────────────
@@ -48,7 +55,7 @@ function classifyError(output) {
 }
 
 // ── 작업 트리 상태 ───────────────────────────────────────────────────────────
-/** 현재 브랜치에서 실제로 바뀐 파일 목록(재개 판단 근거). 실패해도 빈 배열. */
+/** 현재 브랜치에서 실제로 바뀐 파일 목록(원본 — 분류 전). 실패해도 빈 배열. */
 function changedFiles(cwd) {
   try {
     const r = spawnSync('git', ['status', '--porcelain'], { cwd, encoding: 'utf8', windowsHide: true });
@@ -57,8 +64,86 @@ function changedFiles(cwd) {
       .split(/\r?\n/)
       .map(l => l.slice(3).trim())
       .filter(Boolean)
+      .map(l => (l.includes(' -> ') ? l.split(' -> ').pop().trim() : l))   // rename 은 새 경로
+      .map(l => l.replace(/^"|"$/g, ''))
+      .filter(Boolean)
       .slice(0, 200);
   } catch { return []; }
+}
+
+// ── 6.3 실제 소스 변경에서 제외할 경로 ───────────────────────────────────────
+/** 태스크 ID 와 무관하게 항상 런타임 산출물인 경로. */
+const RUNTIME_PATTERNS = [
+  /^\.agent\/runtime\//,
+];
+
+/** 봇 자신의 상태 파일(작업 결과가 아니다). */
+const BOT_STATE_FILES = new Set([
+  'slack-bot/tasklist.json',
+  'slack-bot/.task-state.json',
+  'slack-bot/.conversations.json',
+  'slack-bot/.bot-threads.json',
+  'slack-bot/claude-accounts.json',
+  'slack-bot/minimax-accounts.json',
+]);
+
+function norm(p) { return String(p || '').replace(/\\/g, '/').replace(/^\.\//, ''); }
+
+/**
+ * 실제 소스 변경 파일 판정(6.2).
+ *
+ * @param {string} cwd     git 저장소 경로
+ * @param {string} taskId  현재 태스크 ID
+ * @param {object} [options] { files: string[] } — git 호출 대신 목록을 직접 주입(테스트용)
+ * @returns {{sourceFiles:string[], metadataFiles:string[], runtimeFiles:string[],
+ *            reportFiles:string[], botStateFiles:string[], anomalies:string[],
+ *            totalSourceChanges:number}}
+ */
+function changedSourceFiles(cwd, taskId, options = {}) {
+  const all = (options.files || changedFiles(cwd || '.')).map(norm).filter(Boolean);
+  const id = runtimePaths.safeTaskId(taskId);
+  const rawId = String(taskId || '').replace(/\\/g, '/');
+
+  const sourceFiles = [];
+  const metadataFiles = [];
+  const runtimeFiles = [];
+  const reportFiles = [];
+  const botStateFiles = [];
+  const anomalies = [];
+
+  const isCurrentTask = (base) => base === `${id}.md` || (rawId && base === `${rawId}.md`);
+
+  for (const f of all) {
+    if (RUNTIME_PATTERNS.some(re => re.test(f))) { runtimeFiles.push(f); continue; }
+    if (BOT_STATE_FILES.has(f)) { botStateFiles.push(f); continue; }
+
+    const taskMatch = f.match(/^\.agent\/tasks\/(?:done\/)?(.+\.md)$/);
+    if (taskMatch) {
+      if (isCurrentTask(taskMatch[1])) metadataFiles.push(f);
+      else { metadataFiles.push(f); anomalies.push(`다른 태스크 파일이 변경됨: ${f}`); }
+      continue;
+    }
+
+    const resultMatch = f.match(/^\.agent\/results\/(.+\.md)$/);
+    if (resultMatch) {
+      reportFiles.push(f);
+      if (!isCurrentTask(resultMatch[1])) anomalies.push(`다른 태스크의 결과 보고서가 변경됨: ${f}`);
+      continue;
+    }
+
+    // 6.4: 위 제외 경로가 아닌 모든 변경(수정/생성/삭제/rename/nested repo)은 실제 소스 변경.
+    sourceFiles.push(f);
+  }
+
+  return {
+    sourceFiles,
+    metadataFiles,
+    runtimeFiles,
+    reportFiles,
+    botStateFiles,
+    anomalies,
+    totalSourceChanges: sourceFiles.length,
+  };
 }
 
 /** diff --stat 요약(길이 제한). 재개 프롬프트에 넣어 "이미 한 일"을 알린다. */
@@ -77,13 +162,18 @@ function emptyCheckpoint(taskId) {
     attempt: 0,
     provider: null,
     model: null,
+    project_name: null,
+    work_dir: null,
     started_at: null,
     updated_at: null,
     completed_steps: [],
+    pending_steps: [],
     files_read: [],
     files_changed: [],
+    metadata_files_changed: [],
     commands_run: [],
     test_results: [],
+    progress_event_count: 0,
     error_type: null,
     error_summary: null,
     resume_instruction: null,
@@ -118,16 +208,20 @@ function save(baseDir, taskId, patch = {}) {
 }
 
 /** 시도 시작 기록. */
-function beginAttempt(baseDir, taskId, { attempt, provider, model, taskClass = null }) {
+function beginAttempt(baseDir, taskId, { attempt, provider, model, taskClass = null, workDir = null }) {
   const cur = load(baseDir, taskId) || emptyCheckpoint(taskId);
   const history = (cur.history || []).concat([{
     attempt, provider, model, task_class: taskClass, started_at: new Date().toISOString(),
   }]).slice(-10);
+  const dir = workDir || baseDir;
   return save(baseDir, taskId, {
     attempt,
     provider,
     model,
     task_class: taskClass,
+    // 7.2: 프로젝트 구분은 폴더가 아니라 checkpoint 안에 남기고, 절대경로는 저장하지 않는다.
+    project_name: dir ? path.basename(dir) : null,
+    work_dir: runtimePaths.maskWorkDir(dir),
     started_at: cur.started_at || new Date().toISOString(),
     error_type: null,
     error_summary: null,
@@ -135,31 +229,70 @@ function beginAttempt(baseDir, taskId, { attempt, provider, model, taskClass = n
   });
 }
 
-/** 시도 실패 기록 + 작업 트리 상태 스냅샷 + 재개 지시문 생성. */
-function recordFailure(baseDir, taskId, { attempt, provider, model, output, cwd }) {
+/**
+ * 시도 실패 기록 + 진행 이벤트 반영 + 작업 트리 상태 스냅샷 + 재개 지시문 생성.
+ *
+ * giip-1068: `files_changed` 는 실제 소스 변경 파일만 담는다. 태스크/결과/런타임 파일은
+ * `metadata_files_changed` 로 분리해 "작업이 진행됐다"는 오판을 막는다(6.1).
+ */
+function recordFailure(baseDir, taskId, { attempt, provider, model, output, cwd, taskClass = null }) {
   const errorType = classifyError(output);
-  const files = changedFiles(cwd || baseDir);
+  const workDir = cwd || baseDir;
+  const changed = changedSourceFiles(workDir, taskId);
   const summary = maskString(String(output || '').trim()).slice(-1500);
+
+  // 5.6: 진행 이벤트를 읽어 checkpoint 를 실제로 채운다.
+  const events = progressEvents.readProgressEvents(baseDir, taskId);
+  const prog = progressEvents.summarizeProgressEvents(events, modelConfig.checkpointLimits());
+  const lim = modelConfig.checkpointLimits();
+
+  // 진행 이벤트의 file_changed 와 git 이 본 소스 변경을 합친다(둘 다 근거).
+  const filesChanged = Array.from(new Set(prog.files_changed.concat(changed.sourceFiles)))
+    .slice(0, lim.files_changed);
+
   const cp = save(baseDir, taskId, {
     attempt,
     provider,
     model,
-    files_changed: files,
+    task_class: taskClass || (load(baseDir, taskId) || {}).task_class || null,
+    project_name: path.basename(workDir),
+    work_dir: runtimePaths.maskWorkDir(workDir),
+    completed_steps: prog.completed_steps,
+    pending_steps: prog.pending_steps,
+    files_read: prog.files_read,
+    files_changed: filesChanged,
+    metadata_files_changed: changed.metadataFiles.concat(changed.reportFiles).slice(0, 50),
+    runtime_files_changed: changed.runtimeFiles.slice(0, 50),
+    commands_run: prog.commands_run,
+    test_results: prog.test_results,
+    decisions: prog.decisions,
+    blocked: prog.blocked,
+    progress_event_count: events.length,
+    changed_file_anomalies: changed.anomalies,
     error_type: errorType,
     error_summary: summary,
-    diff_stat: diffSummary(cwd || baseDir),
+    diff_stat: diffSummary(workDir),
   });
   return save(baseDir, taskId, { resume_instruction: buildResumeInstruction(cp) });
 }
 
 /** 시도 성공 기록(다음 실행이 "완료된 단계"를 알 수 있도록). */
 function recordSuccess(baseDir, taskId, { attempt, provider, model, cwd, steps = [] }) {
+  const workDir = cwd || baseDir;
+  const events = progressEvents.readProgressEvents(baseDir, taskId);
+  const prog = progressEvents.summarizeProgressEvents(events, modelConfig.checkpointLimits());
+  const changed = changedSourceFiles(workDir, taskId);
   return save(baseDir, taskId, {
     attempt,
     provider,
     model,
-    completed_steps: steps,
-    files_changed: changedFiles(cwd || baseDir),
+    completed_steps: steps.length ? steps : prog.completed_steps,
+    files_read: prog.files_read,
+    files_changed: Array.from(new Set(prog.files_changed.concat(changed.sourceFiles))),
+    metadata_files_changed: changed.metadataFiles.concat(changed.reportFiles),
+    commands_run: prog.commands_run,
+    test_results: prog.test_results,
+    progress_event_count: events.length,
     error_type: null,
     error_summary: null,
     resume_instruction: null,
@@ -171,7 +304,39 @@ function clear(baseDir, taskId) {
   try { fs.rmSync(checkpointPath(baseDir, taskId), { force: true }); } catch {}
 }
 
-// ── 재개 프롬프트 ────────────────────────────────────────────────────────────
+// ── 재개 여부 판정 (4.6 / 6.5) ───────────────────────────────────────────────
+/**
+ * checkpoint 로 "실제 작업이 있었는지" 판정한다.
+ *
+ *   hasRealWork = sourceFiles>0 || completedSteps>0 || commandsRun>0 || testResults>0
+ *
+ * false 면 최초 프롬프트 재사용을 허용하고, true 면 반드시 resume prompt 를 쓴다.
+ */
+function hasRealWork(cp) {
+  if (!cp) return false;
+  return (cp.files_changed || []).length > 0
+      || (cp.completed_steps || []).length > 0
+      || (cp.commands_run || []).length > 0
+      || (cp.test_results || []).length > 0;
+}
+
+/**
+ * resume prompt 를 써야 하는가(4.6).
+ * @param {{exitCode:number, checkpoint:object, checkpointSaved:boolean}} p
+ */
+function shouldResume({ exitCode = 1, checkpoint: cp = null, checkpointSaved = true } = {}) {
+  if (Number(exitCode) === 0) return { resume: false, reason: '실패가 아님' };
+  if (!cp || !checkpointSaved) return { resume: false, reason: 'checkpoint 저장 전 실패 — 최초 프롬프트 재사용' };
+  const real = hasRealWork(cp);
+  if (!real) return { resume: false, reason: '실제 작업 흔적 없음(소스 변경/완료 단계/명령/테스트 모두 0) — 최초 프롬프트 재사용' };
+  const src = (cp.files_changed || []).length;
+  return {
+    resume: true,
+    reason: `실제 진행 있음(소스 변경 ${src}건 / 완료 단계 ${(cp.completed_steps || []).length}건) — 재개 프롬프트 사용`,
+  };
+}
+
+// ── 재개 지시문 (프롬프트 조각) ──────────────────────────────────────────────
 const RESUME_HEADER = [
   '기존 작업 트리의 변경 사항은 이전 시도의 작업 결과다.',
   '먼저 diff와 checkpoint를 확인하고 완료된 작업을 반복하지 마라.',
@@ -180,22 +345,27 @@ const RESUME_HEADER = [
 
 /**
  * checkpoint 로 재개 지시문을 만든다. 전체 원문을 다시 싣지 않는 것이 핵심.
- * 작업 시작 전 실패(파일 변경 0, error_type=not_started/usage_limit + 변경 없음)면 재개 지시 없이
- * 동일 프롬프트를 재사용해도 되므로 null 을 돌려준다.
+ * 실제 작업 흔적이 없으면(hasRealWork=false) null 을 돌려준다 → 동일 프롬프트 재사용.
  */
 function buildResumeInstruction(cp) {
   if (!cp) return null;
+  if (!hasRealWork(cp)) return null;
+
   const changed = cp.files_changed || [];
   const steps = cp.completed_steps || [];
-  const nothingDone = changed.length === 0 && steps.length === 0;
-  if (nothingDone) return null;   // 작업 시작 전 실패 → 동일 프롬프트 재사용 가능
-
   const lines = [RESUME_HEADER, ''];
   lines.push(`이전 시도: attempt=${cp.attempt}, provider=${cp.provider || '?'}, model=${cp.model || '?'}, 실패 유형=${cp.error_type || 'unknown'}`);
   if (steps.length) lines.push(`완료된 단계: ${steps.slice(0, 20).join(' / ')}`);
+  if ((cp.pending_steps || []).length) lines.push(`미완료 단계: ${cp.pending_steps.slice(0, 20).join(' / ')}`);
   if (changed.length) {
     lines.push(`이미 변경된 파일(${changed.length}건):`);
     lines.push(changed.slice(0, 40).map(f => `  - ${f}`).join('\n'));
+  }
+  if ((cp.files_read || []).length) {
+    lines.push(`이미 읽은 파일: ${cp.files_read.slice(0, 20).join(', ')}`);
+  }
+  if ((cp.commands_run || []).length) {
+    lines.push(`실행한 명령: ${cp.commands_run.slice(0, 10).join(' / ')}`);
   }
   if (cp.diff_stat) lines.push(`\ngit diff --stat:\n${cp.diff_stat}`);
   if ((cp.test_results || []).length) {
@@ -233,10 +403,12 @@ module.exports = {
   ERROR_TYPES,
   RESUME_HEADER,
   RUNTIME_SUBDIR,
+  BOT_STATE_FILES,
   checkpointDir,
   checkpointPath,
   classifyError,
   changedFiles,
+  changedSourceFiles,
   diffSummary,
   load,
   save,
@@ -245,6 +417,8 @@ module.exports = {
   recordFailure,
   recordSuccess,
   buildResumeInstruction,
+  hasRealWork,
+  shouldResume,
   canRetry,
   noteAttempt,
   emptyCheckpoint,

--- a/slack-bot/runtime-paths.js
+++ b/slack-bot/runtime-paths.js
@@ -1,0 +1,90 @@
+/**
+ * runtime-paths.js — 런타임 산출물(checkpoint / progress / cost log)의 중앙 경로 (giip-1068, 7)
+ *
+ * 기존 문제
+ *   - 비용 로그는 `config.BASE_DIR` 기준, checkpoint 는 `startExecution()` 에 넘어온 `baseDir` 기준이라
+ *     프로젝트 프리픽스 작업(예: `giipv3 …`)에서 두 산출물이 서로 다른 폴더로 흩어졌다.
+ *
+ * 여기서
+ *   - `runtimeRoot()` 하나로 통일한다. 환경변수 `FDE_RUNTIME_DIR` 가 있으면 그 절대경로,
+ *     없으면 `config.BASE_DIR/.agent/runtime`.
+ *
+ *   .agent/runtime/
+ *   ├── checkpoints/
+ *   ├── progress/
+ *   ├── cost-usage.jsonl
+ *   └── task-index.json
+ *
+ * 프로젝트 구분은 폴더를 쪼개지 않고 checkpoint 안의 `project_name` / `work_dir` 로 남긴다.
+ * `work_dir` 은 절대경로가 아니라 마스킹된 상대경로다(7.2).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+/** config 를 지연 로드한다(순환 참조 및 dotenv 부작용 회피). 실패해도 동작해야 한다. */
+function workspaceRoot() {
+  try {
+    const config = require('./config');
+    if (config && config.BASE_DIR) return config.BASE_DIR;
+  } catch { /* config 로드 실패 시 저장소 루트로 대체 */ }
+  return path.join(__dirname, '..');
+}
+
+/**
+ * 런타임 루트. 인자 없이도 동작한다(= 중앙 기본값).
+ * @param {string} [baseDir] 명시적 기준 디렉터리(FDE_RUNTIME_DIR 가 있으면 무시된다)
+ */
+function runtimeRoot(baseDir) {
+  const override = process.env.FDE_RUNTIME_DIR;
+  if (override && String(override).trim()) return path.resolve(String(override).trim());
+  return path.join(baseDir || workspaceRoot(), '.agent', 'runtime');
+}
+
+function checkpointsDir(baseDir) { return path.join(runtimeRoot(baseDir), 'checkpoints'); }
+function progressDir(baseDir) { return path.join(runtimeRoot(baseDir), 'progress'); }
+function costLogPath(baseDir) { return path.join(runtimeRoot(baseDir), 'cost-usage.jsonl'); }
+function taskIndexPath(baseDir) { return path.join(runtimeRoot(baseDir), 'task-index.json'); }
+
+/** 파일명으로 안전한 task id. */
+function safeTaskId(taskId) {
+  return String(taskId == null ? 'unknown' : taskId).replace(/[^\w.\-]/g, '_').slice(0, 120) || 'unknown';
+}
+
+function ensureDir(dir) {
+  try { fs.mkdirSync(dir, { recursive: true }); return true; } catch { return false; }
+}
+
+/**
+ * 로그·checkpoint 에 남길 작업 디렉터리 표기(7.2).
+ * 절대경로 전체를 남기지 않는다 — PROJECTS_ROOT 하위면 상대경로, 아니면 `…/<basename>`.
+ */
+function maskWorkDir(dir) {
+  const abs = String(dir || '');
+  if (!abs) return '';
+  let roots = [];
+  try {
+    const config = require('./config');
+    roots = [config.PROJECTS_ROOT, config.BASE_DIR].filter(Boolean);
+  } catch { /* config 없이도 동작 */ }
+  for (const root of roots) {
+    const rel = path.relative(root, abs);
+    if (rel && !rel.startsWith('..') && !path.isAbsolute(rel)) {
+      return rel.replace(/\\/g, '/');
+    }
+    if (rel === '') return path.basename(abs);
+  }
+  return `…/${path.basename(abs)}`;
+}
+
+module.exports = {
+  runtimeRoot,
+  checkpointsDir,
+  progressDir,
+  costLogPath,
+  taskIndexPath,
+  safeTaskId,
+  ensureDir,
+  maskWorkDir,
+  workspaceRoot,
+};

--- a/slack-bot/task-manager.js
+++ b/slack-bot/task-manager.js
@@ -18,11 +18,15 @@ const ctxBuilder = require('./context-builder');
 const prompts = require('./prompt-templates');
 const checkpoint = require('./retry-checkpoint');
 const costTracker = require('./cost-tracker');
+// giip-1068 비용 최적화 2차
+const progressEvents = require('./progress-events');
+const resumeCtx = require('./resume-context-builder');
 
 const BASE_DIR = path.join(__dirname, '..');
-// giip-1063: 비용 로그(.agent/runtime/cost-usage.jsonl)는 `!cost` 가 읽는 곳과 같아야 하므로
-// config.BASE_DIR(=WORKSPACE_DIR) 기준으로 통일한다.
-const COST_LOG_DIR = config.BASE_DIR || BASE_DIR;
+// giip-1063/1068: 비용 로그와 checkpoint 는 같은 중앙 runtime root 를 쓴다(7).
+// `!cost` 가 읽는 곳과 checkpoint 저장 위치가 갈라지지 않도록 여기 한 곳에서만 정한다.
+const RUNTIME_BASE_DIR = config.BASE_DIR || BASE_DIR;
+const COST_LOG_DIR = RUNTIME_BASE_DIR;
 const TASKS_DIR = path.join(BASE_DIR, '.agent', 'tasks');
 const RESULTS_DIR = path.join(BASE_DIR, '.agent', 'results');
 const TASKLIST_FILE = path.join(__dirname, 'tasklist.json');
@@ -214,7 +218,8 @@ function buildContextCatalog(baseDir = BASE_DIR) {
  */
 function selectContextFiles(requestText, catalog, baseDir = BASE_DIR, opts = {}) {
   if (!catalog || !catalog.length) return [];
-  const limits = modelConfig.contextLimits();
+  // giip-1068 2.3: 컨텍스트 한도는 작업 등급별이다.
+  const limits = modelConfig.contextLimits(opts.taskClass);
   const staticPick = () => ctxBuilder.selectContextFilesStatic(requestText, catalog, limits);
 
   if (opts.staticOnly) return staticPick();
@@ -310,12 +315,13 @@ function analyzeRequest(requestText, taskId, baseDir = BASE_DIR) {
 
   const claims = searchKLayer(requestText);
   const projectName = path.basename(baseDir);
-  const limits = modelConfig.contextLimits();
 
   // 1) 카탈로그(본문 미로딩) + 사전 정적 분류(모델 호출 0회)
   const catalog = buildContextCatalog(baseDir);
   const pre = router.classifyTask(requestText, [], '');
   const fastPath = pre.fastPathEligible;
+  // giip-1068 2.3: 컨텍스트 한도는 등급별. 사전 분류 결과를 그대로 쓴다.
+  const limits = modelConfig.contextLimits(pre.class);
 
   // 2) 컨텍스트 선별 — Fast Path 면 LLM 호출 없이 정적 선별
   let selected = selectContextFiles(requestText, catalog, baseDir, {
@@ -383,6 +389,8 @@ status: pending
 requested_at: ${new Date().toISOString()}
 request: "${requestText.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"
 task_class: ${meta.taskClass || 'standard'}
+risk_class: ${meta.riskClass || 'none'}
+operation: ${meta.operation || 'write'}
 fast_path: ${meta.fastPath ? 'true' : 'false'}
 prompt_version: ${prompts.PROMPT_VERSION}
 ${ctxBuilder.formatContextFilesYaml(norm)}
@@ -409,6 +417,13 @@ function upsertContextFilesFrontmatter(content, norm, meta = {}) {
   // task_class 갱신(없으면 나중에 블록과 함께 삽입)
   if (/^task_class:\s*.+$/m.test(out)) {
     out = out.replace(/^task_class:\s*.+$/m, `task_class: ${meta.taskClass || 'standard'}`);
+  }
+  // giip-1068 10.2: risk_class / operation 도 최신값으로 유지한다(있을 때만 갱신).
+  if (meta.riskClass && /^risk_class:\s*.+$/m.test(out)) {
+    out = out.replace(/^risk_class:\s*.+$/m, `risk_class: ${meta.riskClass}`);
+  }
+  if (meta.operation && /^operation:\s*.+$/m.test(out)) {
+    out = out.replace(/^operation:\s*.+$/m, `operation: ${meta.operation}`);
   }
 
   const blockRe = /^context_files:\s*(?:\[\]|\r?\n(?:[ \t]+.*\r?\n?)*)/m;
@@ -512,6 +527,16 @@ function startExecution(taskId, taskFilePath, { onComplete, onError, isn = null 
   const taskContent = fs.readFileSync(taskFilePath, 'utf8');
   const resultFile = path.join(RESULTS_DIR, `${taskId}.md`);
 
+  // 작업 등급: 분석 단계가 남긴 frontmatter 우선, 없으면(구형 태스크) 본문으로 정적 분류.
+  // giip-1068 2.3: 컨텍스트 한도가 등급별이므로 컨텍스트를 읽기 전에 먼저 등급을 정한다.
+  const fmClassMatch = taskContent.match(/^task_class:\s*(\w+)\s*$/m);
+  const fmClass = fmClassMatch && router.ORDER.includes(fmClassMatch[1]) ? fmClassMatch[1] : null;
+  const classification = fmClass
+    ? { class: fmClass, confidence: 1, reasons: ['분석 단계에서 결정된 등급 재사용'] }
+    : router.classifyTask(taskContent, [], taskContent);
+  const taskClass = classification.class;
+  const fastPath = /^fast_path:\s*true\s*$/m.test(taskContent);
+
   // ── 선택된 컨텍스트만 재로딩 (전체 roles 로딩 제거, 3.1) ──────────────────
   // 신규 태스크: frontmatter 의 context_files, 구형 태스크: 주석 목록(하위 호환).
   // 둘 다 없거나 읽기에 실패하면 "최소" 기본 컨텍스트만 쓴다 — 전체 roles 로 되돌아가지 않는다.
@@ -521,7 +546,7 @@ function startExecution(taskId, taskFilePath, { onComplete, onError, isn = null 
   const ctxRead = ctxBuilder.readSelectedContext(selected, baseDir, {
     workspaceDir: BASE_DIR,
     queryText: taskContent,
-    limits: modelConfig.contextLimits(),
+    limits: modelConfig.contextLimits(taskClass),
   });
   if (!ctxRead.filesRead.length && contextSource === 'task-metadata') {
     // 선택 목록이 손상돼 하나도 못 읽은 경우에만 최소 기본으로 대체
@@ -541,39 +566,82 @@ function startExecution(taskId, taskFilePath, { onComplete, onError, isn = null 
   const currentBranch = (ctx && ctx.branch) || getCurrentBranch(baseDir);
   const baseBranch = (ctx && ctx.base) || getBaseBranch(baseDir);
 
-  // 작업 등급: 분석 단계가 남긴 frontmatter 우선, 없으면(구형 태스크) 본문으로 정적 분류.
-  const fmClassMatch = taskContent.match(/^task_class:\s*(\w+)\s*$/m);
-  const fmClass = fmClassMatch && router.ORDER.includes(fmClassMatch[1]) ? fmClassMatch[1] : null;
-  const classification = fmClass
-    ? { class: fmClass, confidence: 1, reasons: ['분석 단계에서 결정된 등급 재사용'] }
-    : router.classifyTask(taskContent, ctxRead.filesRead, taskContent);
-  const taskClass = classification.class;
-  const fastPath = /^fast_path:\s*true\s*$/m.test(taskContent);
-  console.log(`[TaskManager] task ${taskId}: class=${taskClass}${fastPath ? ' (fast path)' : ''} — ${classification.reasons.join(' / ')}`);
+  console.log(`[TaskManager] task ${taskId}: class=${taskClass}${fastPath ? ' (fast path)' : ''}`
+    + `${classification.operation ? ` op=${classification.operation} risk=${classification.risk_class}` : ''}`
+    + ` — ${classification.reasons.join(' / ')}`);
 
   // 進捗コメント・プロトコル(PROTOCOL_PROGRESS_COMMENT.md) は프롬프트 고정부에 있고,
   // 여기서는 issue 번호와 커맨드만 동적 상태로 넘긴다(고정 prefix 안정화).
   const addCommentScript = path.join(BASE_DIR, '..', 'giipprj', 'giipdb', 'mgmt', 'addIssueComment.ps1');
 
-  const buildPrompt = (attemptNo, resumeInstruction) => prompts.buildExecutionPrompt({
-    fastPath,
-    contextText: ctxRead.context,
-    contextFiles: ctxRead.filesRead.map(f => ({ path: f.path, reason: f.reason })),
+  // giip-1068 5.5: 모델이 진행 이벤트를 남길 전용 CLI 명령(프롬프트 동적 상태 절에 싣는다).
+  const progressEventScript = path.join(__dirname, 'tools', 'progress-event.js');
+  const progressEventCommand =
+    `node "${progressEventScript}" --task ${taskId} --attempt <n> --type <type>`
+    + ` --step <step-id> --path <상대경로> --summary "<한 줄 요약>" --base-dir "${RUNTIME_BASE_DIR}"`;
+
+  const commonPromptFields = {
     projectName: path.basename(baseDir),
     baseDir,
     baseBranch,
     langName: config.resolveLangNameForProject(path.basename(baseDir)),
-    taskContent,
-    kLayerClaims: claims,
     taskId,
     taskClass,
     branch: currentBranch,
-    attempt: attemptNo,
     resultFile,
     isn,
     addCommentScript: isn ? addCommentScript : null,
-    resumeInstruction,
+    progressEventCommand,
+  };
+
+  // 4.2: 최초 실행과 재개를 서로 다른 함수로 만든다.
+  const buildInitialPrompt = (attemptNo) => prompts.buildInitialExecutionPrompt({
+    ...commonPromptFields,
+    fastPath,
+    contextText: ctxRead.context,
+    contextFiles: ctxRead.filesRead.map(f => ({ path: f.path, reason: f.reason })),
+    taskContent,
+    kLayerClaims: claims,
+    attempt: attemptNo,
   });
+
+  // 4.4/4.5: 재개 프롬프트에는 태스크 "요약" + 진행 상태 + 최대 3개(critical 4개) 재개 컨텍스트만.
+  const taskSummary = prompts.summarizeTaskSpec(taskContent);
+  const buildResumePrompt = (attemptNo, cp, initialChars) => {
+    const failedStep = (cp.pending_steps || [])[0] || (cp.blocked || [])[0] || cp.error_summary || '';
+    const selected = resumeCtx.selectResumeContext({
+      initialSelection: ctxRead.filesRead.map(f => ({ path: f.path, reason: f.reason })),
+      failedStep,
+      pendingSteps: cp.pending_steps || [],
+      changedFiles: cp.files_changed || [],
+      errorSummary: cp.error_summary || '',
+      taskClass,
+    });
+    const rc = resumeCtx.readResumeContext(selected, baseDir, {
+      workspaceDir: BASE_DIR,
+      queryText: `${failedStep} ${(cp.files_changed || []).join(' ')}`,
+      taskClass,
+    });
+    return prompts.buildResumeExecutionPrompt({
+      ...commonPromptFields,
+      attempt: attemptNo,
+      taskSummary,
+      taskFilePath: path.relative(BASE_DIR, taskFilePath).replace(/\\/g, '/'),
+      completedSteps: cp.completed_steps || [],
+      pendingSteps: cp.pending_steps || [],
+      filesRead: cp.files_read || [],
+      filesChanged: cp.files_changed || [],
+      diffSummary: cp.diff_stat || '',
+      commandsRun: cp.commands_run || [],
+      testResults: cp.test_results || [],
+      decisions: cp.decisions || [],
+      blocked: cp.blocked || [],
+      errorSummary: cp.error_summary || '',
+      resumeContextText: rc.context,
+      resumeContextFiles: rc.filesRead.map(f => ({ path: f.path, reason: f.reason })),
+      initialPromptChars: initialChars,
+    });
+  };
 
   // 実行サブエージェントが roles/rules/skills/workflows を参照できるよう .agent を許可
   // （baseDir に .agent が無ければ BASE_DIR/.agent にフォールバック — index.js の getAgentDir と同じ規則）
@@ -591,8 +659,14 @@ function startExecution(taskId, taskFilePath, { onComplete, onError, isn = null 
   let mmExhausted = false;
   let attemptNo = 0;
   const retryState = { totalAttempts: 0, providerAttempts: {} };
+  // 60% 규칙(2.2) 판정 기준이 되는 최초 프롬프트 길이. 첫 시도에서 채워진다.
+  let initialPromptChars = 0;
 
-  function attempt(resumeInstruction = null, fallbackFrom = null) {
+  /**
+   * @param {object|null} resumeCp 재개에 쓸 checkpoint(null 이면 최초 프롬프트 재사용)
+   * @param {string|null} fallbackFrom
+   */
+  function attempt(resumeCp = null, fallbackFrom = null) {
     const mmAvailable = mmExhausted ? null : minimax.resolve();
     const route = router.selectModel(taskClass, 'execute',
       { minimax: !!mmAvailable, claude: accounts.count() > 0 });
@@ -637,9 +711,24 @@ function startExecution(taskId, taskFilePath, { onComplete, onError, isn = null 
       ? [...args, '--model', modelName]
       : [...args, '--model', modelName];
 
-    const executionPrompt = buildPrompt(attemptNo, resumeInstruction);
-    checkpoint.beginAttempt(baseDir, taskId, {
-      attempt: attemptNo, provider, model: modelName, taskClass,
+    // 4.2/4.6: 실제 작업 흔적이 있는 재시도만 재개 프롬프트를 쓴다. 그 외에는 최초 프롬프트 재사용.
+    let executionPrompt;
+    let promptType;
+    if (resumeCp) {
+      executionPrompt = buildResumePrompt(attemptNo, resumeCp, initialPromptChars);
+      promptType = 'resume';
+      const ratio = initialPromptChars
+        ? Math.round((1 - executionPrompt.length / initialPromptChars) * 1000) / 10 : null;
+      console.log(`[TaskManager] task ${taskId}: 재개 프롬프트 사용 (${executionPrompt.length}자`
+        + `${initialPromptChars ? ` / 최초 ${initialPromptChars}자, -${ratio}%` : ''})`);
+    } else {
+      executionPrompt = buildInitialPrompt(attemptNo);
+      promptType = 'initial';
+      if (!initialPromptChars) initialPromptChars = executionPrompt.length;
+    }
+
+    checkpoint.beginAttempt(RUNTIME_BASE_DIR, taskId, {
+      attempt: attemptNo, provider, model: modelName, taskClass, workDir: baseDir,
     });
 
     const startedAt = Date.now();
@@ -659,6 +748,10 @@ function startExecution(taskId, taskFilePath, { onComplete, onError, isn = null 
     proc.on('close', (code) => {
       const combinedOut = `${stdout}\n${stderr}`;
       const usage = costTracker.parseUsageFromOutput(combinedOut);
+      // 6.2: 태스크/결과/런타임 파일을 제외한 "실제" 소스 변경만 센다.
+      let srcChanged = { sourceFiles: [], metadataFiles: [], reportFiles: [] };
+      try { srcChanged = checkpoint.changedSourceFiles(baseDir, taskId); } catch {}
+      const eventCount = progressEvents.readProgressEvents(RUNTIME_BASE_DIR, taskId).length;
       try {
         costTracker.record(COST_LOG_DIR, {
           task_id: taskId,
@@ -680,17 +773,33 @@ function startExecution(taskId, taskFilePath, { onComplete, onError, isn = null 
           prompt_version: prompts.PROMPT_VERSION,
           context_selection: ctxRead.filesRead.map(f => ({ path: f.path, reason: f.reason })),
           // checkpoint 로 이어서 재개한 시도인지 기록(재시도가 처음부터 다시 한 것인지 구분).
-          resumed: !!resumeInstruction,
+          resumed: promptType === 'resume',
+          // giip-1068 13: 재개 프롬프트 축약 계측
+          prompt_type: promptType,
+          initial_prompt_chars: initialPromptChars || null,
+          current_prompt_chars: executionPrompt.length,
+          actual_source_files_changed: srcChanged.sourceFiles.length,
+          metadata_files_changed: srcChanged.metadataFiles.length + srcChanged.reportFiles.length,
+          checkpoint_used: promptType === 'resume',
+          progress_event_count: eventCount,
+          saving_is_estimated: !usage,
           ...(usage || {}),
         });
       } catch { /* 계측 실패가 태스크를 막지 않는다 */ }
 
       // ── 실패 시: checkpoint 저장 후 "이어서" 재개 ─────────────────────────
       if (code !== 0) {
-        const cp = checkpoint.recordFailure(baseDir, taskId, {
-          attempt: attemptNo, provider, model: modelName, output: combinedOut, cwd: baseDir,
+        const cp = checkpoint.recordFailure(RUNTIME_BASE_DIR, taskId, {
+          attempt: attemptNo, provider, model: modelName, output: combinedOut,
+          cwd: baseDir, taskClass,
         });
-        const nextResume = cp.resume_instruction || null;
+        // 4.6/6.5: 실제 작업이 있으면 반드시 재개 프롬프트, 없으면 최초 프롬프트 재사용.
+        const decision = checkpoint.shouldResume({ exitCode: code, checkpoint: cp, checkpointSaved: true });
+        const nextResume = decision.resume ? cp : null;
+        console.log(`[TaskManager] task ${taskId}: 재개 판정 — ${decision.reason}`);
+        if (cp.changed_file_anomalies && cp.changed_file_anomalies.length) {
+          console.warn(`[TaskManager] task ${taskId}: 이상 변경 감지 — ${cp.changed_file_anomalies.join(' / ')}`);
+        }
 
         // MiniMax(1순위) 실패 → 이번 태스크는 더 이상 MiniMax를 시도하지 않고 Claude 풀로 전환.
         if (provider === 'minimax') {
@@ -723,7 +832,7 @@ function startExecution(taskId, taskFilePath, { onComplete, onError, isn = null 
       }
 
       if (code === 0) {
-        checkpoint.recordSuccess(baseDir, taskId, { attempt: attemptNo, provider, model: modelName, cwd: baseDir });
+        checkpoint.recordSuccess(RUNTIME_BASE_DIR, taskId, { attempt: attemptNo, provider, model: modelName, cwd: baseDir });
         onComplete(resultFile);
       } else {
         onError(new Error(`claude exit ${code}: ${stderr.slice(0, 200)}`), resultFile);
@@ -735,11 +844,16 @@ function startExecution(taskId, taskFilePath, { onComplete, onError, isn = null 
   }
 
   // 이전 실행이 중단된 채 남아 있으면(재실행/이어하기) 그 checkpoint 로 시작한다.
-  const prior = checkpoint.load(baseDir, taskId);
-  const priorResume = prior && !prior.finished_at ? checkpoint.buildResumeInstruction(prior) : null;
-  if (priorResume) console.log(`[TaskManager] task ${taskId}: 이전 checkpoint 발견 → 완료된 단계부터 이어서 실행`);
+  // 단, 최초 프롬프트 길이를 모르므로 여기서는 등급별 재개 상한만 적용된다(60% 규칙은 attempt 내부).
+  const prior = checkpoint.load(RUNTIME_BASE_DIR, taskId);
+  const priorHasWork = prior && !prior.finished_at && checkpoint.hasRealWork(prior);
+  if (priorHasWork) {
+    console.log(`[TaskManager] task ${taskId}: 이전 checkpoint 발견 → 완료된 단계부터 이어서 실행`);
+    // 60% 판정 기준으로 쓸 "최초 프롬프트 길이"를 실제로 조립해 계산한다(전송하지는 않는다).
+    try { initialPromptChars = buildInitialPrompt(1).length; } catch {}
+  }
 
-  return attempt(priorResume);
+  return attempt(priorHasWork ? prior : null);
 }
 
 // ── 작업 완료: 결과를 태스크 파일에 추가 후 done/ 폴더로 이동 ─────────────────

--- a/slack-bot/tools/progress-event.js
+++ b/slack-bot/tools/progress-event.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * progress-event.js — 실행 중인 모델이 진행 이벤트를 남기는 전용 CLI (giip-1068, 5.5)
+ *
+ * 모델이 JSON 파일을 직접 편집하게 하지 않는다. 이 CLI 가 입력 검증 + secret 마스킹 + 길이 제한 +
+ * 파일 정리(500건/1MB)를 모두 책임진다.
+ *
+ * 사용법:
+ *   node slack-bot/tools/progress-event.js \
+ *     --task giip-1234 --attempt 1 --type file_changed \
+ *     --step step-2 --path src/example.js --summary "버튼 글자색 변경"
+ *
+ * 옵션:
+ *   --task     <id>        (필수) 태스크 ID
+ *   --type     <type>      (필수) step_started|step_completed|file_read|file_changed|
+ *                                 command_run|test_result|decision|blocked
+ *   --attempt  <n>         시도 번호(기본 1)
+ *   --step     <id>        단계 ID
+ *   --path     <path>      대상 파일 경로(저장소 기준 상대경로 권장 — 절대경로는 마스킹된다)
+ *   --summary  <text>      한 줄 요약(최대 500자)
+ *   --status   <text>      passed|failed|completed 등
+ *   --command  <text>      실행한 명령(최대 1,000자)
+ *   --output   <text>      명령 출력(최대 2,000자)
+ *   --result   <text>      테스트 결과(최대 2,000자)
+ *   --base-dir <path>      런타임 루트 기준 디렉터리(기본: WORKSPACE_DIR)
+ *   --json                 결과를 JSON 으로 출력
+ *
+ * 종료코드: 0 = 기록 성공, 1 = 검증 실패/기록 실패
+ */
+
+const path = require('path');
+
+const SB = path.join(__dirname, '..');
+const progress = require(path.join(SB, 'progress-events'));
+const runtimePaths = require(path.join(SB, 'runtime-paths'));
+
+const ALIASES = {
+  task: 'task_id', 'task-id': 'task_id', taskid: 'task_id',
+  type: 'type', attempt: 'attempt', step: 'step_id', 'step-id': 'step_id',
+  path: 'path', file: 'path', summary: 'summary', status: 'status',
+  command: 'command', cmd: 'command', output: 'output', result: 'result',
+  'base-dir': 'base_dir', basedir: 'base_dir',
+};
+
+function parseArgs(argv) {
+  const out = { _json: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--json') { out._json = true; continue; }
+    if (a === '--help' || a === '-h') { out._help = true; continue; }
+    if (!a.startsWith('--')) continue;
+    const eq = a.indexOf('=');
+    const rawKey = (eq > 0 ? a.slice(2, eq) : a.slice(2)).toLowerCase();
+    const key = ALIASES[rawKey];
+    if (!key) { out._unknown = (out._unknown || []).concat([rawKey]); continue; }
+    const value = eq > 0 ? a.slice(eq + 1) : (argv[i + 1] !== undefined && !String(argv[i + 1]).startsWith('--') ? argv[++i] : '');
+    out[key] = value;
+  }
+  return out;
+}
+
+function usage() {
+  console.log(require('fs').readFileSync(__filename, 'utf8')
+    .split('\n').slice(1, 33).map(l => l.replace(/^ \* ?/, '').replace(/^\/\*\*?/, '')).join('\n'));
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args._help) { usage(); return 0; }
+  if (args._unknown && args._unknown.length) {
+    console.error(`[progress-event] 알 수 없는 옵션: --${args._unknown.join(', --')}`);
+    return 1;
+  }
+  if (!args.task_id) { console.error('[progress-event] --task 는 필수다.'); return 1; }
+  if (!args.type) { console.error('[progress-event] --type 은 필수다.'); return 1; }
+  if (!progress.EVENT_TYPES.includes(args.type)) {
+    console.error(`[progress-event] 허용되지 않는 --type "${args.type}". 허용: ${progress.EVENT_TYPES.join(', ')}`);
+    return 1;
+  }
+
+  const baseDir = args.base_dir ? path.resolve(args.base_dir) : runtimePaths.workspaceRoot();
+  const res = progress.appendProgressEvent(baseDir, args.task_id, {
+    task_id: args.task_id,
+    attempt: args.attempt,
+    type: args.type,
+    step_id: args.step_id,
+    path: args.path,
+    summary: args.summary,
+    status: args.status,
+    command: args.command,
+    output: args.output,
+    result: args.result,
+  });
+
+  if (!res.ok) {
+    console.error(`[progress-event] 기록 실패: ${res.reason}`);
+    return 1;
+  }
+  if (args._json) console.log(JSON.stringify(res.event));
+  else console.log(`[progress-event] ${res.event.type} 기록 (task=${res.event.task_id}, attempt=${res.event.attempt}${res.pruned ? `, 오래된 이벤트 ${res.pruned}건 정리` : ''})`);
+  return 0;
+}
+
+if (require.main === module) process.exit(main());
+module.exports = { parseArgs, main };

--- a/slack-bot/tools/test-cost-optimization.js
+++ b/slack-bot/tools/test-cost-optimization.js
@@ -377,9 +377,9 @@ test('동적 값(시각/taskID/브랜치/재시도)은 프롬프트 뒤쪽에만
 });
 
 test('프롬프트 버전이 기록된다', () => {
-  assert.strictEqual(prompts.PROMPT_VERSION, 'fde-cost-v1');
-  assert.ok(prompts.buildExecutionPrompt({ taskContent: 'x' }).includes('prompt_version: fde-cost-v1'));
-  assert.ok(prompts.buildAnalysisPrompt({ requestText: 'x' }).includes('prompt_version: fde-cost-v1'));
+  assert.strictEqual(prompts.PROMPT_VERSION, 'fde-cost-v2');
+  assert.ok(prompts.buildExecutionPrompt({ taskContent: 'x' }).includes('prompt_version: fde-cost-v2'));
+  assert.ok(prompts.buildAnalysisPrompt({ requestText: 'x' }).includes('prompt_version: fde-cost-v2'));
 });
 
 test('재개 지시문은 checkpoint 절(맨 뒤)에만 들어간다', () => {
@@ -482,7 +482,10 @@ test('한 메시지의 독립 조회 여러 건을 한 번에 묶는다', () => 
   ].join('\n'));
   assert.strictEqual(p.batchable, true);
   assert.strictEqual(p.batch_size, 3);
-  assert.strictEqual(p.model_calls_saved, 2);
+  // giip-1068 8: 실제 절감은 0, 가정 절감만 2. 구 필드(model_calls_saved)는 제거됐다.
+  assert.strictEqual(p.actual_model_calls_saved, 0);
+  assert.strictEqual(p.hypothetical_separate_calls_avoided, 2);
+  assert.strictEqual(p.model_calls_saved, undefined, '가상 절감을 실제 절감처럼 부르던 필드는 제거돼야 한다');
   assert.ok(p.instruction.includes('배치 처리 지시'));
 });
 
@@ -560,6 +563,670 @@ test('MiniMax 우선 → Claude fallback 구조가 유지된다', () => {
 test('런타임 산출물이 .gitignore 대상이다', () => {
   const gi = fs.readFileSync(path.join(SB, '..', '.gitignore'), 'utf8');
   assert.ok(/^\.agent\/runtime\/$/m.test(gi), '.agent/runtime/ 이 .gitignore 에 없다');
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// giip-1068 비용 최적화 2차 — 테스트 A~I (이슈 §11.2)
+// ═══════════════════════════════════════════════════════════════════════════
+const progress = require(path.join(SB, 'progress-events'));
+const resumeCtx = require(path.join(SB, 'resume-context-builder'));
+const runtimePaths = require(path.join(SB, 'runtime-paths'));
+
+/** 프롬프트 조립용 공통 옵션 — 최초/재개를 같은 태스크로 비교하기 위해. */
+const G_TASK = [
+  '---',
+  'task_id: giip-1234',
+  'task_class: standard',
+  '---',
+  '',
+  '# TASK: 버튼 글자색 변경',
+  '',
+  '## 요청 내용',
+  '대시보드 버튼 글자색을 파랑으로 바꾼다. ' + '상세 배경 설명. '.repeat(60),
+  '',
+  '## 실행 계획',
+  '1. src/a.js 의 색상 상수 수정',
+  '2. src/b.js 의 스타일 적용',
+  '3. npm test 로 검증',
+  '',
+  '## 영향 파일/서브시스템',
+  '- src/a.js',
+  '- src/b.js',
+  '',
+  '## 주의사항',
+  '- 요청 범위 밖 수정 금지',
+  '',
+  '## 부가 설명',
+  '아주 긴 부가 설명. '.repeat(400),
+].join('\n');
+
+function gInitialPrompt(over = {}) {
+  return prompts.buildInitialExecutionPrompt(Object.assign({
+    taskContent: G_TASK,
+    taskClass: 'standard',
+    taskId: 'giip-1234',
+    branch: 'bot/task-giip-1234',
+    attempt: 1,
+    now: '2026-08-13T00:00:00Z',
+    contextText: '컨텍스트 본문. '.repeat(800),
+    contextFiles: [
+      { path: '.agent/rules/10_karpathy_guidelines.md', reason: '요청 범위 밖 수정 방지' },
+      { path: '.agent/roles/developer.md', reason: '소스 수정 및 테스트 수행' },
+      { path: '.agent/skills/frontend/SKILL.md', reason: '스타일 적용 규칙' },
+    ],
+  }, over));
+}
+
+// ── 테스트 A: 시작 전 MiniMax 429 ───────────────────────────────────────────
+section('테스트 A: 시작 전 429 (작업 흔적 0) → 최초 프롬프트 재사용');
+const A_DIR = tmpdir('fde-1068a-');
+
+test('실제 소스 변경 0 / 완료 단계 0 / 명령 0 → hasRealWork=false', () => {
+  const cp = checkpoint.save(A_DIR, 'giip-1234', {
+    error_type: 'usage_limit',
+    completed_steps: [], files_changed: [], commands_run: [], test_results: [],
+  });
+  assert.strictEqual(checkpoint.hasRealWork(cp), false);
+  const d = checkpoint.shouldResume({ exitCode: 1, checkpoint: cp, checkpointSaved: true });
+  assert.strictEqual(d.resume, false, `resume=${d.resume} (${d.reason})`);
+  assert.strictEqual(checkpoint.buildResumeInstruction(cp), null, 'resume prompt 를 만들면 안 된다');
+  assert.strictEqual(cp.error_type, 'usage_limit');
+});
+
+test('checkpoint 저장 전 실패면 재개하지 않는다', () => {
+  const d = checkpoint.shouldResume({ exitCode: 1, checkpoint: null, checkpointSaved: false });
+  assert.strictEqual(d.resume, false);
+});
+
+test('태스크 파일만 바뀐 상태는 source change 에 포함되지 않는다', () => {
+  const r = checkpoint.changedSourceFiles(A_DIR, 'giip-1234', {
+    files: ['.agent/tasks/giip-1234.md', '.agent/results/giip-1234.md',
+            '.agent/runtime/checkpoints/giip-1234.json', 'slack-bot/tasklist.json'],
+  });
+  assert.strictEqual(r.sourceFiles.length, 0, `sourceFiles=${JSON.stringify(r.sourceFiles)}`);
+  assert.strictEqual(r.totalSourceChanges, 0);
+});
+
+// ── 테스트 B: 파일 2개 수정 후 429 → 재개 프롬프트 ──────────────────────────
+section('테스트 B: 파일 2개 수정 후 429 → 재개 프롬프트 (60% 이하)');
+
+test('hasRealWork=true 이면 반드시 재개 프롬프트를 쓴다', () => {
+  const cp = {
+    attempt: 1, error_type: 'usage_limit',
+    files_changed: ['src/a.js', 'src/b.js'], completed_steps: [], commands_run: [], test_results: [],
+  };
+  assert.strictEqual(checkpoint.hasRealWork(cp), true);
+  assert.strictEqual(checkpoint.shouldResume({ exitCode: 1, checkpoint: cp }).resume, true);
+});
+
+test('재개 프롬프트에 변경 파일이 들어가고 전체 taskContent 는 안 들어간다', () => {
+  const initial = gInitialPrompt();
+  const resume = prompts.buildResumeExecutionPrompt({
+    taskContent: G_TASK, taskClass: 'standard', taskId: 'giip-1234',
+    branch: 'bot/task-giip-1234', attempt: 2, now: '2026-08-13T00:10:00Z',
+    filesChanged: ['src/a.js', 'src/b.js'],
+    pendingSteps: ['3. npm test 로 검증'],
+    errorSummary: 'HTTP 429 rate limit',
+    resumeContextText: '재개 컨텍스트 본문',
+    resumeContextFiles: [{ path: '.agent/rules/10_karpathy_guidelines.md', reason: '범위 밖 수정 방지' }],
+    initialPromptChars: initial.length,
+  });
+  assert.ok(resume.includes('src/a.js') && resume.includes('src/b.js'));
+  assert.ok(!resume.includes('아주 긴 부가 설명.'), '전체 taskContent 가 재개 프롬프트에 들어갔다');
+  assert.ok(!resume.includes('컨텍스트 본문. 컨텍스트 본문.'), '최초 선택 컨텍스트 전체가 재개 프롬프트에 들어갔다');
+  assert.ok(resume.includes('태스크 요약'), '태스크 요약 절이 있어야 한다');
+});
+
+test('재개 프롬프트가 최초 프롬프트의 60% 이하다', () => {
+  const initial = gInitialPrompt();
+  const resume = prompts.buildResumeExecutionPrompt({
+    taskContent: G_TASK, taskClass: 'standard', taskId: 'giip-1234', attempt: 2,
+    filesChanged: ['src/a.js', 'src/b.js'],
+    completedSteps: ['step-1: 색상 상수 수정', 'step-2: 스타일 적용'],
+    pendingSteps: ['step-3: npm test'],
+    filesRead: Array.from({ length: 40 }, (_, i) => `src/read${i}.js`),
+    diffSummary: 'src/a.js | 4 ++--\nsrc/b.js | 2 +-',
+    errorSummary: 'x'.repeat(3000),
+    resumeContextText: 'C'.repeat(8000),
+    initialPromptChars: initial.length,
+  });
+  const ratio = resume.length / initial.length;
+  assert.ok(ratio <= 0.60, `ratio=${ratio.toFixed(3)} (initial=${initial.length}, resume=${resume.length})`);
+});
+
+test('재개 컨텍스트는 최대 3개(critical 4개), 8,000자(critical 14,000자)', () => {
+  const initialSelection = Array.from({ length: 8 }, (_, i) => ({
+    path: `.agent/rules/rule${i}.md`, reason: `테스트 검증 실패 관련 규칙 ${i}`,
+  }));
+  const pick = resumeCtx.selectResumeContext({
+    initialSelection, failedStep: '테스트 검증 실패', pendingSteps: ['테스트 수정'],
+    changedFiles: ['src/a.js'], taskClass: 'standard',
+  });
+  assert.ok(pick.length <= 3, `picked=${pick.length}`);
+  assert.ok(pick.every(p => p.max_chars <= 3000));
+  const critPick = resumeCtx.selectResumeContext({
+    initialSelection, failedStep: '테스트 검증 실패', taskClass: 'critical',
+  });
+  assert.ok(critPick.length <= 4, `criticalPicked=${critPick.length}`);
+  assert.ok(critPick.every(p => p.max_chars <= 4000));
+  const lim = modelConfig.resumeContextLimits('standard');
+  assert.strictEqual(lim.totalMaxChars, 8000);
+  assert.strictEqual(modelConfig.resumeContextLimits('critical').totalMaxChars, 14000);
+});
+
+// ── 테스트 C: 테스트 단계에서 실패 ──────────────────────────────────────────
+section('테스트 C: 테스트 단계 실패 → 구현 재시작 금지');
+const C_DIR = tmpdir('fde-1068c-');
+
+test('진행 이벤트 4건을 기록하고 checkpoint 에 반영한다', () => {
+  const ev = (e) => {
+    const r = progress.appendProgressEvent(C_DIR, 'giip-1234', e);
+    assert.ok(r.ok, `이벤트 기록 실패: ${r.reason}`);
+  };
+  ev({ type: 'step_completed', step_id: 'step-1', summary: '색상 상수 수정', attempt: 1 });
+  ev({ type: 'step_completed', step_id: 'step-2', summary: '스타일 적용', attempt: 1 });
+  ev({ type: 'command_run', command: 'npm test', summary: '테스트 실행', attempt: 1 });
+  ev({ type: 'test_result', command: 'npm test', status: 'failed', result: '2 failing', attempt: 1 });
+  const events = progress.readProgressEvents(C_DIR, 'giip-1234');
+  assert.strictEqual(events.length, 4);
+  const sum = progress.summarizeProgressEvents(events);
+  assert.strictEqual(sum.completed_steps.length, 2);
+  assert.strictEqual(sum.commands_run.length, 1);
+  assert.strictEqual(sum.test_results.length, 1);
+  assert.strictEqual(sum.test_results[0].status, 'failed');
+});
+
+test('recordFailure 가 진행 이벤트로 checkpoint 필드를 채운다(빈 배열이 아님)', () => {
+  const cp = checkpoint.recordFailure(C_DIR, 'giip-1234', {
+    attempt: 1, provider: 'minimax', model: 'MiniMax-M2.7',
+    output: 'HTTP 429 rate limit', cwd: C_DIR, taskClass: 'standard',
+  });
+  assert.strictEqual(cp.completed_steps.length, 2, `completed=${JSON.stringify(cp.completed_steps)}`);
+  assert.strictEqual(cp.commands_run.length, 1);
+  assert.strictEqual(cp.test_results.length, 1);
+  assert.strictEqual(cp.progress_event_count, 4);
+  assert.strictEqual(checkpoint.hasRealWork(cp), true);
+});
+
+test('재개 프롬프트에 완료 단계·실패 명령이 들어가고 재시작 금지 지시가 있다', () => {
+  const cp = checkpoint.load(C_DIR, 'giip-1234');
+  const resume = prompts.buildResumeExecutionPrompt({
+    taskContent: G_TASK, taskClass: 'standard', taskId: 'giip-1234', attempt: 2,
+    completedSteps: cp.completed_steps,
+    pendingSteps: ['테스트 수정 또는 실패 원인 처리'],
+    commandsRun: cp.commands_run,
+    testResults: cp.test_results,
+    initialPromptChars: gInitialPrompt().length,
+  });
+  assert.ok(resume.includes('step-1'), 'step-1 완료 표시가 있어야 한다');
+  assert.ok(resume.includes('step-2'), 'step-2 완료 표시가 있어야 한다');
+  assert.ok(resume.includes('npm test'), '실패한 테스트 명령이 있어야 한다');
+  assert.ok(/구현을 처음부터 다시 하지 말고/.test(resume), '구현 재시작 금지 지시가 있어야 한다');
+  assert.ok(/테스트 수정 또는 실패 원인 처리/.test(resume), '다음 단계가 지정돼야 한다');
+});
+
+// ── 테스트 D: 태스크 파일만 변경 ────────────────────────────────────────────
+section('테스트 D: 태스크 파일만 변경 → 작업 수행으로 보지 않는다');
+
+test('sourceFiles=0, metadataFiles=1', () => {
+  const r = checkpoint.changedSourceFiles('.', 'giip-1234', { files: ['.agent/tasks/giip-1234.md'] });
+  assert.strictEqual(r.sourceFiles.length, 0);
+  assert.strictEqual(r.metadataFiles.length, 1);
+  assert.strictEqual(r.totalSourceChanges, 0);
+});
+
+test('다른 태스크 파일 변경은 제외하지 않고 이상 상태로 기록한다(6.3)', () => {
+  const r = checkpoint.changedSourceFiles('.', 'giip-1234', { files: ['.agent/tasks/giip-9999.md'] });
+  assert.strictEqual(r.anomalies.length, 1, `anomalies=${JSON.stringify(r.anomalies)}`);
+  assert.ok(r.anomalies[0].includes('giip-9999'));
+});
+
+test('런타임·봇 상태 파일도 소스 변경이 아니다', () => {
+  const r = checkpoint.changedSourceFiles('.', 'giip-1234', {
+    files: ['.agent/runtime/progress/giip-1234.jsonl', '.agent/runtime/cost-usage.jsonl',
+            'slack-bot/.task-state.json', 'slack-bot/minimax-accounts.json'],
+  });
+  assert.strictEqual(r.sourceFiles.length, 0);
+  assert.strictEqual(r.runtimeFiles.length, 2);
+  assert.strictEqual(r.botStateFiles.length, 2);
+});
+
+// ── 테스트 E: nested repository 변경 ────────────────────────────────────────
+section('테스트 E: nested repository 의 실제 변경');
+
+test('nested repo 변경은 실제 source change 로 본다', () => {
+  const r = checkpoint.changedSourceFiles('.', 'giip-1234', {
+    files: ['projects/giipprj/giipv3/src/example.js'],
+  });
+  assert.deepStrictEqual(r.sourceFiles, ['projects/giipprj/giipv3/src/example.js']);
+  assert.strictEqual(r.totalSourceChanges, 1);
+});
+
+test('재개 프롬프트에 상대경로로 표시되고 절대경로가 노출되지 않는다', () => {
+  const resume = prompts.buildResumeExecutionPrompt({
+    taskContent: G_TASK, taskClass: 'standard', taskId: 'giip-1234', attempt: 2,
+    filesChanged: ['projects/giipprj/giipv3/src/example.js'],
+    initialPromptChars: gInitialPrompt().length,
+  });
+  assert.ok(resume.includes('projects/giipprj/giipv3/src/example.js'));
+  assert.ok(!/[A-Za-z]:\\Users\\/.test(resume), 'Windows 절대경로가 노출됐다');
+  assert.ok(!/\/home\/[a-z]+\//.test(resume), 'POSIX 홈 절대경로가 노출됐다');
+});
+
+test('진행 이벤트의 절대경로는 저장 시 마스킹된다(7.2)', () => {
+  const E2 = tmpdir('fde-1068e-');
+  const abs = path.join(E2, 'src', 'secretpath.js');
+  const r = progress.appendProgressEvent(E2, 'giip-1234', { type: 'file_changed', path: abs });
+  assert.ok(r.ok);
+  assert.strictEqual(r.event.path, 'src/secretpath.js', `path=${r.event.path}`);
+});
+
+// ── 테스트 F: prompt 길이 제한 ──────────────────────────────────────────────
+section('테스트 F: 등급별 프롬프트 길이 상한');
+
+test('등급별 최초/재개 상한값이 이슈 표와 일치한다', () => {
+  const expect = {
+    trivial: [24000, 12000], standard: [48000, 24000],
+    complex: [80000, 40000], critical: [120000, 64000],
+  };
+  for (const [cls, [ini, res]] of Object.entries(expect)) {
+    const l = modelConfig.promptLimits(cls);
+    assert.strictEqual(l.initialMaxChars, ini, `${cls} initial`);
+    assert.strictEqual(l.resumeMaxChars, res, `${cls} resume`);
+    assert.strictEqual(l.initialMaxTokensEstimated, Math.ceil(ini / 4));
+  }
+});
+
+test('거대 컨텍스트를 넣어도 등급별 상한을 1자도 넘지 않는다', () => {
+  const huge = '가'.repeat(400000);
+  for (const cls of ['trivial', 'standard', 'complex', 'critical']) {
+    const l = modelConfig.promptLimits(cls);
+    const p = prompts.buildInitialExecutionPrompt({
+      taskClass: cls, taskContent: huge, contextText: huge, taskId: 't', attempt: 1,
+    });
+    assert.ok(p.length <= l.initialMaxChars, `${cls} initial=${p.length} > ${l.initialMaxChars}`);
+    const r = prompts.buildResumeExecutionPrompt({
+      taskClass: cls, taskContent: huge, taskId: 't', attempt: 2,
+      resumeContextText: huge, errorSummary: huge, diffSummary: huge,
+      filesChanged: Array.from({ length: 200 }, (_, i) => `src/f${i}.js`),
+    });
+    assert.ok(r.length <= l.resumeMaxChars, `${cls} resume=${r.length} > ${l.resumeMaxChars}`);
+  }
+});
+
+test('등급별 컨텍스트 총량 한도가 적용된다(48,000자 일괄 적용 폐지)', () => {
+  assert.strictEqual(modelConfig.contextLimits('trivial').totalMaxChars, 12000);
+  assert.strictEqual(modelConfig.contextLimits('standard').totalMaxChars, 24000);
+  assert.strictEqual(modelConfig.contextLimits('complex').totalMaxChars, 40000);
+  assert.strictEqual(modelConfig.contextLimits('critical').totalMaxChars, 64000);
+  assert.strictEqual(modelConfig.contextLimits('critical').perFileMaxChars, 6000);
+  assert.strictEqual(modelConfig.contextLimits('standard').perFileMaxChars, 4000);
+});
+
+// ── 테스트 G: 배치 수치 ─────────────────────────────────────────────────────
+section('테스트 G: 배치 절감 수치 (실제 vs 가정)');
+const G_DIR = tmpdir('fde-1068g-');
+
+test('3개 질문 → batch_size 3, 가정 절감 2, 실제 절감 0', () => {
+  const p = batchPlanner.planBatch('1. a.js 있는지 확인해줘\n2. b.js 있는지 확인해줘\n3. c.js 있는지 확인해줘');
+  assert.strictEqual(p.batch_size, 3);
+  assert.strictEqual(p.hypothetical_separate_calls_avoided, 2);
+  assert.strictEqual(p.actual_model_calls_before, 1);
+  assert.strictEqual(p.actual_model_calls_after, 1);
+  assert.strictEqual(p.actual_model_calls_saved, 0);
+});
+
+test('!cost 기본 보고서에 가상 절감 2회가 실제 절감으로 표시되지 않는다', () => {
+  costTracker.record(G_DIR, {
+    task_id: 'giip-1068', phase: 'qa', provider: 'minimax', model: 'MiniMax-M2.7',
+    input_chars: 400, output_chars: 100, batch_size: 3,
+    actual_model_calls_saved: 0, hypothetical_separate_calls_avoided: 2,
+  });
+  const sum = costTracker.summarize(G_DIR);
+  assert.strictEqual(sum.batch_actual_model_calls_saved, 0);
+  assert.strictEqual(sum.batch_hypothetical_separate_calls_avoided, 2);
+  const basic = costTracker.report(G_DIR, '');
+  assert.ok(/실제 절감 호출: 0회/.test(basic), `기본 보고서: ${basic}`);
+  assert.ok(!/가정/.test(basic), '기본 보고서에 가정 절감이 나오면 안 된다');
+  const detail = costTracker.report(G_DIR, 'detail');
+  assert.ok(/가정값.*2회/.test(detail), `상세 보고서에 가정값 표기가 없다: ${detail}`);
+});
+
+test('Fast Path 절감값에 estimated 표시가 있다(8.4)', () => {
+  costTracker.record(G_DIR, {
+    task_id: 'giip-fp', phase: 'execute', provider: 'minimax', model: 'MiniMax-M2.7',
+    input_chars: 100, fast_path: true,
+  });
+  const sum = costTracker.summarize(G_DIR);
+  assert.strictEqual(sum.fast_path.saving_is_estimated, true);
+  assert.strictEqual(sum.fast_path.estimated_calls_saved, 2);
+  assert.strictEqual(sum.fast_path.baseline_expected_calls, 3);
+  assert.ok(/ESTIMATED/.test(costTracker.report(G_DIR, '')), '보고서에 ESTIMATED 표기가 없다');
+});
+
+test('비용 로그에 프롬프트 축약 필드가 기록된다(13)', () => {
+  const row = costTracker.record(G_DIR, {
+    task_id: 'giip-1068', phase: 'execute', provider: 'claude', model: 'sonnet', attempt: 2,
+    prompt_type: 'resume', initial_prompt_chars: 48000, current_prompt_chars: 22000,
+    actual_source_files_changed: 2, metadata_files_changed: 1,
+    checkpoint_used: true, progress_event_count: 14, saving_is_estimated: false,
+  });
+  assert.strictEqual(row.prompt_type, 'resume');
+  assert.strictEqual(row.prompt_reduction_chars, 26000);
+  assert.strictEqual(row.prompt_reduction_ratio, 0.5417, `ratio=${row.prompt_reduction_ratio}`);
+  assert.strictEqual(row.actual_source_files_changed, 2);
+  assert.strictEqual(row.checkpoint_used, true);
+  assert.strictEqual(row.progress_event_count, 14);
+});
+
+test('재개인데 감소율이 40% 미만이면 경고를 남긴다', () => {
+  const orig = console.warn;
+  let warned = '';
+  console.warn = (...a) => { warned += a.join(' '); };
+  try {
+    costTracker.record(G_DIR, {
+      task_id: 'giip-warn', phase: 'execute', provider: 'claude', model: 'sonnet',
+      prompt_type: 'resume', initial_prompt_chars: 10000, current_prompt_chars: 9000,
+    });
+  } finally { console.warn = orig; }
+  assert.ok(/CostOptimizationWarning/.test(warned), `경고가 없다: ${warned}`);
+  assert.ok(/less than 40%/.test(warned));
+});
+
+// ── 테스트 H: read-only 보안 질문 ───────────────────────────────────────────
+section('테스트 H: read-only 보안 질문 (Opus 금지)');
+
+test('"인증 관련 코드가 어느 파일에 있는지 알려줘" → read / critical / standard', () => {
+  const c = router.classifyTask('인증 관련 코드가 어느 파일에 있는지 알려줘', [], '');
+  assert.strictEqual(c.operation, 'read');
+  assert.strictEqual(c.risk_class, 'critical');
+  assert.strictEqual(c.task_class, 'standard', `task_class=${c.task_class} (${c.reasons.join('/')})`);
+});
+
+test('읽기 전용 위험 질문은 프리미엄(Opus) 모델로 라우팅되지 않는다', () => {
+  const c = router.classifyTask('인증 관련 코드가 어느 파일에 있는지 알려줘', [], '');
+  const sel = router.selectModel(c.task_class, 'execute', { minimax: false });
+  assert.strictEqual(sel.premiumAllowed, false);
+  assert.notStrictEqual(sel.model, modelConfig.LEGACY_PREMIUM_MODEL);
+  assert.strictEqual(router.selectModel(c.task_class, 'plan').premiumAllowed, false);
+});
+
+test('§10.1 의 읽기 전용 예시 4건이 모두 critical 실행으로 오인되지 않는다', () => {
+  for (const q of ['로그인 구조를 설명해줘',
+                   '인증 관련 문서가 어디 있어?',
+                   '결제 기능이 구현되어 있는지 확인해줘',
+                   '운영 DB 스키마를 읽기 전용으로 보여줘']) {
+    const c = router.classifyTask(q, [], '');
+    assert.strictEqual(c.operation, 'read', `${q} → operation=${c.operation}`);
+    assert.notStrictEqual(c.task_class, 'critical', `${q} → task_class=${c.task_class}`);
+    assert.ok(['trivial', 'standard', 'complex'].includes(c.task_class));
+  }
+});
+
+// ── 테스트 I: 인증 코드 수정 ────────────────────────────────────────────────
+section('테스트 I: 인증 코드 수정 (write + critical)');
+
+test('"auth/login.js의 세션 토큰 검증 로직을 수정해줘" → write / critical / critical', () => {
+  const c = router.classifyTask('auth/login.js의 세션 토큰 검증 로직을 수정해줘', [], '');
+  assert.strictEqual(c.operation, 'write');
+  assert.strictEqual(c.risk_class, 'critical');
+  assert.strictEqual(c.task_class, 'critical');
+  assert.strictEqual(c.fastPathEligible, false, 'Fast Path 금지');
+});
+
+test('delete/deploy/migrate 위험 작업이 적절히 승격된다(10.2)', () => {
+  const del = router.classifyTask('운영 DB 의 사용자 테이블을 전부 삭제해줘', [], '');
+  assert.strictEqual(del.operation, 'delete');
+  assert.strictEqual(del.task_class, 'critical');
+  const dep = router.classifyTask('운영 서버에 배포해줘', [], '');
+  assert.strictEqual(dep.operation, 'deploy');
+  assert.strictEqual(dep.task_class, 'critical');
+  const mig = router.classifyTask('사용자 테이블 스키마 마이그레이션을 실행해줘', [], '');
+  assert.strictEqual(mig.operation, 'migrate');
+  assert.ok(['complex', 'critical'].includes(mig.task_class), `migrate=${mig.task_class}`);
+  for (const c of [del, dep, mig]) assert.strictEqual(c.fastPathEligible, false);
+});
+
+// ── 진행 이벤트 모듈 상세 (5) ───────────────────────────────────────────────
+section('진행 이벤트 모듈 (giip-1068 §5)');
+const P_DIR = tmpdir('fde-1068p-');
+
+test('허용 이벤트는 정확히 8종이다', () => {
+  assert.deepStrictEqual(progress.EVENT_TYPES, [
+    'step_started', 'step_completed', 'file_read', 'file_changed',
+    'command_run', 'test_result', 'decision', 'blocked']);
+});
+
+test('허용되지 않는 종류는 기록하지 않고 경고만 남긴다', () => {
+  const orig = console.warn;
+  let warned = '';
+  console.warn = (...a) => { warned += a.join(' '); };
+  let r;
+  try { r = progress.appendProgressEvent(P_DIR, 'giip-x', { type: 'random_event' }); }
+  finally { console.warn = orig; }
+  assert.strictEqual(r.ok, false);
+  assert.ok(/허용되지 않는/.test(warned));
+  assert.strictEqual(progress.readProgressEvents(P_DIR, 'giip-x').length, 0);
+});
+
+test('JSON Lines 로 .agent/runtime/progress/<task-id>.jsonl 에 저장된다', () => {
+  progress.appendProgressEvent(P_DIR, 'giip-1234', { type: 'file_read', path: 'src/a.js' });
+  const p = progress.eventPath(P_DIR, 'giip-1234').replace(/\\/g, '/');
+  assert.ok(p.endsWith('.agent/runtime/progress/giip-1234.jsonl'), p);
+  const raw = fs.readFileSync(progress.eventPath(P_DIR, 'giip-1234'), 'utf8');
+  assert.strictEqual(raw.trim().split('\n').length, 1);
+  const o = JSON.parse(raw.trim());
+  assert.ok(o.timestamp && o.task_id === 'giip-1234' && o.type === 'file_read');
+});
+
+test('길이 제한을 적용한다 (summary 500 / command 1000 / output 2000)', () => {
+  const r = progress.appendProgressEvent(P_DIR, 'giip-len', {
+    type: 'command_run', summary: 'S'.repeat(2000), command: 'C'.repeat(5000), output: 'O'.repeat(9000),
+  });
+  assert.strictEqual(r.event.summary.length, 500);
+  assert.strictEqual(r.event.command.length, 1000);
+  assert.strictEqual(r.event.output.length, 2000);
+});
+
+test('진행 이벤트에도 비밀값을 남기지 않는다', () => {
+  const FAKE = fakeSecrets();
+  progress.appendProgressEvent(P_DIR, 'giip-sec', {
+    type: 'decision', summary: `used SLACK_BOT_TOKEN=${FAKE.slack} and ${FAKE.anthropic}`,
+  });
+  const raw = fs.readFileSync(progress.eventPath(P_DIR, 'giip-sec'), 'utf8');
+  assert.ok(!raw.includes(FAKE.slack));
+  assert.ok(!raw.includes(FAKE.anthropic));
+  assert.ok(/REDACTED/.test(raw));
+});
+
+test('500개 초과 시 오래된 중복 file_read 부터 정리하고 보호 종류는 남긴다', () => {
+  const events = [];
+  for (let i = 0; i < 520; i++) {
+    events.push({ timestamp: new Date(Date.now() + i).toISOString(), task_id: 't', attempt: 1,
+                  type: 'file_read', path: 'src/dup.js' });
+  }
+  events.push({ timestamp: new Date().toISOString(), task_id: 't', attempt: 1,
+                type: 'file_changed', path: 'src/keep.js' });
+  events.push({ timestamp: new Date().toISOString(), task_id: 't', attempt: 1,
+                type: 'test_result', command: 'npm test', status: 'failed' });
+  const { events: kept, removed } = progress.pruneEvents(events);
+  assert.ok(kept.length <= progress.LIMITS.maxEvents, `kept=${kept.length}`);
+  assert.ok(removed > 0);
+  assert.ok(kept.some(e => e.type === 'file_changed'), 'file_changed 를 지우면 안 된다');
+  assert.ok(kept.some(e => e.type === 'test_result'), 'test_result 를 지우면 안 된다');
+});
+
+test('checkpoint 필드 상한을 지킨다(5.6)', () => {
+  const lim = modelConfig.checkpointLimits();
+  assert.deepStrictEqual(lim, {
+    completed_steps: 30, files_read: 100, files_changed: 100, commands_run: 50, test_results: 30,
+  });
+  const many = [];
+  for (let i = 0; i < 200; i++) {
+    many.push({ timestamp: new Date(Date.now() + i).toISOString(), type: 'file_read', path: `src/f${i}.js` });
+    many.push({ timestamp: new Date(Date.now() + i).toISOString(), type: 'step_completed', step_id: `s${i}` });
+  }
+  const sum = progress.summarizeProgressEvents(many, lim);
+  assert.strictEqual(sum.files_read.length, 100);
+  assert.strictEqual(sum.completed_steps.length, 30);
+});
+
+test('전용 CLI 가 입력을 검증하고 이벤트를 기록한다', () => {
+  const { spawnSync } = require('child_process');
+  const CLI = path.join(SB, 'tools', 'progress-event.js');
+  const D = tmpdir('fde-1068cli-');
+  const ok = spawnSync(process.execPath, [CLI, '--task', 'giip-1234', '--attempt', '1',
+    '--type', 'file_changed', '--step', 'step-2', '--path', 'src/example.js',
+    '--summary', '버튼 글자색 변경', '--base-dir', D], { encoding: 'utf8' });
+  assert.strictEqual(ok.status, 0, `${ok.stdout}${ok.stderr}`);
+  const events = progress.readProgressEvents(D, 'giip-1234');
+  assert.strictEqual(events.length, 1);
+  assert.strictEqual(events[0].type, 'file_changed');
+  assert.strictEqual(events[0].path, 'src/example.js');
+  assert.strictEqual(events[0].step_id, 'step-2');
+
+  const bad = spawnSync(process.execPath, [CLI, '--task', 'giip-1234', '--type', 'nope',
+    '--base-dir', D], { encoding: 'utf8' });
+  assert.notStrictEqual(bad.status, 0, '허용되지 않는 type 은 실패해야 한다');
+});
+
+// ── 중앙 runtime 경로 (7) ───────────────────────────────────────────────────
+section('중앙 runtime 경로 통일 (giip-1068 §7)');
+
+test('checkpoint / progress / cost 로그가 같은 runtime root 아래에 있다', () => {
+  const D = tmpdir('fde-1068rt-');
+  const root = runtimePaths.runtimeRoot(D).replace(/\\/g, '/');
+  assert.ok(root.endsWith('.agent/runtime'), root);
+  for (const p of [checkpoint.checkpointPath(D, 't'), progress.eventPath(D, 't'), costTracker.logPath(D)]) {
+    assert.ok(p.replace(/\\/g, '/').startsWith(root), `${p} 가 runtime root 밖이다`);
+  }
+});
+
+test('FDE_RUNTIME_DIR 로 런타임 루트를 덮어쓸 수 있다', () => {
+  const D = tmpdir('fde-1068env-');
+  const prev = process.env.FDE_RUNTIME_DIR;
+  process.env.FDE_RUNTIME_DIR = D;
+  try {
+    assert.strictEqual(path.resolve(runtimePaths.runtimeRoot('/somewhere/else')), path.resolve(D));
+    assert.ok(costTracker.logPath('/somewhere/else').startsWith(D));
+    assert.ok(checkpoint.checkpointPath('/somewhere/else', 't').startsWith(D));
+  } finally {
+    if (prev === undefined) delete process.env.FDE_RUNTIME_DIR; else process.env.FDE_RUNTIME_DIR = prev;
+  }
+});
+
+test('checkpoint 에 절대경로 대신 project_name + 마스킹 상대경로를 남긴다(7.2)', () => {
+  const D = tmpdir('fde-1068wd-');
+  const cp = checkpoint.beginAttempt(D, 'giip-1234', {
+    attempt: 1, provider: 'minimax', model: 'M', taskClass: 'standard', workDir: D,
+  });
+  assert.ok(cp.project_name, 'project_name 이 있어야 한다');
+  assert.ok(cp.work_dir && cp.work_dir.length < D.length, `work_dir=${cp.work_dir}`);
+  const raw = fs.readFileSync(checkpoint.checkpointPath(D, 'giip-1234'), 'utf8');
+  assert.ok(!raw.includes(D.replace(/\\/g, '\\\\')), 'checkpoint 에 절대경로 전체가 들어갔다');
+});
+
+// ── 프롬프트 함수 분리 (4.2) ────────────────────────────────────────────────
+section('최초/재개 프롬프트 함수 분리 (giip-1068 §4.2)');
+
+test('buildInitialExecutionPrompt / buildResumeExecutionPrompt 가 분리돼 있다', () => {
+  assert.strictEqual(typeof prompts.buildInitialExecutionPrompt, 'function');
+  assert.strictEqual(typeof prompts.buildResumeExecutionPrompt, 'function');
+});
+
+test('buildExecutionPrompt 는 하위 호환으로 최초 실행 프롬프트를 만든다', () => {
+  const a = prompts.buildExecutionPrompt({ taskContent: 'T', taskId: 'x', now: '2026-01-01T00:00:00Z' });
+  const b = prompts.buildInitialExecutionPrompt({ taskContent: 'T', taskId: 'x', now: '2026-01-01T00:00:00Z' });
+  assert.strictEqual(a, b);
+});
+
+test('최초 프롬프트 절 순서가 4.3 그대로다', () => {
+  const p = gInitialPrompt();
+  const idx = [
+    p.indexOf('senior software engineer'),
+    p.indexOf('=== 안전 규칙 (고정) ==='),
+    p.indexOf('=== 실행 프로토콜 (고정) ==='),
+    p.indexOf('=== 선택된 컨텍스트'),
+    p.indexOf('=== 프로젝트 정보 ==='),
+    p.indexOf('=== 태스크 ==='),
+    p.indexOf('=== 동적 상태 ==='),
+  ];
+  for (let i = 1; i < idx.length; i++) {
+    assert.ok(idx[i] > idx[i - 1] && idx[i] > 0, `절 순서가 어긋났다: ${JSON.stringify(idx)}`);
+  }
+});
+
+test('재개 프롬프트 절 순서가 4.4 그대로다', () => {
+  const p = prompts.buildResumeExecutionPrompt({
+    taskContent: G_TASK, taskClass: 'standard', taskId: 'x', attempt: 2,
+    completedSteps: ['s1'], pendingSteps: ['s2'], filesRead: ['a.js'], filesChanged: ['b.js'],
+    diffSummary: 'b.js | 1 +', commandsRun: ['npm test'],
+    testResults: [{ command: 'npm test', status: 'failed' }],
+    errorSummary: 'boom', resumeContextText: 'RC',
+  });
+  const order = ['=== 재개 전용 안전 규칙', '=== 태스크 요약', '=== 완료된 단계',
+    '=== 미완료 단계', '=== 이미 읽은 파일', '=== 이미 변경한 파일', '=== 변경 diff 요약',
+    '=== 실행한 명령', '=== 테스트 결과', '=== 이전 오류', '=== 재개 컨텍스트', '=== 동적 상태'];
+  let prev = -1;
+  for (const s of order) {
+    const i = p.indexOf(s);
+    assert.ok(i > prev, `${s} 위치 이상 (i=${i}, prev=${prev})`);
+    prev = i;
+  }
+});
+
+test('태스크 요약은 4.4 상한(목적 500 / 성공 10 / 영향 20 / 금지 10 / 전체 3000)을 지킨다', () => {
+  const big = ['# TASK: T', '', '## 요청 내용', '목'.repeat(3000), '', '## 실행 계획',
+    ...Array.from({ length: 30 }, (_, i) => `${i + 1}. 단계 ${i}`), '', '## 영향 파일/서브시스템',
+    ...Array.from({ length: 40 }, (_, i) => `- file${i}.js`), '', '## 주의사항',
+    ...Array.from({ length: 30 }, (_, i) => `- 금지 ${i}`)].join('\n');
+  const s = prompts.summarizeTaskSpec(big);
+  assert.ok(s.length <= 3000, `summary=${s.length}`);
+  const purposeLine = s.split('\n').find(l => l.startsWith('- 목적:'));
+  assert.ok(purposeLine.length <= 500 + 10, `purpose=${purposeLine.length}`);
+  assert.ok((s.match(/^  \d+\. /gm) || []).length <= 10, '성공 조건 10개 초과');
+  assert.ok((s.match(/^  - file\d+\.js/gm) || []).length <= 20, '영향 대상 20개 초과');
+});
+
+test('실행 프롬프트에 진행 이벤트 기록 규칙이 들어간다(5.5)', () => {
+  const p = gInitialPrompt({ progressEventCommand: 'node tools/progress-event.js --task x ...' });
+  assert.ok(p.includes('진행 이벤트 기록'));
+  for (const t of progress.EVENT_TYPES) assert.ok(p.includes(t), `${t} 안내가 없다`);
+  assert.ok(p.includes('progress_event_command'), '동적 상태에 실제 명령이 있어야 한다');
+});
+
+// ── 회귀: 기존 Slack/PR 흐름 ────────────────────────────────────────────────
+section('회귀: 기존 기능 (giip-1068 이후)');
+
+test('신규 모듈이 전부 로드된다', () => {
+  for (const m of ['progress-events', 'resume-context-builder', 'runtime-paths']) {
+    require(path.join(SB, m));
+  }
+});
+
+test('task-manager 가 최초/재개 프롬프트를 각각 호출한다', () => {
+  const src = fs.readFileSync(path.join(SB, 'task-manager.js'), 'utf8');
+  assert.ok(/buildInitialExecutionPrompt\(/.test(src), '최초 프롬프트 호출이 없다');
+  assert.ok(/buildResumeExecutionPrompt\(/.test(src), '재개 프롬프트 호출이 없다');
+  assert.ok(/shouldResume\(/.test(src), '재개 판정 호출이 없다');
+  assert.ok(/changedSourceFiles\(/.test(src), '소스 변경 판정 호출이 없다');
+  assert.ok(/RUNTIME_BASE_DIR/.test(src), 'checkpoint/비용 로그 루트 통일이 안 됐다');
+});
+
+test('Slack 명령/흐름 문자열이 그대로 남아 있다', () => {
+  const h = fs.readFileSync(path.join(SB, 'handlers.js'), 'utf8');
+  for (const needle of ["cmd === 'tasklist'", '!issues', '!klayer', '!cost', 'startExecution',
+                        'commitAndPRChangedRepos', 'cancelTaskFile']) {
+    assert.ok(h.includes(needle), `${needle} 가 사라졌다`);
+  }
+});
+
+test('slack-bot-minimax 는 이번 최적화 대상이 아니다(별개 프로젝트용 배포)', () => {
+  const envEx = path.join(SB, '..', 'slack-bot-minimax', '.env.example');
+  if (!fs.existsSync(envEx)) return;   // 폴더가 없으면 검증 생략
+  const txt = fs.readFileSync(envEx, 'utf8');
+  assert.ok(/GITHUB_REPO=LowyShin\/smartorder-works/.test(txt),
+    'slack-bot-minimax 가 다른 프로젝트(smartorder-works)를 향한다는 근거가 사라졌다');
 });
 
 // ── 결과 ────────────────────────────────────────────────────────────────────

--- a/slack-bot/tools/test-live-pipeline.js
+++ b/slack-bot/tools/test-live-pipeline.js
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+/**
+ * test-live-pipeline.js — 라이브 통합 테스트 (giip-1068 §12)
+ *
+ *   node slack-bot/tools/test-live-pipeline.js
+ *
+ * 실제 Slack → 모델 → 파일 변경 → PR 생성 경로를 검증한다. 외부 자격증명과 테스트용 Slack 채널이
+ * 있어야 하므로 단위 테스트(test-cost-optimization.js)와 분리했다.
+ *
+ * 결과 등급은 §12.2 의 다섯 가지만 쓴다.
+ *   PASS / FAIL / SKIP_NO_CREDENTIAL / SKIP_NO_TEST_CHANNEL / SKIP_PROVIDER_UNAVAILABLE
+ *
+ * SKIP 을 PASS 에 포함하지 않는다. 자격증명이 없으면 성공으로 처리하지 않고 SKIP 으로 남긴다.
+ *
+ * 필요한 환경변수
+ *   SLACK_BOT_TOKEN / SLACK_APP_TOKEN   Slack 자격증명 (slack-bot/.env)
+ *   FDE_TEST_SLACK_CHANNEL              테스트 전용 채널 ID (운영 채널을 쓰지 마라)
+ *   MINIMAX_API_KEY 또는 claude-accounts.json  모델 공급자
+ *   GITHUB_TOKEN 또는 gh CLI 로그인       PR 생성 확인용
+ *
+ * 이 스크립트는 봇 프로세스를 대신 돌리지 않는다. 시나리오별로
+ *   (a) 사전 조건을 실측하고
+ *   (b) 조건이 갖춰졌을 때만 테스트 채널에 요청을 올린 뒤 결과를 폴링한다.
+ * 조건이 없으면 그 시나리오는 SKIP 사유와 함께 기록된다.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const SB = path.join(__dirname, '..');
+try { require('dotenv').config({ path: path.join(SB, '.env') }); } catch { /* dotenv 없으면 env 그대로 */ }
+
+const GRADES = ['PASS', 'FAIL', 'SKIP_NO_CREDENTIAL', 'SKIP_NO_TEST_CHANNEL', 'SKIP_PROVIDER_UNAVAILABLE'];
+const results = [];
+
+function record(scenario, grade, detail) {
+  if (!GRADES.includes(grade)) throw new Error(`허용되지 않는 결과 등급: ${grade}`);
+  results.push({ scenario, grade, detail: detail || '' });
+  console.log(`  ${grade.padEnd(26)} ${scenario}${detail ? ` — ${detail}` : ''}`);
+}
+
+// ── 사전 조건 실측 ───────────────────────────────────────────────────────────
+function haveSlackCredentials() {
+  return !!(process.env.SLACK_BOT_TOKEN && process.env.SLACK_APP_TOKEN);
+}
+
+function haveTestChannel() {
+  return !!(process.env.FDE_TEST_SLACK_CHANNEL && String(process.env.FDE_TEST_SLACK_CHANNEL).trim());
+}
+
+function haveProvider() {
+  const minimax = !!process.env.MINIMAX_API_KEY;
+  let claude = false;
+  try {
+    const accounts = require(path.join(SB, 'claude-accounts'));
+    claude = accounts.count() > 0;
+  } catch { claude = false; }
+  const cli = spawnSync(process.platform === 'win32' ? 'where' : 'which', ['claude'],
+    { encoding: 'utf8', windowsHide: true }).status === 0;
+  return { minimax, claude, cli, any: (minimax || claude) && cli };
+}
+
+function haveGitHub() {
+  if (process.env.GITHUB_TOKEN) return true;
+  const r = spawnSync('gh', ['auth', 'status'], { encoding: 'utf8', windowsHide: true });
+  return r.status === 0;
+}
+
+function preflight() {
+  const provider = haveProvider();
+  return {
+    slack: haveSlackCredentials(),
+    channel: haveTestChannel(),
+    provider,
+    github: haveGitHub(),
+  };
+}
+
+/**
+ * 시나리오별 SKIP 사유를 우선순위대로 판정한다.
+ * @returns {string|null} SKIP 등급 또는 null(실행 가능)
+ */
+function skipReason(pre, needs = {}) {
+  if (needs.slack && !pre.slack) return 'SKIP_NO_CREDENTIAL';
+  if (needs.channel && !pre.channel) return 'SKIP_NO_TEST_CHANNEL';
+  if (needs.provider && !pre.provider.any) return 'SKIP_PROVIDER_UNAVAILABLE';
+  // 429 재현은 MiniMax 테스트 계정(또는 mock provider)이 있어야만 가능하다.
+  if (needs.minimax && !pre.provider.minimax) return 'SKIP_PROVIDER_UNAVAILABLE';
+  if (needs.github && !pre.github) return 'SKIP_NO_CREDENTIAL';
+  return null;
+}
+
+// ── Slack 왕복 (자격증명이 있을 때만 실제로 호출) ────────────────────────────
+async function postToTestChannel(text) {
+  const slack = require(path.join(SB, 'slack-api'));
+  const channel = String(process.env.FDE_TEST_SLACK_CHANNEL).trim();
+  return slack.postMessage(channel, text);
+}
+
+async function runScenario(name, needs, pre, fn, note) {
+  const skip = skipReason(pre, needs);
+  if (skip) { record(name, skip, note || missingDetail(pre, needs)); return; }
+  try {
+    const r = await fn();
+    record(name, r.ok ? 'PASS' : 'FAIL', r.detail);
+  } catch (e) {
+    record(name, 'FAIL', e.message);
+  }
+}
+
+function missingDetail(pre, needs) {
+  const missing = [];
+  if (needs.slack && !pre.slack) missing.push('SLACK_BOT_TOKEN/SLACK_APP_TOKEN 미설정');
+  if (needs.channel && !pre.channel) missing.push('FDE_TEST_SLACK_CHANNEL 미설정');
+  if (needs.provider && !pre.provider.any) {
+    missing.push(`모델 공급자 없음(minimax=${pre.provider.minimax}, claude=${pre.provider.claude}, claude CLI=${pre.provider.cli})`);
+  }
+  if (needs.minimax && !pre.provider.minimax) {
+    missing.push('MINIMAX_API_KEY 미설정 — 429 재현용 테스트 계정/mock provider 없음');
+  }
+  if (needs.github && !pre.github) missing.push('GITHUB_TOKEN/gh 인증 없음');
+  return missing.join(', ');
+}
+
+// ── 시나리오 ────────────────────────────────────────────────────────────────
+async function main() {
+  const pre = preflight();
+  console.log('라이브 통합 테스트 (giip-1068 §12)');
+  console.log(`사전 조건: slack=${pre.slack} testChannel=${pre.channel}`
+    + ` minimax=${pre.provider.minimax} claude=${pre.provider.claude} claudeCLI=${pre.provider.cli}`
+    + ` github=${pre.github}\n`);
+
+  // 시나리오 1: trivial (Fast Path, 모델 호출 1회, PR 생성)
+  await runScenario('시나리오 1: trivial (Fast Path → PR)',
+    { slack: true, channel: true, provider: true, github: true }, pre, async () => {
+      const req = 'README.md의 "Zero Tool Setup"을 "Minimal Tool Setup"으로 변경해줘.';
+      await postToTestChannel(req);
+      return {
+        ok: false,
+        detail: '요청은 테스트 채널에 올렸다. 봇 프로세스의 처리 완료(Fast Path/모델 호출 1회/PR 생성/'
+          + '결과 보고서/전체 role 미로딩)는 `!cost task <id>` 와 PR 목록으로 사람이 확인해야 한다 — '
+          + '자동 판정 미구현이므로 PASS 로 올리지 않는다',
+      };
+    });
+
+  // 시나리오 2: standard (컨텍스트 최대 6개, MiniMax 우선, Sonnet fallback, PR)
+  await runScenario('시나리오 2: standard (컨텍스트 6개/MiniMax 우선/PR)',
+    { slack: true, channel: true, provider: true, github: true }, pre, async () => {
+      await postToTestChannel('slack-bot/repo-status.js 의 미사용 변수 경고를 하나 고쳐줘');
+      return { ok: false, detail: '요청 게시 완료 — 결과 판정은 사람이 PR/로그로 확인' };
+    });
+
+  // 시나리오 3: fallback (429 → checkpoint → Claude, 부분 작업 유무에 따른 프롬프트 선택)
+  await runScenario('시나리오 3: fallback (429 → checkpoint → resume prompt)',
+    { provider: true, minimax: true }, pre, async () => {
+      // 이 시나리오는 MiniMax 를 실제로 429 상태로 만들거나 mock provider 가 필요하다.
+      return {
+        ok: false,
+        detail: 'MiniMax 테스트 계정의 429 재현 또는 mock provider 주입 경로가 이 환경에 없다 — '
+          + '단위 테스트 A/B/C 가 같은 판정 로직(shouldResume/hasRealWork/재개 프롬프트 60%)을 '
+          + '검증하지만, 라이브 왕복은 NOT_MEASURED',
+      };
+    });
+
+  // 시나리오 4: cancel (실행 중 취소 → checkpoint 보존)
+  await runScenario('시나리오 4: cancel (실행 중 취소 → checkpoint 보존)',
+    { slack: true, channel: true, provider: true }, pre, async () => {
+      await postToTestChannel('cancel <task-id>');
+      return { ok: false, detail: '요청 게시 완료 — 프로세스 중단/checkpoint 보존/재실행 감지는 사람이 확인' };
+    });
+
+  // ── 결과 ──────────────────────────────────────────────────────────────────
+  const pass = results.filter(r => r.grade === 'PASS').length;
+  const fail = results.filter(r => r.grade === 'FAIL').length;
+  const skip = results.filter(r => r.grade.startsWith('SKIP')).length;
+  console.log(`\n${'─'.repeat(60)}`);
+  console.log(`PASS ${pass} / FAIL ${fail} / SKIP ${skip}  (SKIP 은 PASS 에 포함하지 않는다)`);
+  console.log(JSON.stringify(results, null, 2));
+  // SKIP 만 있는 경우도 성공 종료로 처리하지 않는다 — 검증되지 않았음을 종료코드로 남긴다.
+  process.exit(fail > 0 || pass === 0 ? 1 : 0);
+}
+
+if (require.main === module) {
+  main().catch(e => { console.error(e); process.exit(1); });
+}
+module.exports = { preflight, skipReason, GRADES };


### PR DESCRIPTION
# GIIP FDE Agent 비용 최적화 2차 완료 보고서

giip issue #1068 (csn 47) — giip-1063(PR #55) 후속 보완.

## 1. 기준 정보
- 기준 커밋: `620d3101d7eb9c6b243f149fd61905e70b02336d` (main)
- 작업 커밋: `c9fdcc0` (브랜치 `bot/task-giip-1068`)
- 테스트 일시: 2026-08-13
- 테스트 환경: Windows 10, Node v24.13.0, 별도 git worktree. Slack 자격증명/테스트 채널/MiniMax 키 **없음**

## 2. 변경 파일

| 파일 | 변경 내용 | 변경 이유 |
|---|---|---|
| `slack-bot/prompt-templates.js` | `buildInitialExecutionPrompt` / `buildResumeExecutionPrompt` 분리, `summarizeTaskSpec()`, 진행이벤트 규칙, 등급별 길이 예산 적용 | §4 재시도 전용 프롬프트 분리 |
| `slack-bot/resume-context-builder.js` (신규) | 재개 컨텍스트 최대 3개(critical 4개) 선택·읽기 | §4.5 |
| `slack-bot/progress-events.js` (신규) | 8종 이벤트 JSON Lines 기록/읽기/요약/정리 | §5 |
| `slack-bot/tools/progress-event.js` (신규) | 모델이 쓰는 전용 CLI(검증 + secret 마스킹 + 절대경로 마스킹) | §5.5 |
| `slack-bot/retry-checkpoint.js` | `changedSourceFiles()`, `hasRealWork()`, `shouldResume()`, 진행 이벤트로 checkpoint 필드 채우기, runtime root 사용 | §5.6 / §6 / §7 |
| `slack-bot/runtime-paths.js` (신규) | `runtimeRoot()` + `FDE_RUNTIME_DIR`, `maskWorkDir()` | §7 |
| `slack-bot/model-config.js` | 등급별 `contextLimits` / `promptLimits` / `resumeContextLimits` / `checkpointLimits` | §2.1~2.3, §5.6 |
| `slack-bot/model-router.js` | `detectOperation()` / `detectRiskClass()`, operation×risk 규칙표, read-only critical 오탐 차단 | §10 |
| `slack-bot/batch-planner.js` | `model_calls_saved` 제거 → 실제/가정 절감 분리 | §8.1~8.2 |
| `slack-bot/cost-tracker.js` | §13 신규 필드, 40% 미만 경고, 실제/가정 절감 분리 집계, `!cost detail` | §8.3~8.4, §13 |
| `slack-bot/task-manager.js` | 최초/재개 프롬프트 호출 분리, 재개 판정 연동, runtime root 통일, 신규 계측 필드 | §4.6, §6.5, §7 |
| `slack-bot/claude-cli.js` | 배치 로그/계측을 실제·가정 절감으로 분리 | §8 |
| `slack-bot/handlers.js` | `risk_class`/`operation` 태스크 메타 전달, `!cost detail` 안내 | §10.2 |
| `slack-bot/.env.example` | `FDE_RUNTIME_DIR`, 프롬프트/재개컨텍스트/checkpoint 한도 문서화 | §7, §2 |
| `slack-bot/docs/BOT_VARIANTS.md` (신규) | `slack-bot-minimax` 사용 여부 판정과 결정 근거 | §9 |
| `slack-bot/tools/test-cost-optimization.js` | 테스트 A~I 추가 (51건 → 101건) | §11 |
| `slack-bot/tools/test-live-pipeline.js` (신규) | 라이브 4 시나리오 + SKIP 등급 | §12 |

## 3. 프롬프트 비교

핵심 완료 기준(§16 마지막 문장)을 실제로 재현한 E2E 측정 — 진행 이벤트 9건 기록 → MiniMax 429 → checkpoint → 재개 프롬프트 조립:

| 테스트 | 등급 | 최초 문자 수 | 재개 문자 수 | 감소율 | 기준 통과 |
|---|---|---:|---:|---:|---|
| E2E 재현(파일 2개 변경 + 단계 2개 완료 + 테스트 실패) | standard | 19,340 | 1,715 | 91.1% | PASS (≤60%) |
| 단위 테스트 B(대형 컨텍스트/오류/diff 포함) | standard | 측정값 기준 비율 검증 | — | — | PASS (≤60%) |
| 테스트 F trivial | trivial | ≤24,000 | ≤12,000 | — | PASS |
| 테스트 F standard | standard | ≤48,000 | ≤24,000 | — | PASS |
| 테스트 F complex | complex | ≤80,000 | ≤40,000 | — | PASS |
| 테스트 F critical | critical | ≤120,000 | ≤64,000 | — | PASS |

테스트 F는 40만 자 컨텍스트를 넣어도 등급별 상한을 **1자도** 넘지 않음을 확인한다.

## 4. checkpoint 정확성

E2E 재현에서 진행 이벤트가 checkpoint 에 실제로 반영됨(1차에서는 전부 빈 배열이었다):

| 테스트 | 완료 단계 | 소스 변경 파일 | 명령 | 테스트 결과 | 정확성 |
|---|---:|---:|---:|---:|---|
| C: 테스트 단계 실패 | 2 | 2 | 1 | 1 | 정확 (progress_event_count=9) |
| A: 시작 전 429 | 0 | 0 | 0 | 0 | 정확 (`hasRealWork=false` → 최초 프롬프트 재사용) |
| D: 태스크 파일만 변경 | 0 | 0 (metadata 1) | 0 | 0 | 정확 |
| E: nested repo 변경 | — | 1 (`projects/giipprj/giipv3/src/example.js`) | — | — | 정확, 절대경로 노출 0 |

## 5. 모델 라우팅

| 요청 | operation | risk_class | task_class | 선택 모델 | 기대값 일치 |
|---|---|---|---|---|---|
| 인증 관련 코드가 어느 파일에 있는지 알려줘 | read | critical | standard | `MODEL_FALLBACK_STANDARD`(sonnet)/MiniMax — Opus 아님 | ✅ |
| auth/login.js의 세션 토큰 검증 로직을 수정해줘 | write | critical | critical | 실행=complex 티어, 프리미엄은 plan/review 만 · Fast Path 금지 | ✅ |
| 로그인 구조를 설명해줘 | read | critical | standard | — | ✅ |
| 인증 관련 문서가 어디 있어? | read | critical | standard | — | ✅ |
| 결제 기능이 구현되어 있는지 확인해줘 | read | critical | standard | — | ✅ |
| 운영 DB 스키마를 읽기 전용으로 보여줘 | read | critical | standard | — | ✅ |
| 운영 DB 의 사용자 테이블을 전부 삭제해줘 | delete | elevated | critical | — | ✅ |
| 운영 서버에 배포해줘 | deploy | none(운영 키워드) | critical | — | ✅ |
| 사용자 테이블 스키마 마이그레이션을 실행해줘 | migrate | elevated | complex | — | ✅ |
| README.md의 "…"을 "…"으로 변경해줘 | write | none | trivial | Fast Path | ✅ (회귀 없음) |

## 6. 비용 계측

| 항목 | 변경 전 | 변경 후 | 실측/추정 |
|---|---:|---:|---|
| 재개 프롬프트 입력 문자 수(E2E 재현) | 19,340 (동일 프롬프트 재전송) | 1,715 | 실측 |
| 배치 "절감 호출"(3항목 메시지) | 2회 (가상 수치를 실제처럼 표기) | 실제 0회 / 가정 2회(분리) | 실측 |
| Fast Path 절감 | 2회(추정을 실측처럼 표기) | 2회 + `saving_is_estimated:true`, 보고서에 `ESTIMATED` | ESTIMATED |
| 실제 토큰·비용 절감액 | — | NOT_MEASURED | 라이브 미실행 |

`model-pricing.json` 에 단가가 없으면 비용은 여전히 `null`(측정 불가)로 남고 지어내지 않는다.

## 7. slack-bot-minimax 처리

- **사용 여부 판정**: §9.1 체크리스트 5항목을 실측 → `register-startup.ps1` 있음, 독립 `index.js`+`package.json` 있음, 최근 180일 내 기능 커밋 있음(2026-07-30 `a437db9`, `f8c9df7`) → **"사용 가능 경로"**. 근거 없이 미사용으로 처리하지 않았다.
- **근거**: `slack-bot-minimax/.env.example:12` 의 `GITHUB_REPO=LowyShin/smartorder-works`. 이 봇은 giip-fde-agent 자신의 이슈 큐를 처리하는 봇이 **아니라** 완전히 별개의 다운스트림 프로젝트(Vegetrade SmartOrder, `smartorder-works`)를 위한 **독립 배포본**이다. `check_stock_db.js` / `reset_password.js` 등 SmartOrder 전용 파일이 이 폴더에만 있는 것도 같은 근거다. `slack-bot`(base)이 이 저장소의 실제 이슈 처리 봇이고, `minimax-accounts.js`(MiniMax 우선 → Claude 폴백)는 giip-780 대부터 있던 기존 구조라 두 코드베이스의 모델 라우팅 정책이 어긋나지 않는다.
- **처리 내용**: **현행 유지 (사용자 결정, 2026-08-13)**. 서로 다른 프로젝트를 위한 별개 배포이므로 `slack-bot-core/` 강제 통합도, deprecated 표시도 하지 않는다. 대신 판정 절차·근거·재검토 조건을 `slack-bot/docs/BOT_VARIANTS.md` 에 명시 기록했다. 이는 §9.2 가 금지한 "근거 없는 방치"가 아니라 실측+결정에 근거한 명시적 판단이다. 이번 최적화는 `slack-bot/`(base)에만 적용했고 `slack-bot-minimax/`·`slack-bot-openclaw/` 는 수정하지 않았다.
- 회귀 테스트에 이 근거(`GITHUB_REPO`)가 바뀌면 알아채도록 가드 테스트를 넣었다.

## 8. 단위 테스트

```
node slack-bot/tools/test-cost-optimization.js
통과 101 / 실패 0
```

- PASS: 101
- FAIL: 0
- 총 테스트: 101 (기준 커밋 51건 → 신규 50건 추가)
- 커버: A(시작 전 429) B(파일 2개 후 429/60% 규칙) C(테스트 단계 실패) D(태스크 파일만 변경) E(nested repo) F(등급별 길이 상한) G(배치 수치) H(read-only 보안 질문) I(인증 코드 수정) + 진행이벤트 모듈·runtime 경로·프롬프트 분리·회귀

## 9. 라이브 통합 테스트

```
node slack-bot/tools/test-live-pipeline.js
PASS 0 / FAIL 0 / SKIP 4   (exit 1)
사전 조건: slack=false testChannel=false minimax=false claude=true claudeCLI=true github=true
```

| 시나리오 | 결과 | 실패 또는 SKIP 사유 |
|---|---|---|
| 1. trivial (Fast Path → PR) | `SKIP_NO_CREDENTIAL` | `SLACK_BOT_TOKEN`/`SLACK_APP_TOKEN` 미설정, `FDE_TEST_SLACK_CHANNEL` 미설정 |
| 2. standard (컨텍스트 6개/MiniMax 우선/PR) | `SKIP_NO_CREDENTIAL` | 동일 |
| 3. fallback (429 → checkpoint → resume) | `SKIP_PROVIDER_UNAVAILABLE` | `MINIMAX_API_KEY` 미설정 — 429 재현용 테스트 계정/mock provider 없음 |
| 4. cancel (실행 중 취소 → checkpoint 보존) | `SKIP_NO_CREDENTIAL` | 동일 |

**SKIP 을 PASS 로 세지 않았고, 스크립트도 PASS 0 이면 exit 1 로 끝난다.**

## 10. 남은 문제

1. **라이브 Slack→모델→PR 왕복 미검증** (§12, 이슈 문제 6번). 이 환경에 Slack 자격증명·테스트 채널·MiniMax 키가 없다. 자격증명이 있는 환경에서 `FDE_TEST_SLACK_CHANNEL` 을 지정해 `test-live-pipeline.js` 를 다시 돌려야 한다.
2. **라이브 시나리오 1·2·4 의 자동 판정 미구현**. 현재는 테스트 채널에 요청을 올린 뒤 결과 판정을 사람에게 맡기므로, 자격증명이 있어도 `FAIL`(=미판정)로 떨어진다. 봇 프로세스 상태를 폴링해 자동 판정하는 하네스가 추가로 필요하다.
3. **실제 토큰·비용 절감액은 `NOT_MEASURED`**. 문자 수 감소(91.1%)는 실측이지만 USD 절감은 `model-pricing.json` 단가와 라이브 로그가 있어야 나온다.
4. **진행 이벤트는 모델이 CLI 를 실제로 호출해야 채워진다**. 프롬프트에 필수 규칙으로 넣었지만 모델이 이를 무시하면 checkpoint 는 다시 비게 된다(이때는 `changedSourceFiles()` 의 git 기반 판정으로 폴백). 라이브에서 `progress_event_count` 를 확인해야 한다.
5. `slack-bot-openclaw` 는 이번 판정 범위 밖이다(별도 실행 모델).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
