### PR TITLE
fix(slack-bot): 상태전이 코멘트 생략 구조적 방지 + GIIP_ACTOR_TAG 도입

### DIFF
--- a/.agent/rules/PROTOCOL_PROGRESS_COMMENT.md
+++ b/.agent/rules/PROTOCOL_PROGRESS_COMMENT.md
@@ -6,6 +6,28 @@
 ## 전제 (Gate)
 - **giip issue API 접근 가능 + 작업 중인 이슈 번호(isn)를 알 때만** 적용. **isn 미상/미연동이면 전량 조용히 스킵.**
 
+## 상태 전이는 항상 코멘트를 동반한다 (강화 규정, giip #1146~1151/#1155 인시던트 재발방지)
+- 2026-08-16: 자매 프로젝트(giipprj, csn 47)에서 무인 세션이 giip 이슈 여러 건을 IN_PROGRESS 로
+  전이시키면서 **코멘트를 전혀 남기지 않아** 누가/언제/왜 착수했는지 추적 불가능했던 인시던트
+  (giip #1146~1151/#1155)가 발생했다. 이 레포(`slack-bot/giip-task.js` `maybeFinish`)도
+  `handlers.js` 가 `comment=null` 로 IN_PROGRESS 전이를 호출해 동일한 결함을 갖고 있었다.
+- **단독 상태변경 금지**(위 §"남기는 시점" 5번 규정의 강화): 상태 전이(PENDING→READY→
+  IN_PROGRESS→REVIEW/DONE 등)는 반드시 코멘트를 동반해야 하며, 그 코멘트에는 다음 3요소를
+  명시한다.
+  - **행위자(Actor)**: 어느 배포/누가 처리했는지. 이 레포는 `GIIP_ACTOR_TAG` 환경변수로
+    배포자가 지정한다(예: 이 PC 배포=`lowyclaude`). 미설정 시 `slack-bot@<hostname>` 자동 폴백.
+  - **시각(When)**: ISO 타임스탬프.
+  - **사유(Why)**: 왜 이 상태로 전이하는지. caller 가 준 comment 가 있으면 그 내용, 없으면
+    "(자동 전이, 상세 사유 미기재)".
+- **코드 레벨 강제**: `slack-bot/giip-task.js`(및 `slack-bot-minimax/giip-task.js`, 동일 코드)의
+  `maybeFinish(channelId, isn, status, comment)` 가 `status` 가 지정된 모든 호출에서 위 헤더가
+  붙은 코멘트를 자동 생성해 남긴다 — caller 가 `comment` 를 `null`/미지정으로 넘겨도(예:
+  `handlers.js` 의 IN_PROGRESS 착수 호출) 코멘트 자체가 스킵되지 않도록 구조적으로 막았다.
+  `maybeComment`(상태전이 없는 note)도 동일하게 행위자/시각 헤더를 붙인다.
+- 정본 쪽(giipprj, `giipdb/docs/30_Specs/SPEC_GISSUE_SCHEDULER.md`, 이 문서 작성 시점 기준
+  §5.1 근방으로 추정 — 다른 에이전트가 병렬로 formalize 중이라 정확한 섹션은 정본에서 확인할 것)
+  에도 동등한 규정이 추가되는 중이다. 동기화 시 이 섹션을 정본 문구로 갱신할 것.
+
 ## 남기는 시점 (논리 단위로, 각 1~3줄 note)
 파일 1개당 코멘트 1개 강제 금지. **논리 묶음** 단위로:
 1. **착수**: 로드해 따르는 role/rule/skill/workflow 명시.

--- a/slack-bot-minimax/.env.example
+++ b/slack-bot-minimax/.env.example
@@ -18,6 +18,12 @@ SLACK_CHANNEL_IDS=C0XXXXXXXXX,C0YYYYYYYYY
 # 폴링 간격 (기본 60초)
 POLL_INTERVAL_MS=60000
 
+# 이 배포가 giip 이슈 코멘트에 남길 행위자 이름표(actor tag). 여러 사용자가 각자 배포해 쓰는
+# 범용 코드라 하드코딩하지 않는다 — 상태 전이(IN_PROGRESS/REVIEW 등) 코멘트마다 "누가" 처리했는지
+# 이 값이 헤더에 찍힌다(giip-task.js maybeFinish). 미설정 시 slack-bot@<hostname> 자동 사용.
+# 예: GIIP_ACTOR_TAG=lowyclaude
+# GIIP_ACTOR_TAG=
+
 # MiniMax Token Plan Subscription Key (sk-cp-...) — 선택사항.
 # Claude 전 계정(claude-accounts.json) 사용량 한도 소진 시 최종 폴백 실행 엔진으로 사용.
 # 발급: platform.minimax.io → Console → Account/Token Plan (일반 API Key 아닌 Subscription Key, sk-cp- 접두 필수)

--- a/slack-bot-minimax/giip-task.js
+++ b/slack-bot-minimax/giip-task.js
@@ -4,8 +4,47 @@
  * 설계: docs/DESIGN_slackbot_giip_issue_integration.md §4.
  * 모든 함수는 절대 throw 하지 않는다(봇 무중단). 실패는 로그 + null/no-op.
  */
+const os = require('os');
 const accounts = require('./giip-accounts');
 const giip = require('./giip-api');
+
+/**
+ * 이 배포가 giip 이슈 코멘트에 남길 행위자 이름표. 여러 사용자가 배포해 쓰는 범용 코드이므로
+ * 하드코딩하지 않고 env 로 설정한다(예: 이 PC 배포는 GIIP_ACTOR_TAG=lowyclaude).
+ * 미설정 시 host 기준 합리적 기본값으로 폴백 — 최소한 "어느 머신의 봇인지"는 항상 남는다.
+ */
+function actorTag() {
+  return process.env.GIIP_ACTOR_TAG || `slack-bot@${os.hostname()}`;
+}
+
+/**
+ * 상태전이 코멘트에 행위자(actor)·시각(when)·사유(why) 헤더를 항상 붙인다.
+ * giip #1146~1151/#1155 인시던트(무인 세션이 코멘트 없이 IN_PROGRESS 전이) 재발방지 —
+ * caller 가 comment 를 안 줘도(null) 이 헤더만은 구조적으로 남긴다.
+ */
+function buildTransitionComment(isn, status, comment) {
+  const actor = actorTag();
+  const when = new Date().toISOString();
+  const why = comment ? String(comment) : '(자동 전이, 상세 사유 미기재)';
+  return [
+    `## [${actor}] ISN ${isn} 상태전이: → ${status}`,
+    `**행위자(Actor)**: ${actor}`,
+    `**시각(When)**: ${when}`,
+    `**사유(Why)**: ${why}`,
+  ].join('\n');
+}
+
+/** 상태전이가 없는 note 코멘트에도 일관되게 행위자/시각 헤더를 붙인다. */
+function buildNoteComment(comment) {
+  const actor = actorTag();
+  const when = new Date().toISOString();
+  return [
+    `**행위자(Actor)**: ${actor}`,
+    `**시각(When)**: ${when}`,
+    '',
+    String(comment),
+  ].join('\n');
+}
 
 /** 타임아웃/네트워크 등 일시적 오류인지 판단(1회 재시도 대상). 권한/데이터 오류는 재시도해도 무의미하므로 제외. */
 function isRetryableIssueError(e) {
@@ -54,13 +93,23 @@ async function maybeCreateIssue(channelId, title, content, csn = null) {
   return { isn: null, error: lastErr.message };
 }
 
-/** 완료/에러 시: 코멘트 + 상태전이(best-effort, 실패해도 무시). */
+/**
+ * 완료/에러/착수 시: 코멘트 + 상태전이(best-effort, 실패해도 무시).
+ * 상태 전이(status 지정)는 comment 인자 유무와 무관하게 항상 행위자/시각/사유 헤더가 붙은
+ * 코멘트를 남긴다 — "comment=null 이면 코멘트 자체를 스킵"하던 구버전 버그(giip #1155)가
+ * 재발하지 않도록 여기서 구조적으로 막는다. caller 가 준 comment 는 "사유"에 그대로 보존된다.
+ */
 async function maybeFinish(channelId, isn, status, comment) {
   if (!isn) return;
   const acct = accounts.resolve(channelId);
   if (!acct) return;
-  try { if (comment) await giip.issueComment(acct, isn, comment); }
-  catch (e) { console.error('[giip-task] comment 실패:', e.message); }
+  const wrapped = status
+    ? buildTransitionComment(isn, status, comment)
+    : (comment ? buildNoteComment(comment) : null);
+  if (wrapped) {
+    try { await giip.issueComment(acct, isn, wrapped); }
+    catch (e) { console.error('[giip-task] comment 실패:', e.message); }
+  }
   try { if (status) await giip.issueUpdate(acct, { isn, status }); }
   catch (e) { console.error('[giip-task] status 실패:', e.message); }
 }
@@ -68,12 +117,13 @@ async function maybeFinish(channelId, isn, status, comment) {
 /**
  * 코멘트만 남긴다(상태 전이 없음, best-effort). 작업트리 점유 대기 관계 등
  * "상태는 그대로 두고 사실만 기록"하는 용도. 실패해도 봇 흐름을 막지 않는다.
+ * 일관성을 위해 이 코멘트에도 행위자/시각 헤더를 붙인다.
  */
 async function maybeComment(channelId, isn, comment) {
   if (!isn || !comment) return;
   const acct = accounts.resolve(channelId);
   if (!acct) return;
-  try { await giip.issueComment(acct, isn, comment); }
+  try { await giip.issueComment(acct, isn, buildNoteComment(comment)); }
   catch (e) { console.error('[giip-task] comment(note) 실패:', e.message); }
 }
 

--- a/slack-bot/.env.example
+++ b/slack-bot/.env.example
@@ -18,6 +18,12 @@ SLACK_APP_TOKEN=xapp-your-app-level-token-here
 # Display name used in Slack messages
 BOT_NAME=giipclaude Bot
 
+# 이 배포가 giip 이슈 코멘트에 남길 행위자 이름표(actor tag). 여러 사용자가 각자 배포해 쓰는
+# 범용 코드라 하드코딩하지 않는다 — 상태 전이(IN_PROGRESS/REVIEW 등) 코멘트마다 "누가" 처리했는지
+# 이 값이 헤더에 찍힌다(giip-task.js maybeFinish). 미설정 시 slack-bot@<hostname> 자동 사용.
+# 예: GIIP_ACTOR_TAG=lowyclaude
+# GIIP_ACTOR_TAG=
+
 # ── Workspace / project directories ──────────────────────────────────────────
 # Root directory of the workspace (where .agent/ lives and git push targets)
 WORKSPACE_DIR=/path/to/your/workspace

--- a/slack-bot/giip-task.js
+++ b/slack-bot/giip-task.js
@@ -4,8 +4,47 @@
  * 설계: docs/DESIGN_slackbot_giip_issue_integration.md §4.
  * 모든 함수는 절대 throw 하지 않는다(봇 무중단). 실패는 로그 + null/no-op.
  */
+const os = require('os');
 const accounts = require('./giip-accounts');
 const giip = require('./giip-api');
+
+/**
+ * 이 배포가 giip 이슈 코멘트에 남길 행위자 이름표. 여러 사용자가 배포해 쓰는 범용 코드이므로
+ * 하드코딩하지 않고 env 로 설정한다(예: 이 PC 배포는 GIIP_ACTOR_TAG=lowyclaude).
+ * 미설정 시 host 기준 합리적 기본값으로 폴백 — 최소한 "어느 머신의 봇인지"는 항상 남는다.
+ */
+function actorTag() {
+  return process.env.GIIP_ACTOR_TAG || `slack-bot@${os.hostname()}`;
+}
+
+/**
+ * 상태전이 코멘트에 행위자(actor)·시각(when)·사유(why) 헤더를 항상 붙인다.
+ * giip #1146~1151/#1155 인시던트(무인 세션이 코멘트 없이 IN_PROGRESS 전이) 재발방지 —
+ * caller 가 comment 를 안 줘도(null) 이 헤더만은 구조적으로 남긴다.
+ */
+function buildTransitionComment(isn, status, comment) {
+  const actor = actorTag();
+  const when = new Date().toISOString();
+  const why = comment ? String(comment) : '(자동 전이, 상세 사유 미기재)';
+  return [
+    `## [${actor}] ISN ${isn} 상태전이: → ${status}`,
+    `**행위자(Actor)**: ${actor}`,
+    `**시각(When)**: ${when}`,
+    `**사유(Why)**: ${why}`,
+  ].join('\n');
+}
+
+/** 상태전이가 없는 note 코멘트에도 일관되게 행위자/시각 헤더를 붙인다. */
+function buildNoteComment(comment) {
+  const actor = actorTag();
+  const when = new Date().toISOString();
+  return [
+    `**행위자(Actor)**: ${actor}`,
+    `**시각(When)**: ${when}`,
+    '',
+    String(comment),
+  ].join('\n');
+}
 
 /** 타임아웃/네트워크 등 일시적 오류인지 판단(1회 재시도 대상). 권한/데이터 오류는 재시도해도 무의미하므로 제외. */
 function isRetryableIssueError(e) {
@@ -54,13 +93,23 @@ async function maybeCreateIssue(channelId, title, content, csn = null) {
   return { isn: null, error: lastErr.message };
 }
 
-/** 완료/에러 시: 코멘트 + 상태전이(best-effort, 실패해도 무시). */
+/**
+ * 완료/에러/착수 시: 코멘트 + 상태전이(best-effort, 실패해도 무시).
+ * 상태 전이(status 지정)는 comment 인자 유무와 무관하게 항상 행위자/시각/사유 헤더가 붙은
+ * 코멘트를 남긴다 — "comment=null 이면 코멘트 자체를 스킵"하던 구버전 버그(giip #1155)가
+ * 재발하지 않도록 여기서 구조적으로 막는다. caller 가 준 comment 는 "사유"에 그대로 보존된다.
+ */
 async function maybeFinish(channelId, isn, status, comment) {
   if (!isn) return;
   const acct = accounts.resolve(channelId);
   if (!acct) return;
-  try { if (comment) await giip.issueComment(acct, isn, comment); }
-  catch (e) { console.error('[giip-task] comment 실패:', e.message); }
+  const wrapped = status
+    ? buildTransitionComment(isn, status, comment)
+    : (comment ? buildNoteComment(comment) : null);
+  if (wrapped) {
+    try { await giip.issueComment(acct, isn, wrapped); }
+    catch (e) { console.error('[giip-task] comment 실패:', e.message); }
+  }
   try { if (status) await giip.issueUpdate(acct, { isn, status }); }
   catch (e) { console.error('[giip-task] status 실패:', e.message); }
 }
@@ -68,12 +117,13 @@ async function maybeFinish(channelId, isn, status, comment) {
 /**
  * 코멘트만 남긴다(상태 전이 없음, best-effort). 작업트리 점유 대기 관계 등
  * "상태는 그대로 두고 사실만 기록"하는 용도. 실패해도 봇 흐름을 막지 않는다.
+ * 일관성을 위해 이 코멘트에도 행위자/시각 헤더를 붙인다.
  */
 async function maybeComment(channelId, isn, comment) {
   if (!isn || !comment) return;
   const acct = accounts.resolve(channelId);
   if (!acct) return;
-  try { await giip.issueComment(acct, isn, comment); }
+  try { await giip.issueComment(acct, isn, buildNoteComment(comment)); }
   catch (e) { console.error('[giip-task] comment(note) 실패:', e.message); }
 }
 


### PR DESCRIPTION
## Summary
- 자매 프로젝트(giipprj, csn 47)에서 무인 세션이 giip 이슈를 IN_PROGRESS로 전이시키면서 코멘트를 전혀 남기지 않아 누가/언제/왜 착수했는지 추적이 불가능했던 인시던트(giip #1146~1151/#1155)와 완전히 동일한 결함이 이 레포(`slack-bot/giip-task.js` `maybeFinish`)에도 있었다. `handlers.js`가 IN_PROGRESS 착수 시 `comment=null`을 명시적으로 넘겨왔고, `maybeFinish`는 comment가 falsy면 코멘트를 통째로 건너뛰었다.
- `maybeFinish`/`maybeComment`를 고쳐 상태 전이 시 항상 행위자(Actor)/시각(When)/사유(Why) 헤더가 붙은 코멘트를 자동 생성해 남기도록 함(코멘트 완전 생략을 구조적으로 차단). 기존 caller가 실제 comment를 넘기는 경우(REVIEW 등)는 그 내용을 "사유"에 그대로 보존.
- 행위자 이름표는 하드코딩하지 않고 `GIIP_ACTOR_TAG` 환경변수로 배포자가 지정(미설정 시 `slack-bot@<hostname>` 자동 폴백). `.env.example`에 항목 추가.
- `slack-bot-minimax/`도 byte-identical한 동일 결함이 있어 동일하게 수정. `slack-bot-openclaw/`는 giip 이슈 연동 코드가 없어 해당 없음(확인함).
- `.agent/rules/PROTOCOL_PROGRESS_COMMENT.md`(정본은 giipprj, 이 파일은 미러)에 "상태 전이는 항상 코멘트 동반" 강화 규정 및 코드 레벨 강제 내용 반영.

giip #1155 (원인 이슈, csn 47) 관련.

## Test plan
- [x] `node -c slack-bot/giip-task.js`, `node -c slack-bot-minimax/giip-task.js`, `node -c slack-bot/handlers.js`, `node -c slack-bot-minimax/handlers.js` — 모두 문법 오류 없음
- [x] diff 리뷰: 기존 caller의 comment 내용이 삭제/축약 없이 "사유" 필드로 보존됨을 확인
- [ ] 라이브 Slack/giip API 통합 테스트는 하지 않음(운영 중인 봇 서비스라 정적 검증으로 한정, 사용자 지시)

🤖 Generated with [Claude Code](https://claude.com/claude-code)