### PR TITLE
fix(slack-bot): 상태전이 코멘트를 issueUpdate가 항상 남기도록 강화

### DIFF
--- a/.agent/rules/PROTOCOL_PROGRESS_COMMENT.md
+++ b/.agent/rules/PROTOCOL_PROGRESS_COMMENT.md
@@ -19,14 +19,23 @@
   - **시각(When)**: ISO 타임스탬프.
   - **사유(Why)**: 왜 이 상태로 전이하는지. caller 가 준 comment 가 있으면 그 내용, 없으면
     "(자동 전이, 상세 사유 미기재)".
-- **코드 레벨 강제**: `slack-bot/giip-task.js`(및 `slack-bot-minimax/giip-task.js`, 동일 코드)의
-  `maybeFinish(channelId, isn, status, comment)` 가 `status` 가 지정된 모든 호출에서 위 헤더가
-  붙은 코멘트를 자동 생성해 남긴다 — caller 가 `comment` 를 `null`/미지정으로 넘겨도(예:
-  `handlers.js` 의 IN_PROGRESS 착수 호출) 코멘트 자체가 스킵되지 않도록 구조적으로 막았다.
-  `maybeComment`(상태전이 없는 note)도 동일하게 행위자/시각 헤더를 붙인다.
-- 정본 쪽(giipprj, `giipdb/docs/30_Specs/SPEC_GISSUE_SCHEDULER.md`, 이 문서 작성 시점 기준
-  §5.1 근방으로 추정 — 다른 에이전트가 병렬로 formalize 중이라 정확한 섹션은 정본에서 확인할 것)
-  에도 동등한 규정이 추가되는 중이다. 동기화 시 이 섹션을 정본 문구로 갱신할 것.
+- **코드 레벨 강제(2026-08-18 갱신, giip #1211)**: 2026-08-16 판(위 문단)은 `giip-task.js#maybeFinish`
+  에만 강제를 걸어, 이를 거치지 않는 `giip-commands.js`(`giip issue done/review/progress` Slack
+  명령)와 `handlers.js` 의 일부 `issueUpdate` 직접 호출은 여전히 코멘트 없이 조용히 상태만
+  바뀌는 구멍이 남아 있었다(giipprj `updateIssueStatus.ps1` 이 `-Actor`/`-Reason` opt-in 이라
+  실효성이 없었던 것과 동일한 근본 결함). 이제 이 함수는 **`slack-bot/giip-api.js#issueUpdate`
+  자체**로 이동했다 — `fields.status` 가 주어지고 실제로 값이 바뀌면(현재 상태를 읽어 대조),
+  호출부가 무엇이든(`giip-commands.js` 직접 호출 포함) 항상 "[Actor] ISN X 상태전이:
+  `<이전상태>` -> `<새상태>`" 헤더가 붙은 코멘트를 자동 등록한다(이전상태도 이번에 추가 — 과거엔
+  `→ <새상태>`만 표기해 "어느 상태에서" 왔는지가 없었다). `actor`/`reason` 은 `opts` 로 넘길 수
+  있고(기본값: `actorTag()`/`"(사유 미기재 - 자동 기본값)"`), `giip-task.js#maybeFinish` 는
+  자신이 별도로 코멘트를 만들지 않고 이 `opts.reason` 에 caller comment 를 실어 넘기기만 한다
+  (중복 코멘트 방지). `skipComment` opts 는 향후 호출부가 자체 코멘트를 남기고 싶을 때만 쓴다.
+  `slack-bot-minimax/`도 동일하게 적용(byte-identical 유지). `slack-bot-openclaw/`는 giip 이슈
+  연동 코드 자체가 없어 해당 없음.
+- 정본 쪽은 `giipprj/giipdb/mgmt/updateIssueStatus.ps1`(giip #1211, `-Actor`/`-Reason` 이 비어도
+  기본값으로 채워 항상 코멘트) — 접근 방식은 다르지만(PowerShell vs Node HTTP API) "opt-in 이면
+  실효성이 없다"는 동일한 교훈을 반영한다.
 
 ## 남기는 시점 (논리 단위로, 각 1~3줄 note)
 파일 1개당 코멘트 1개 강제 금지. **논리 묶음** 단위로:
@@ -46,7 +55,8 @@
 (lowyworkenv `scripts/gissue/get-issue.sh`와 동일 계열 — `giip-accounts.js`에서 csn에 맞는 SK를 읽어
 `giipIssueComments` 엔드포인트로 POST). 한글 콘텐츠는 `\uXXXX` JSON escape로 보내야 안 깨진다
 ([[reference_giip_issue_sk_api]] 참고).
-- 상태 변경은 코멘트와 분리된 별도 status-only PUT으로 처리한다.
+- 상태 변경(PUT) 자체가 `issueUpdate` 내부에서 상태전이 코멘트를 자동으로 동반한다(위 §"상태 전이는
+  항상 코멘트를 동반한다" 2026-08-18 갱신 참고) — 별도로 코멘트 POST 를 먼저/나중에 호출할 필요 없음.
 
 ## 연계
 - 정본: `giipprj/.agent/rules/PROTOCOL_PROGRESS_COMMENT.md` (전체 규칙·result 게이트·완료 위조 금지 포함).

--- a/slack-bot-minimax/giip-api.js
+++ b/slack-bot-minimax/giip-api.js
@@ -6,11 +6,22 @@
  * AK 도출(AdminGetAK) 안 함 — SK 를 AT(token) 자리에 넣으면 401(SK≠AT 혼동 금지, rule 39).
  */
 const https = require('https');
+const os = require('os');
 const { URL } = require('url');
 const accounts = require('./giip-accounts');
 
 const AK_TTL_MS = 20 * 60 * 60 * 1000; // 20h
 const akCache = new Map(); // login_id → { ak, csn, usn, fetchedAt }
+
+/**
+ * [giip #1211] 이 배포가 giip 이슈 상태전이 코멘트에 남길 행위자 이름표.
+ * giip-task.js 의 동명 함수와 동일한 폴백 규칙(GIIP_ACTOR_TAG 우선, 없으면 호스트 기준).
+ * 여기 두는 이유: issueUpdate 자체가 코멘트를 남기므로(아래 참고) giip-task.js 를 거치지
+ * 않는 호출부(giip-commands.js 등)도 이 모듈 하나만으로 행위자 이름표를 얻을 수 있어야 한다.
+ */
+function actorTag() {
+  return process.env.GIIP_ACTOR_TAG || `slack-bot@${os.hostname()}`;
+}
 
 function request(method, urlStr, { headers = {}, body = null, timeoutMs = 30000 } = {}) {
   return new Promise((resolve, reject) => {
@@ -101,8 +112,25 @@ async function issueCreate(account, { title, content, status = 'PENDING', csn, t
   return res.body; // { success, isn, message }
 }
 
-/** PUT 은 전체 덮어쓰기 → read-modify-write 로 미지정 필드 보존(설계 §6). */
-async function issueUpdate(account, fields) {
+/**
+ * PUT 은 전체 덮어쓰기 → read-modify-write 로 미지정 필드 보존(설계 §6).
+ *
+ * [giip #1211] 상태전이 코멘트를 이 함수 자체가 항상 남긴다. 이전에는 giip-task.js#maybeFinish
+ * 를 거치는 호출부만 코멘트를 남기고, giip-commands.js(`giip issue done/review/progress`)나
+ * handlers.js 처럼 issueUpdate 를 직접 호출하는 경로는 코멘트 없이 조용히 상태만 바뀌었다
+ * (giipprj/giipdb/mgmt/updateIssueStatus.ps1 이 opt-in 이라 겪은 것과 동일한 근본 결함,
+ * giip #1155/#1208). 모든 호출부가 이 함수 하나를 거치므로 여기서 강제하면 개별 호출부
+ * 수정 없이도 구조적으로 보장된다. 코멘트 자체가 실패해도 상태 변경은 이미 끝난 뒤이므로
+ * throw 하지 않고 로그만 남긴다(봇 무중단 원칙).
+ *
+ * @param {object} fields isn/title/content/status/csn/target_lssn/agent_workflow
+ * @param {{actor?:string, reason?:string, skipComment?:boolean}} [opts]
+ *   actor: 코멘트에 남길 행위자 이름표(기본: actorTag()).
+ *   reason: 상태 변경 사유(기본: "(사유 미기재 - 자동 기본값)").
+ *   skipComment: true 면 이 함수가 코멘트를 남기지 않는다 — 호출부(giip-task.js#maybeFinish)가
+ *     이미 자기 코멘트를 남기는 경우 중복 방지용으로만 쓴다.
+ */
+async function issueUpdate(account, fields, opts = {}) {
   const cur = await issueGet(account, fields.isn);
   const merged = {
     isn: fields.isn,
@@ -115,6 +143,26 @@ async function issueUpdate(account, fields) {
   };
   const res = await issueApi(account, 'PUT', { body: merged });
   if (res.status !== 200) throw new Error(`issueUpdate 실패: ${res.body?.error || res.status}`);
+
+  const oldStatus = cur.status ?? cur.Status ?? null;
+  const newStatus = merged.status;
+  if (!opts.skipComment && fields.status && newStatus && oldStatus !== newStatus) {
+    try {
+      const actor = opts.actor || actorTag();
+      const reason = opts.reason || '(사유 미기재 - 자동 기본값)';
+      const when = new Date().toISOString();
+      const commentBody = [
+        `## [${actor}] ISN ${fields.isn} 상태전이: ${oldStatus || 'UNKNOWN'} -> ${newStatus}`,
+        `**행위자(Actor)**: ${actor}`,
+        `**시각(When)**: ${when}`,
+        `**사유(Why)**: ${reason}`,
+      ].join('\n');
+      await issueComment(account, fields.isn, commentBody);
+    } catch (e) {
+      console.error(`[giip-api] 상태전이 코멘트 등록 실패(isn=${fields.isn}):`, e.message);
+    }
+  }
+
   return res.body;
 }
 
@@ -186,6 +234,7 @@ async function apiCall(account, verb, jsondata = null) {
 
 module.exports = {
   getAK,
+  actorTag,
   issueGet,
   issueList,
   issueCreate,

--- a/slack-bot-minimax/giip-commands.js
+++ b/slack-bot-minimax/giip-commands.js
@@ -187,9 +187,11 @@ async function handleGiipCommand(rawText, channelId) {
         const r = await giip.issueCreate(acct, { title, content: title, status: 'IN_PROGRESS' });
         return { handled: true, text: `✅ 이슈 생성 #${r.isn} — ${title}` };
       }
-      if (action === 'done') { await giip.issueUpdate(acct, { isn: Number(arg), status: 'DONE' }); return { handled: true, text: `✅ #${arg} → DONE` }; }
-      if (action === 'review') { await giip.issueUpdate(acct, { isn: Number(arg), status: 'REVIEW' }); return { handled: true, text: `✅ #${arg} → REVIEW` }; }
-      if (action === 'progress' || action === 'start') { await giip.issueUpdate(acct, { isn: Number(arg), status: 'IN_PROGRESS' }); return { handled: true, text: `✅ #${arg} → IN_PROGRESS` }; }
+      // [giip #1211] 상태전이 코멘트는 giip.issueUpdate 내부에서 항상 자동 등록된다(giip-api.js 참고) —
+      // 여기서는 어떤 Slack 명령이 트리거했는지만 reason 으로 넘긴다.
+      if (action === 'done') { await giip.issueUpdate(acct, { isn: Number(arg), status: 'DONE' }, { reason: 'Slack 명령: giip issue done' }); return { handled: true, text: `✅ #${arg} → DONE` }; }
+      if (action === 'review') { await giip.issueUpdate(acct, { isn: Number(arg), status: 'REVIEW' }, { reason: 'Slack 명령: giip issue review' }); return { handled: true, text: `✅ #${arg} → REVIEW` }; }
+      if (action === 'progress' || action === 'start') { await giip.issueUpdate(acct, { isn: Number(arg), status: 'IN_PROGRESS' }, { reason: `Slack 명령: giip issue ${action}` }); return { handled: true, text: `✅ #${arg} → IN_PROGRESS` }; }
       if (action === 'get' || action === 'show') { const i = await giip.issueGet(acct, Number(arg)); return { handled: true, text: code(i, 1500) }; }
       if (action === 'comment') {
         const cm = arg.match(/^(\d+)\s+([\s\S]+)$/);

--- a/slack-bot-minimax/giip-task.js
+++ b/slack-bot-minimax/giip-task.js
@@ -17,23 +17,6 @@ function actorTag() {
   return process.env.GIIP_ACTOR_TAG || `slack-bot@${os.hostname()}`;
 }
 
-/**
- * 상태전이 코멘트에 행위자(actor)·시각(when)·사유(why) 헤더를 항상 붙인다.
- * giip #1146~1151/#1155 인시던트(무인 세션이 코멘트 없이 IN_PROGRESS 전이) 재발방지 —
- * caller 가 comment 를 안 줘도(null) 이 헤더만은 구조적으로 남긴다.
- */
-function buildTransitionComment(isn, status, comment) {
-  const actor = actorTag();
-  const when = new Date().toISOString();
-  const why = comment ? String(comment) : '(자동 전이, 상세 사유 미기재)';
-  return [
-    `## [${actor}] ISN ${isn} 상태전이: → ${status}`,
-    `**행위자(Actor)**: ${actor}`,
-    `**시각(When)**: ${when}`,
-    `**사유(Why)**: ${why}`,
-  ].join('\n');
-}
-
 /** 상태전이가 없는 note 코멘트에도 일관되게 행위자/시각 헤더를 붙인다. */
 function buildNoteComment(comment) {
   const actor = actorTag();
@@ -95,23 +78,29 @@ async function maybeCreateIssue(channelId, title, content, csn = null) {
 
 /**
  * 완료/에러/착수 시: 코멘트 + 상태전이(best-effort, 실패해도 무시).
- * 상태 전이(status 지정)는 comment 인자 유무와 무관하게 항상 행위자/시각/사유 헤더가 붙은
- * 코멘트를 남긴다 — "comment=null 이면 코멘트 자체를 스킵"하던 구버전 버그(giip #1155)가
- * 재발하지 않도록 여기서 구조적으로 막는다. caller 가 준 comment 는 "사유"에 그대로 보존된다.
+ * [giip #1211] 상태전이 코멘트 자체는 이제 giip-api.js#issueUpdate 가 항상 남긴다(그래야
+ * giip-commands.js 등 issueUpdate 를 직접 호출하는 다른 경로도 구조적으로 보장됨). 이 함수는
+ * caller 가 준 comment 를 "사유(Why)"로 그대로 전달하기만 한다 — "comment=null 이면 코멘트
+ * 자체를 스킵"하던 구버전 버그(giip #1155)는 issueUpdate 쪽에서 기본 사유로 채워지므로 재발하지
+ * 않는다.
  */
 async function maybeFinish(channelId, isn, status, comment) {
   if (!isn) return;
   const acct = accounts.resolve(channelId);
   if (!acct) return;
-  const wrapped = status
-    ? buildTransitionComment(isn, status, comment)
-    : (comment ? buildNoteComment(comment) : null);
-  if (wrapped) {
-    try { await giip.issueComment(acct, isn, wrapped); }
+  if (status) {
+    try {
+      await giip.issueUpdate(acct, { isn, status }, {
+        actor: actorTag(),
+        reason: comment ? String(comment) : '(자동 전이, 상세 사유 미기재)',
+      });
+    } catch (e) { console.error('[giip-task] status 실패:', e.message); }
+    return;
+  }
+  if (comment) {
+    try { await giip.issueComment(acct, isn, buildNoteComment(comment)); }
     catch (e) { console.error('[giip-task] comment 실패:', e.message); }
   }
-  try { if (status) await giip.issueUpdate(acct, { isn, status }); }
-  catch (e) { console.error('[giip-task] status 실패:', e.message); }
 }
 
 /**

--- a/slack-bot-minimax/handlers.js
+++ b/slack-bot-minimax/handlers.js
@@ -665,7 +665,9 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
         if (isn && planContent) {
           try {
             await giip.issueComment(acct, isn, `📋 작업지시서 (봇 자동 분석)\n\n${planContent}`.slice(0, 8000));
-            await giip.issueUpdate(acct, { isn, status: 'READY' }); // read-modify-write(제목·본문 보존)
+            // read-modify-write(제목·본문 보존). [giip #1211] 상태전이 코멘트(PENDING -> READY)는
+            // giip.issueUpdate 내부에서 항상 자동 등록된다(giip-api.js 참고).
+            await giip.issueUpdate(acct, { isn, status: 'READY' }, { reason: '봇 자동 분석: 작업지시서 첨부 후 READY 승격' });
             promoted = true;
           } catch (e) { console.error('[Bot] issue 작업지시서 첨부 실패:', e.message); }
         }

--- a/slack-bot/giip-api.js
+++ b/slack-bot/giip-api.js
@@ -6,11 +6,22 @@
  * AK 도출(AdminGetAK) 안 함 — SK 를 AT(token) 자리에 넣으면 401(SK≠AT 혼동 금지, rule 39).
  */
 const https = require('https');
+const os = require('os');
 const { URL } = require('url');
 const accounts = require('./giip-accounts');
 
 const AK_TTL_MS = 20 * 60 * 60 * 1000; // 20h
 const akCache = new Map(); // login_id → { ak, csn, usn, fetchedAt }
+
+/**
+ * [giip #1211] 이 배포가 giip 이슈 상태전이 코멘트에 남길 행위자 이름표.
+ * giip-task.js 의 동명 함수와 동일한 폴백 규칙(GIIP_ACTOR_TAG 우선, 없으면 호스트 기준).
+ * 여기 두는 이유: issueUpdate 자체가 코멘트를 남기므로(아래 참고) giip-task.js 를 거치지
+ * 않는 호출부(giip-commands.js 등)도 이 모듈 하나만으로 행위자 이름표를 얻을 수 있어야 한다.
+ */
+function actorTag() {
+  return process.env.GIIP_ACTOR_TAG || `slack-bot@${os.hostname()}`;
+}
 
 function request(method, urlStr, { headers = {}, body = null, timeoutMs = 30000 } = {}) {
   return new Promise((resolve, reject) => {
@@ -101,8 +112,25 @@ async function issueCreate(account, { title, content, status = 'PENDING', csn, t
   return res.body; // { success, isn, message }
 }
 
-/** PUT 은 전체 덮어쓰기 → read-modify-write 로 미지정 필드 보존(설계 §6). */
-async function issueUpdate(account, fields) {
+/**
+ * PUT 은 전체 덮어쓰기 → read-modify-write 로 미지정 필드 보존(설계 §6).
+ *
+ * [giip #1211] 상태전이 코멘트를 이 함수 자체가 항상 남긴다. 이전에는 giip-task.js#maybeFinish
+ * 를 거치는 호출부만 코멘트를 남기고, giip-commands.js(`giip issue done/review/progress`)나
+ * handlers.js 처럼 issueUpdate 를 직접 호출하는 경로는 코멘트 없이 조용히 상태만 바뀌었다
+ * (giipprj/giipdb/mgmt/updateIssueStatus.ps1 이 opt-in 이라 겪은 것과 동일한 근본 결함,
+ * giip #1155/#1208). 모든 호출부가 이 함수 하나를 거치므로 여기서 강제하면 개별 호출부
+ * 수정 없이도 구조적으로 보장된다. 코멘트 자체가 실패해도 상태 변경은 이미 끝난 뒤이므로
+ * throw 하지 않고 로그만 남긴다(봇 무중단 원칙).
+ *
+ * @param {object} fields isn/title/content/status/csn/target_lssn/agent_workflow
+ * @param {{actor?:string, reason?:string, skipComment?:boolean}} [opts]
+ *   actor: 코멘트에 남길 행위자 이름표(기본: actorTag()).
+ *   reason: 상태 변경 사유(기본: "(사유 미기재 - 자동 기본값)").
+ *   skipComment: true 면 이 함수가 코멘트를 남기지 않는다 — 호출부(giip-task.js#maybeFinish)가
+ *     이미 자기 코멘트를 남기는 경우 중복 방지용으로만 쓴다.
+ */
+async function issueUpdate(account, fields, opts = {}) {
   const cur = await issueGet(account, fields.isn);
   const merged = {
     isn: fields.isn,
@@ -115,6 +143,26 @@ async function issueUpdate(account, fields) {
   };
   const res = await issueApi(account, 'PUT', { body: merged });
   if (res.status !== 200) throw new Error(`issueUpdate 실패: ${res.body?.error || res.status}`);
+
+  const oldStatus = cur.status ?? cur.Status ?? null;
+  const newStatus = merged.status;
+  if (!opts.skipComment && fields.status && newStatus && oldStatus !== newStatus) {
+    try {
+      const actor = opts.actor || actorTag();
+      const reason = opts.reason || '(사유 미기재 - 자동 기본값)';
+      const when = new Date().toISOString();
+      const commentBody = [
+        `## [${actor}] ISN ${fields.isn} 상태전이: ${oldStatus || 'UNKNOWN'} -> ${newStatus}`,
+        `**행위자(Actor)**: ${actor}`,
+        `**시각(When)**: ${when}`,
+        `**사유(Why)**: ${reason}`,
+      ].join('\n');
+      await issueComment(account, fields.isn, commentBody);
+    } catch (e) {
+      console.error(`[giip-api] 상태전이 코멘트 등록 실패(isn=${fields.isn}):`, e.message);
+    }
+  }
+
   return res.body;
 }
 
@@ -186,6 +234,7 @@ async function apiCall(account, verb, jsondata = null) {
 
 module.exports = {
   getAK,
+  actorTag,
   issueGet,
   issueList,
   issueCreate,

--- a/slack-bot/giip-commands.js
+++ b/slack-bot/giip-commands.js
@@ -229,9 +229,11 @@ async function handleGiipCommand(rawText, channelId) {
         const r = await giip.issueCreate(acct, { title, content: title, status: 'IN_PROGRESS' });
         return { handled: true, text: `✅ 이슈 생성 #${r.isn} — ${title}` };
       }
-      if (action === 'done') { await giip.issueUpdate(acct, { isn: Number(arg), status: 'DONE' }); return { handled: true, text: `✅ #${arg} → DONE` }; }
-      if (action === 'review') { await giip.issueUpdate(acct, { isn: Number(arg), status: 'REVIEW' }); return { handled: true, text: `✅ #${arg} → REVIEW` }; }
-      if (action === 'progress' || action === 'start') { await giip.issueUpdate(acct, { isn: Number(arg), status: 'IN_PROGRESS' }); return { handled: true, text: `✅ #${arg} → IN_PROGRESS` }; }
+      // [giip #1211] 상태전이 코멘트는 giip.issueUpdate 내부에서 항상 자동 등록된다(giip-api.js 참고) —
+      // 여기서는 어떤 Slack 명령이 트리거했는지만 reason 으로 넘긴다.
+      if (action === 'done') { await giip.issueUpdate(acct, { isn: Number(arg), status: 'DONE' }, { reason: 'Slack 명령: giip issue done' }); return { handled: true, text: `✅ #${arg} → DONE` }; }
+      if (action === 'review') { await giip.issueUpdate(acct, { isn: Number(arg), status: 'REVIEW' }, { reason: 'Slack 명령: giip issue review' }); return { handled: true, text: `✅ #${arg} → REVIEW` }; }
+      if (action === 'progress' || action === 'start') { await giip.issueUpdate(acct, { isn: Number(arg), status: 'IN_PROGRESS' }, { reason: `Slack 명령: giip issue ${action}` }); return { handled: true, text: `✅ #${arg} → IN_PROGRESS` }; }
       if (action === 'get' || action === 'show') { const i = await giip.issueGet(acct, Number(arg)); return { handled: true, text: code(i, 1500) }; }
       if (action === 'comment') {
         const cm = arg.match(/^(\d+)\s+([\s\S]+)$/);

--- a/slack-bot/giip-task.js
+++ b/slack-bot/giip-task.js
@@ -17,23 +17,6 @@ function actorTag() {
   return process.env.GIIP_ACTOR_TAG || `slack-bot@${os.hostname()}`;
 }
 
-/**
- * 상태전이 코멘트에 행위자(actor)·시각(when)·사유(why) 헤더를 항상 붙인다.
- * giip #1146~1151/#1155 인시던트(무인 세션이 코멘트 없이 IN_PROGRESS 전이) 재발방지 —
- * caller 가 comment 를 안 줘도(null) 이 헤더만은 구조적으로 남긴다.
- */
-function buildTransitionComment(isn, status, comment) {
-  const actor = actorTag();
-  const when = new Date().toISOString();
-  const why = comment ? String(comment) : '(자동 전이, 상세 사유 미기재)';
-  return [
-    `## [${actor}] ISN ${isn} 상태전이: → ${status}`,
-    `**행위자(Actor)**: ${actor}`,
-    `**시각(When)**: ${when}`,
-    `**사유(Why)**: ${why}`,
-  ].join('\n');
-}
-
 /** 상태전이가 없는 note 코멘트에도 일관되게 행위자/시각 헤더를 붙인다. */
 function buildNoteComment(comment) {
   const actor = actorTag();
@@ -95,23 +78,29 @@ async function maybeCreateIssue(channelId, title, content, csn = null) {
 
 /**
  * 완료/에러/착수 시: 코멘트 + 상태전이(best-effort, 실패해도 무시).
- * 상태 전이(status 지정)는 comment 인자 유무와 무관하게 항상 행위자/시각/사유 헤더가 붙은
- * 코멘트를 남긴다 — "comment=null 이면 코멘트 자체를 스킵"하던 구버전 버그(giip #1155)가
- * 재발하지 않도록 여기서 구조적으로 막는다. caller 가 준 comment 는 "사유"에 그대로 보존된다.
+ * [giip #1211] 상태전이 코멘트 자체는 이제 giip-api.js#issueUpdate 가 항상 남긴다(그래야
+ * giip-commands.js 등 issueUpdate 를 직접 호출하는 다른 경로도 구조적으로 보장됨). 이 함수는
+ * caller 가 준 comment 를 "사유(Why)"로 그대로 전달하기만 한다 — "comment=null 이면 코멘트
+ * 자체를 스킵"하던 구버전 버그(giip #1155)는 issueUpdate 쪽에서 기본 사유로 채워지므로 재발하지
+ * 않는다.
  */
 async function maybeFinish(channelId, isn, status, comment) {
   if (!isn) return;
   const acct = accounts.resolve(channelId);
   if (!acct) return;
-  const wrapped = status
-    ? buildTransitionComment(isn, status, comment)
-    : (comment ? buildNoteComment(comment) : null);
-  if (wrapped) {
-    try { await giip.issueComment(acct, isn, wrapped); }
+  if (status) {
+    try {
+      await giip.issueUpdate(acct, { isn, status }, {
+        actor: actorTag(),
+        reason: comment ? String(comment) : '(자동 전이, 상세 사유 미기재)',
+      });
+    } catch (e) { console.error('[giip-task] status 실패:', e.message); }
+    return;
+  }
+  if (comment) {
+    try { await giip.issueComment(acct, isn, buildNoteComment(comment)); }
     catch (e) { console.error('[giip-task] comment 실패:', e.message); }
   }
-  try { if (status) await giip.issueUpdate(acct, { isn, status }); }
-  catch (e) { console.error('[giip-task] status 실패:', e.message); }
 }
 
 /**

--- a/slack-bot/handlers.js
+++ b/slack-bot/handlers.js
@@ -743,7 +743,9 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
         if (isn && planContent) {
           try {
             await giip.issueComment(acct, isn, `📋 작업지시서 (봇 자동 분석)\n\n${planContent}`.slice(0, 8000));
-            await giip.issueUpdate(acct, { isn, status: 'READY' }); // read-modify-write(제목·본문 보존)
+            // read-modify-write(제목·본문 보존). [giip #1211] 상태전이 코멘트(PENDING -> READY)는
+            // giip.issueUpdate 내부에서 항상 자동 등록된다(giip-api.js 참고).
+            await giip.issueUpdate(acct, { isn, status: 'READY' }, { reason: '봇 자동 분석: 작업지시서 첨부 후 READY 승격' });
             promoted = true;
           } catch (e) { console.error('[Bot] issue 작업지시서 첨부 실패:', e.message); }
         }


### PR DESCRIPTION
## Summary
- giip #1155에서 `giip-task.js#maybeFinish`에만 상태전이 코멘트 강제를 걸었으나, `giip-commands.js`(`giip issue done/review/progress` Slack 명령)와 `handlers.js`의 일부 `issueUpdate` 직접 호출은 여전히 코멘트 없이 상태만 바뀌는 구멍이 있었음(giip #1208 사건도 같은 계열).
- `giip-api.js#issueUpdate` 자체가 상태가 실제로 바뀌면 항상 "[Actor] ISN X 상태전이: A -> B" 코멘트를 등록하도록 변경 — 어떤 호출부를 거치든 구조적으로 보장.
- 이전상태(A)도 이번에 추가(과거엔 "→ B"만 표기).
- `giip-task.js#maybeFinish`는 이제 자체 코멘트를 만들지 않고 caller comment를 reason으로 전달(중복 코멘트 방지).
- `slack-bot/`과 `slack-bot-minimax/`(byte-identical 사본) 동일 적용. `slack-bot-openclaw/`는 giip 이슈 연동 코드 없어 해당 없음.
- `.agent/rules/PROTOCOL_PROGRESS_COMMENT.md`(미러) 갱신.

## Test plan
- [x] `node --check`로 수정된 8개 JS 파일 구문 검증
- [x] `https.request`를 스텁한 dry-run 스크립트로 `issueUpdate` 3케이스 검증(기본 opts로도 코멘트 등록 / skipComment로 억제 / 명시 actor·reason과 "A -> B" 포맷이 코멘트에 포함) — slack-bot, slack-bot-minimax 양쪽 모두 PASS
- 실제 프로덕션 DB/Slack에는 호출하지 않음(정적 리뷰 + dry-run으로 충분, giip #1211 지시사항 준수)

giip #1211

🤖 Generated with [Claude Code](https://claude.com/claude-code)