### PR TITLE
feat(slack-bot): csn 실제 언어(clang) 자동조회 + issue 등록 다국어 확인메시지 (giip #1252)

### DIFF
--- a/slack-bot/config.js
+++ b/slack-bot/config.js
@@ -217,9 +217,20 @@ function deleteProjectLang(name) {
   }
   return false;
 }
+// giip #1252: csn 의 실제 언어(tCorp.cLang, csn-lang-cache 경유)를 project-lang.json 수동맵보다
+// 우선한다. 캐시 미스/조회실패/csn 미상 시엔 항상 기존 수동맵 → DEFAULT_LANG 순으로 조용히
+// 폴백한다(csn-lang-cache.peekCachedLangCode 는 순수 동기·네트워크 없음이라 기존 호출부를
+// async 로 바꾸지 않고도 안전하게 끼워 넣을 수 있다). 캐시를 채우는 백그라운드 조회는
+// csn-lang-cache.prefetch(account, csn) 를 account/csn 이 함께 확보되는 지점에서 호출한다
+// (handlers.js issue 등록/answerInChannel, giip-task.js maybeCreateIssue 등).
 function resolveLangForProject(projectName) {
   const key = String(projectName || '').trim().toLowerCase();
   if (!key) return DEFAULT_LANG;
+  const csn = resolveProjectCsn(key);
+  if (csn != null) {
+    const csnLang = require('./csn-lang-cache').peekCachedLangCode(csn);
+    if (csnLang) return csnLang;
+  }
   return loadProjectLangMap()[key] || DEFAULT_LANG;
 }
 function resolveLangNameForProject(projectName) {

--- a/slack-bot/csn-lang-cache.js
+++ b/slack-bot/csn-lang-cache.js
@@ -1,0 +1,88 @@
+/**
+ * csn-lang-cache.js — csn(giip 조직번호) → 응답 언어코드 캐시 + 백그라운드 조회.
+ * giip #1252: "csn 이 인식되면 그 csn 의 clang(tCorp.cLang) 을 읽어 그 언어로 답변" 요구를
+ * config.js 의 project-lang.json(수동 등록 맵) 보다 우선 적용하기 위한 보조 모듈.
+ *
+ * 설계 원칙(장애 유발 금지):
+ *  - 이 모듈의 모든 조회 함수는 절대 throw 하지 않는다. 실패/미상은 항상 null 로 조용히 반환하고,
+ *    호출측(config.resolveLangForProject)이 기존 수동맵 → DEFAULT_LANG 순으로 폴백한다.
+ *  - peekCachedLangCode() 는 순수 동기·네트워크 없음 — 프롬프트 빌드처럼 sync 한 호출부(task-manager.js
+ *    등)에서 await 없이 그냥 불러도 안전하다. 캐시 미스면 null 을 반환할 뿐, 그 자리에서 API 를 부르지
+ *    않는다(그러면 매 응답마다 지연이 생김).
+ *  - prefetch(account, csn) 가 실제 네트워크 조회를 백그라운드로 수행해 캐시를 채운다 — 호출부는
+ *    channelId/account/csn 이 함께 확보되는 지점(handlers.js 이슈등록, giip-task.js 태스크생성 등)에서
+ *    fire-and-forget 으로 호출하면 된다. 동일 csn 에 대한 동시 중복 호출은 inflight 맵으로 합친다.
+ *  - giipdb SP(pApiCorpLangGetbySk) 가 현재 admin SK 게이트라 테넌트 SK 로는 403 이 날 수 있음
+ *    (giip-api.js#corpLangGet 주석 참고) — 이 경우도 실패로 캐시(짧은 TTL)해 매 호출마다 재시도하지
+ *    않는다.
+ */
+const giip = require('./giip-api');
+
+const SUCCESS_TTL_MS = 5 * 60 * 1000;   // 5분 — 성공 조회는 비교적 오래 재사용
+const FAILURE_TTL_MS = 60 * 1000;       // 1분 — 실패(403 등)는 짧게만 캐시해 과도한 침묵을 피함
+
+// csn(Number) -> { code: 'ko'|'ja'|'en'|'zh-CN'|'zh-TW'|null, fetchedAt: number }
+const cache = new Map();
+// csn(Number) -> Promise, 동시 prefetch 중복 호출 방지
+const inflight = new Map();
+
+/** giipdb cLang 값('ko-KR','en-US','ja-JP' 등) → config.js LANG_NAMES 코드로 정규화. 미상이면 null. */
+function normalizeLangCode(cLang) {
+  if (!cLang) return null;
+  const s = String(cLang).trim();
+  if (/^zh-CN/i.test(s)) return 'zh-CN';
+  if (/^zh-TW/i.test(s)) return 'zh-TW';
+  const short = s.split(/[-_]/)[0].toLowerCase();
+  if (short === 'ko' || short === 'ja' || short === 'en') return short;
+  return null;
+}
+
+/** 캐시에서 즉시 읽는다(동기, 네트워크 없음). 유효 엔트리 없으면 undefined. */
+function readCache(csnNum) {
+  const e = cache.get(csnNum);
+  if (!e) return undefined;
+  const ttl = e.code ? SUCCESS_TTL_MS : FAILURE_TTL_MS;
+  if (Date.now() - e.fetchedAt >= ttl) return undefined; // 만료 → 재조회 필요
+  return e.code; // 문자열(성공) 또는 null(최근 실패 — 짧게 폴백 유지)
+}
+
+/**
+ * 캐시 피크: hit 이면 코드(string) 또는 null(최근 실패=폴백 위임), miss 면 null 반환.
+ * 절대 네트워크를 부르지 않는다 — sync 호출부(config.js)에서 안전하게 쓰기 위함.
+ */
+function peekCachedLangCode(csn) {
+  if (csn == null) return null;
+  const n = Number(csn);
+  if (!Number.isInteger(n)) return null;
+  const hit = readCache(n);
+  return hit === undefined ? null : hit;
+}
+
+/**
+ * 백그라운드 조회로 캐시를 채운다. fire-and-forget 로 호출하는 것을 전제로 하며,
+ * 이 함수 자체도 절대 throw 하지 않는다(실패는 캐시에 기록만 하고 조용히 종료).
+ */
+async function prefetch(account, csn) {
+  if (!account || csn == null) return;
+  const n = Number(csn);
+  if (!Number.isInteger(n)) return;
+  if (readCache(n) !== undefined) return; // 이미 유효한 캐시 있음
+  if (inflight.has(n)) return inflight.get(n);
+
+  const p = (async () => {
+    try {
+      const res = await giip.corpLangGet(account, n);
+      const code = res && res.ok ? normalizeLangCode(res.cLang) : null;
+      cache.set(n, { code, fetchedAt: Date.now() });
+    } catch (e) {
+      cache.set(n, { code: null, fetchedAt: Date.now() });
+      console.error(`[csn-lang-cache] csn=${n} clang 조회 실패(폴백 유지): ${e && e.message}`);
+    } finally {
+      inflight.delete(n);
+    }
+  })();
+  inflight.set(n, p);
+  return p;
+}
+
+module.exports = { peekCachedLangCode, prefetch, normalizeLangCode, _cache: cache };

--- a/slack-bot/giip-api.js
+++ b/slack-bot/giip-api.js
@@ -219,6 +219,32 @@ async function grantBotCsn(account, csn) {
   return { ok: rstVal === 200, rstVal, already, msg, raw };
 }
 
+/**
+ * [giip #1252] csn 의 실제 언어 설정(tCorp.cLang) 조회 — giipdb SP pApiCorpLangGetbySk 호출.
+ * 이 SP 는 giipprj/giipdb/SP/pApiCorpLangGetbySk.sql 에 이미 존재하지만(2025-12-26 신설, MQE AI
+ * Advisor 용), **일반 bySk 검증(tSecretKey↔csn) 이 아니라 하드코딩된 단일 Admin SK 게이트**다
+ * (`IF (@sk = 'ffd968...')` 외엔 전부 403). giip-fde-agent 는 각 채널의 테넌트 SK(account.sk)만
+ * 갖고 있어 이 호출은 (admin SK 를 쓰지 않는 한) 403 으로 실패할 가능성이 높다 — 그래도 실패는
+ * 정상 흐름으로 취급해 호출측이 조용히 project-lang.json/DEFAULT_LANG 으로 폴백하게 한다(장애 유발 금지).
+ * 후속 조치(giipdb 쪽): SP 를 호출자 자신의 csn 범위로 tSecretKey 검증하도록 완화하거나, 이 봇 전용
+ * admin SK 를 안전하게 프로비저닝해야 실제로 200 을 받을 수 있다(이번 PR 범위 밖).
+ *
+ * 디스패처 규약: pApiCorpLangGetbySk 는 이름에 "Get" 이 포함돼 giipApiSk2/run.ps1 의 jsondata
+ * 자동첨부(ISN 161)가 스킵된다 — 그래서 csn 은 jsondata 가 아니라 text 뒤에 숫자 리터럴로 직접
+ * 붙여 보낸다(`CorpLangGet <csn>` → `exec pApiCorpLangGetbySk '<sk>', <csn>`), apiCall 의 jsondata
+ * 인자는 쓰지 않는다.
+ * @returns {{ ok:boolean, cLang:string|null, rstVal:number|null, raw:any }}
+ */
+async function corpLangGet(account, csn) {
+  const n = Number(csn);
+  if (!Number.isInteger(n)) throw new Error('csn 은 정수여야 합니다.');
+  const raw = await apiCall(account, `CorpLangGet ${n}`);
+  const row = raw && Array.isArray(raw.data) ? raw.data[0] : null;
+  const rstVal = row && row.RstVal != null ? Number(row.RstVal) : null;
+  const cLang = rstVal === 200 && row && row.cLang ? String(row.cLang) : null;
+  return { ok: rstVal === 200, cLang, rstVal, raw };
+}
+
 /** 범용: 임의 giip API 를 giipApi 디스패처로 호출(text=Verb). */
 async function apiCall(account, verb, jsondata = null) {
   const base = account.apiBase || accounts.apiBase();
@@ -243,5 +269,6 @@ module.exports = {
   issueComments,
   apiCall,
   grantBotCsn,
+  corpLangGet,
   _akCache: akCache,
 };

--- a/slack-bot/giip-task.js
+++ b/slack-bot/giip-task.js
@@ -51,6 +51,11 @@ function isRetryableIssueError(e) {
 async function maybeCreateIssue(channelId, title, content, csn = null) {
   const acct = accounts.resolve(channelId);
   if (!acct) return { isn: null, error: null };
+  // [giip #1252] csn 이 인식되는 이 지점에서 실제 언어(tCorp.cLang)를 백그라운드로 조회해
+  // csn-lang-cache 를 채운다(fire-and-forget, 실패해도 무시 — 장애 유발 금지, 이 캐시는
+  // config.resolveLangForProject 가 project-lang.json 수동맵보다 우선 참조한다).
+  const effCsn = csn != null ? csn : (acct.csn != null ? acct.csn : null);
+  if (effCsn != null) require('./csn-lang-cache').prefetch(acct, effCsn).catch(() => {});
   const body = {
     title: (title || '(무제)').slice(0, 200),
     content: (content || title || '').slice(0, 8000),

--- a/slack-bot/handlers.js
+++ b/slack-bot/handlers.js
@@ -44,6 +44,20 @@ async function resolveChannelName(channelId) {
   return name;
 }
 
+// [giip #1252] csn 이 인식되는 지점(project→csn 매핑 확보 시점)마다 호출해 그 csn 의 실제 언어
+// (tCorp.cLang, csn-lang-cache 경유)를 백그라운드로 조회해 캐시를 채운다. fire-and-forget —
+// 이번 응답에는 반영되지 않는다(캐시 미스 시 config.resolveLangForProject 가 project-lang.json
+// 수동맵/DEFAULT_LANG 으로 폴백). 다음 메시지부터 캐시가 우선 사용된다. giip 계정 미연결/조회
+// 실패는 완전히 무시한다 — 언어 감지는 절대 응답 흐름을 막아선 안 된다.
+function triggerCsnLangPrefetch(channelId, projectName) {
+  try {
+    const csn = config.resolveProjectCsn(projectName);
+    const acct = require('./giip-accounts').resolve(channelId);
+    const effCsn = csn != null ? csn : (acct && acct.csn != null ? acct.csn : null);
+    if (acct && effCsn != null) require('./csn-lang-cache').prefetch(acct, effCsn).catch(() => {});
+  } catch (e) { /* best-effort */ }
+}
+
 async function buildAllowlistReply() {
   const users = config.ALLOWED_USERS;
   const channels = config.CHANNEL_IDS;
@@ -116,6 +130,7 @@ async function answerInChannel({ channelId, replyTs, text, workDir = BASE_DIR, t
   }
 
   const projectName = path.basename(workDir);
+  triggerCsnLangPrefetch(channelId, projectName);
   const agentDir = getAgentDir(workDir);
   let prompt = `You are giipclaude, an AI assistant. Always respond in ${config.resolveLangNameForProject(projectName)}.
 
@@ -289,6 +304,7 @@ async function handleDM({ channelId, ts, threadTs, text, conversations, workDir 
   }
 
   const projectName = path.basename(workDir);
+  triggerCsnLangPrefetch(channelId, projectName);
   const agentDirDM = getAgentDir(workDir);
   let prompt = `You are giipclaude, an AI assistant. Always respond in ${config.resolveLangNameForProject(projectName)} regardless of the language the user writes in.\n\nWorking project: ${projectName}\nWorking directory: ${workDir}\nAgent context directory: ${agentDirDM} (roles/, rules/, skills/, workflows/)\nRead relevant files from the agent context directory to apply the correct role and rules.\n\nIMPORTANT: Answer based on your knowledge of the project and K-Layer context. If you do not know the answer, say "모르겠습니다" clearly.\n\n되묻지 말고 실측: 설정·사양은 직접 조회하라. giip 서비스 설정(SMTP 등)의 정본=giipdb \`docs/30_Specs/\` + DB(예: SMTP=\`tEmailServerConfig\`, API \`EmailServerConfigGetActive\`). 사람만 아는 값만 질문한다.\n\nMANDATORY RULE — Task Number: If the user's message contains a 14-digit task number (e.g. 20260630170105), you MUST start your response with "[태스크 \`<task_number>\`]" on the very first line. Never omit the task number from your response.`;
   if (claims.length) prompt += '\n\nK-Layer:\n' + claims.map(c=>`• ${c}`).join('\n');
@@ -709,8 +725,13 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
     const effWorkDir = /^giip\s+/i.test(text.trim())
       ? path.join(config.PROJECTS_ROOT, 'giipprj')
       : workDir;
+    // [giip #1252] 확인/에러 메시지 다국어화(범위: 이 등록 트리거만, i18n-issue-reg.js 참고).
+    // 트리거 자체(등록/登録/register)와 body(내용)는 이미 언어 무관하게 그대로 통과되므로 그대로 둔다.
+    const effProjectName = projectName || path.basename(effWorkDir);
+    const msgLang = config.resolveLangForProject(effProjectName);
+    const msg = require('./i18n-issue-reg').t;
     if (!body) {
-      await postMessage(channelId, '사용법: `<프로젝트> issue 등록 <내용>` — 내용을 그대로 giip issue 로 등록합니다.', replyTs);
+      await postMessage(channelId, msg(msgLang, 'usage'), replyTs);
       return;
     }
     const title = body.split(/\r?\n/)[0].slice(0, 200).trim() || '(무제)';
@@ -719,25 +740,25 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
       const giip = require('./giip-api');
       const acct = giipAccounts.resolve(channelId);
       if (!acct) {
-        await postMessage(channelId,
-          '⚠️ giip 계정 미설정입니다. `giip account set <login_id> <sk> [csn]` 로 먼저 등록하세요(SK 포함이라 DM 권장).',
-          replyTs);
+        await postMessage(channelId, msg(msgLang, 'noAccount'), replyTs);
         return;
       }
+      const csn = config.resolveProjectCsn(effProjectName) ?? acct.csn ?? null;
+      triggerCsnLangPrefetch(channelId, effProjectName); // 캐시 워밍(fire-and-forget), 이번 응답엔 미반영
       // giipprj(giipprj 폴더) 는 의뢰를 그대로 넣지 않고, 분석해 '작업지시서' 수준으로 등록한다.
       //   무인 처리기(run-gissue-claude)의 refine([B]) 를 등록 시점에 앞당겨 수행하는 셈:
       //   raw 본문은 content 로, 분석된 작업지시서는 코멘트로 붙이고 status=READY 로 두면
       //   처리기 [C](READY + 지시서 코멘트)가 다음 :20/:40 에 바로 착수한다.
       const isGiipprj = /(^|[\\/])giipprj$/i.test(String(effWorkDir).replace(/[\\/]+$/, ''));
       if (isGiipprj) {
-        await postMessage(channelId, '🔍 의뢰 내용을 분석해 작업지시서로 정리 중입니다... (수십 초 소요)', replyTs);
+        await postMessage(channelId, msg(msgLang, 'analyzing'), replyTs);
         let planContent = null;
         try { ({ planContent } = tm.analyzeRequest(body, null, effWorkDir)); }
         catch (e) { console.error('[Bot] issue 등록 분석 실패:', e.message); }
 
         const specTitle = ((planContent && tm.extractTitle(planContent)) || title).slice(0, 200);
         // create 는 항상 PENDING 으로(유실 방지). 분석 성공 시에만 작업지시서 코멘트 + READY 로 승격.
-        const r = await giip.issueCreate(acct, { title: specTitle, content: body.slice(0, 8000), status: 'PENDING', csn: config.resolveProjectCsn(projectName || effWorkDir) });
+        const r = await giip.issueCreate(acct, { title: specTitle, content: body.slice(0, 8000), status: 'PENDING', csn });
         const isn = r && r.isn ? Number(r.isn) : null;
         let promoted = false;
         if (isn && planContent) {
@@ -751,27 +772,21 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
         }
         await postMessage(channelId,
           isn
-            ? [
-                `✅ giip issue #${isn} 등록 완료 (${promoted ? 'READY · 작업지시서 첨부 → 자동 처리 대기' : 'PENDING · 무인 refine 대기'})`,
-                `• 제목: ${specTitle}`,
-                ...(promoted ? ['', '```', planContent.slice(0, 1200), '```'] : []),
-              ].join('\n')
-            : '⚠️ issue 등록 응답에 isn 이 없습니다. 계정/CSN 설정을 확인하세요.',
+            ? msg(msgLang, promoted ? 'doneReady' : 'donePending', { isn, title: specTitle, plan: planContent ? planContent.slice(0, 1200) : '' })
+            : msg(msgLang, 'noIsn'),
           replyTs);
         return;
       }
       // 그 외 프로젝트: 의뢰를 그대로 PENDING 으로 등록(무인 처리기가 refine 부터 수행).
       //   IN_PROGRESS 로 만들면 PENDING/READY 만 집는 처리기의 사각지대에 빠져 '먹통'이 된다.
-      const r = await giip.issueCreate(acct, { title, content: body.slice(0, 8000), status: 'PENDING', csn: config.resolveProjectCsn(projectName || effWorkDir) });
+      const r = await giip.issueCreate(acct, { title, content: body.slice(0, 8000), status: 'PENDING', csn });
       const isn = r && r.isn ? Number(r.isn) : null;
       await postMessage(channelId,
-        isn
-          ? `✅ giip issue #${isn} 등록 완료 (PENDING · 대기열 등록 → 자동 처리 대기)\n• 제목: ${title}`
-          : '⚠️ issue 등록 응답에 isn 이 없습니다. 계정/CSN 설정을 확인하세요.',
+        isn ? msg(msgLang, 'doneQueued', { isn, title }) : msg(msgLang, 'noIsn'),
         replyTs);
     } catch (e) {
       console.error('[Bot] issue 등록 실패:', e.message);
-      await postMessage(channelId, `❌ issue 등록 실패: ${e.message}`, replyTs);
+      await postMessage(channelId, msg(msgLang, 'error', { message: e.message }), replyTs);
     }
     return;
   }

--- a/slack-bot/i18n-issue-reg.js
+++ b/slack-bot/i18n-issue-reg.js
@@ -1,0 +1,108 @@
+/**
+ * i18n-issue-reg.js — giip #1252: `issue 등록` 트리거(handlers.js handleChannelMention)의
+ * 확인/에러 메시지 다국어화.
+ *
+ * 범위 한정(rule): 이슈 등록 성공/실패, 계정·csn 안내 메시지만. 봇 UI 전반에 흩어진 다른 하드코딩
+ * 한국어 문자열(!help, giip project/channel 안내 등)은 이번 PR 범위 밖 — 후속 이슈 후보로 남긴다
+ * (PR 본문 참고). 트리거 자체(등록/登録/register, issue/이슈/イシュー)와 등록되는 내용(content)은
+ * 이미 언어 무관하게 그대로 통과되므로 손대지 않는다.
+ *
+ * 지원 언어 코드는 config.js LANG_NAMES 와 동일(ko/ja/en/zh-CN/zh-TW). 미지원/미상 코드는 ko 로 폴백.
+ */
+
+const MESSAGES = {
+  ko: {
+    usage: () => '사용법: `<프로젝트> issue 등록 <내용>` — 내용을 그대로 giip issue 로 등록합니다.',
+    noAccount: () => '⚠️ giip 계정 미설정입니다. `giip account set <login_id> <sk> [csn]` 로 먼저 등록하세요(SK 포함이라 DM 권장).',
+    analyzing: () => '🔍 의뢰 내용을 분석해 작업지시서로 정리 중입니다... (수십 초 소요)',
+    doneReady: ({ isn, title, plan }) => [
+      `✅ giip issue #${isn} 등록 완료 (READY · 작업지시서 첨부 → 자동 처리 대기)`,
+      `• 제목: ${title}`,
+      '',
+      '```',
+      plan,
+      '```',
+    ].join('\n'),
+    donePending: ({ isn, title }) => `✅ giip issue #${isn} 등록 완료 (PENDING · 무인 refine 대기)\n• 제목: ${title}`,
+    doneQueued: ({ isn, title }) => `✅ giip issue #${isn} 등록 완료 (PENDING · 대기열 등록 → 자동 처리 대기)\n• 제목: ${title}`,
+    noIsn: () => '⚠️ issue 등록 응답에 isn 이 없습니다. 계정/CSN 설정을 확인하세요.',
+    error: ({ message }) => `❌ issue 등록 실패: ${message}`,
+  },
+  en: {
+    usage: () => 'Usage: `<project> issue register <content>` — registers the content as-is as a giip issue.',
+    noAccount: () => '⚠️ No giip account configured. Run `giip account set <login_id> <sk> [csn]` first (contains a secret key — DM is recommended).',
+    analyzing: () => '🔍 Analyzing the request and drafting a work order... (can take tens of seconds)',
+    doneReady: ({ isn, title, plan }) => [
+      `✅ giip issue #${isn} registered (READY · work order attached → queued for automatic processing)`,
+      `• Title: ${title}`,
+      '',
+      '```',
+      plan,
+      '```',
+    ].join('\n'),
+    donePending: ({ isn, title }) => `✅ giip issue #${isn} registered (PENDING · awaiting unattended refine)\n• Title: ${title}`,
+    doneQueued: ({ isn, title }) => `✅ giip issue #${isn} registered (PENDING · queued → awaiting automatic processing)\n• Title: ${title}`,
+    noIsn: () => '⚠️ The issue registration response had no isn. Check your account/CSN configuration.',
+    error: ({ message }) => `❌ Issue registration failed: ${message}`,
+  },
+  ja: {
+    usage: () => '使い方: `<プロジェクト> issue 登録 <内容>` — 内容をそのまま giip issue として登録します。',
+    noAccount: () => '⚠️ giip アカウント未設定です。先に `giip account set <login_id> <sk> [csn]` で登録してください(SK を含むため DM 推奨)。',
+    analyzing: () => '🔍 依頼内容を分析して作業指示書にまとめています…(数十秒かかります)',
+    doneReady: ({ isn, title, plan }) => [
+      `✅ giip issue #${isn} 登録完了 (READY・作業指示書添付 → 自動処理待ち)`,
+      `• タイトル: ${title}`,
+      '',
+      '```',
+      plan,
+      '```',
+    ].join('\n'),
+    donePending: ({ isn, title }) => `✅ giip issue #${isn} 登録完了 (PENDING・無人 refine 待ち)\n• タイトル: ${title}`,
+    doneQueued: ({ isn, title }) => `✅ giip issue #${isn} 登録完了 (PENDING・キュー登録 → 自動処理待ち)\n• タイトル: ${title}`,
+    noIsn: () => '⚠️ issue 登録応答に isn がありません。アカウント/CSN 設定を確認してください。',
+    error: ({ message }) => `❌ issue 登録失敗: ${message}`,
+  },
+  'zh-CN': {
+    usage: () => '用法: `<项目> issue register <内容>` — 将内容原样注册为 giip issue。',
+    noAccount: () => '⚠️ 尚未配置 giip 账户。请先执行 `giip account set <login_id> <sk> [csn]`(含密钥,建议使用私信)。',
+    analyzing: () => '🔍 正在分析请求内容并整理成工单...(可能需要几十秒)',
+    doneReady: ({ isn, title, plan }) => [
+      `✅ giip issue #${isn} 注册完成 (READY · 已附工单 → 等待自动处理)`,
+      `• 标题: ${title}`,
+      '',
+      '```',
+      plan,
+      '```',
+    ].join('\n'),
+    donePending: ({ isn, title }) => `✅ giip issue #${isn} 注册完成 (PENDING · 等待无人值守整理)\n• 标题: ${title}`,
+    doneQueued: ({ isn, title }) => `✅ giip issue #${isn} 注册完成 (PENDING · 已加入队列 → 等待自动处理)\n• 标题: ${title}`,
+    noIsn: () => '⚠️ issue 注册响应中没有 isn。请检查账户/CSN 设置。',
+    error: ({ message }) => `❌ issue 注册失败: ${message}`,
+  },
+  'zh-TW': {
+    usage: () => '用法: `<專案> issue register <內容>` — 將內容原樣註冊為 giip issue。',
+    noAccount: () => '⚠️ 尚未設定 giip 帳戶。請先執行 `giip account set <login_id> <sk> [csn]`(含密鑰,建議使用私訊)。',
+    analyzing: () => '🔍 正在分析請求內容並整理成工單...(可能需要幾十秒)',
+    doneReady: ({ isn, title, plan }) => [
+      `✅ giip issue #${isn} 註冊完成 (READY · 已附工單 → 等待自動處理)`,
+      `• 標題: ${title}`,
+      '',
+      '```',
+      plan,
+      '```',
+    ].join('\n'),
+    donePending: ({ isn, title }) => `✅ giip issue #${isn} 註冊完成 (PENDING · 等待無人值守整理)\n• 標題: ${title}`,
+    doneQueued: ({ isn, title }) => `✅ giip issue #${isn} 註冊完成 (PENDING · 已加入佇列 → 等待自動處理)\n• 標題: ${title}`,
+    noIsn: () => '⚠️ issue 註冊回應中沒有 isn。請檢查帳戶/CSN 設定。',
+    error: ({ message }) => `❌ issue 註冊失敗: ${message}`,
+  },
+};
+
+/** lang 코드(config.resolveLangForProject 결과) + 메시지 key + 변수로 로컬라이즈된 문자열을 얻는다. */
+function t(langCode, key, vars = {}) {
+  const table = MESSAGES[langCode] || MESSAGES.ko;
+  const fn = table[key] || MESSAGES.ko[key];
+  return fn ? fn(vars) : '';
+}
+
+module.exports = { t };


### PR DESCRIPTION
## 배경 / 원본 요청 (giip #1252)
> slack-bot은 giip 연동후 csn 이 인식되면 해당 csn의 언어(clang) 를 읽어서 그 언어에 해당하는 언어로만 답변해줘. issue 등록 같은 명령도 한국어로만 가능하니 issue reg 도 등록할 수 있게 해주고, 다국어 모두 받을 수 있게 해줘.

## 변경 요약

### 1. csn → clang(응답언어) 자동 조회 + 캐시
- `slack-bot/giip-api.js`에 `corpLangGet(account, csn)` 추가 — giipdb SP `pApiCorpLangGetbySk`를 `giipApiSk2` 디스패처(bySk 계열)로 호출.
- `slack-bot/csn-lang-cache.js`(신규) — csn→언어코드 인메모리 캐시(성공 TTL 5분/실패 TTL 1분) + fire-and-forget `prefetch()` + 순수 동기·네트워크 없는 `peekCachedLangCode()`.
- `slack-bot/config.js#resolveLangForProject`가 **csn 캐시를 project-lang.json 수동맵보다 우선** 적용. 캐시 미스/조회실패/csn 미상은 항상 기존 수동맵 → `DEFAULT_LANG('ko')` 순으로 조용히 폴백 — 기존 동작 100% 유지.
- csn이 인식되는 지점(`handlers.js#answerInChannel`/`handleDM`, `giip-task.js#maybeCreateIssue`, issue 등록 트리거)마다 캐시 워밍용 `prefetch()` 호출을 걸어둠. 첫 메시지는 항상 기존 폴백으로 응답하고, 다음 메시지부터 캐시가 반영됨(매 응답마다 API를 부르지 않기 위한 설계).

**(a) giipdb SP 존재 여부 확인 결과 — 있지만 그대로 못 쓴다.**
`giipprj/giipdb/SP/pApiCorpLangGetbySk.sql`이 이미 존재한다(2025-12-26 신설, MQE AI Advisor용, `SELECT ISNULL(cLang,'ko-KR') FROM tCorp WHERE CSn=@csn`). 그런데 인증이 **일반 bySk 검증(tSecretKey↔csn)이 아니라 하드코딩된 단일 Admin SK 게이트**다(`IF (@sk = 'ffd968...')` 외엔 전부 403). giip-fde-agent는 각 채널의 테넌트 SK(`account.sk`)만 갖고 있어, 이 코드는 giipdb 쪽에서 (a) SP를 호출자 자신의 csn 범위로 tSecretKey 검증하도록 완화하거나 (b) 이 봇 전용 admin SK를 안전하게 프로비저닝하기 전까지는 **403으로 계속 실패하고 항상 폴백만 탄다** — giipdb SP 변경은 giipprj nested repo 소관이라 이번 PR 범위 밖. 실패해도 봇은 절대 죽지 않고 기존 수동맵/DEFAULT_LANG으로 조용히 동작한다(설계상 안전).

디스패처 호출 규약 관련 세부사항: `pApiCorpLangGetbySk`는 이름에 `Get`이 포함돼 `giipApiSk2/run.ps1`의 jsondata 자동첨부(ISN 161)가 스킵되므로, csn은 jsondata가 아니라 `text` 뒤에 숫자 리터럴로 직접 붙여 보낸다(`CorpLangGet <csn>` → `exec pApiCorpLangGetbySk '<sk>', <csn>`). mock-request로 실제 전송 페이로드를 확인함(`text=CorpLangGet%2070424&token=...`).

### 2. issue 등록 경로 다국어 확인 결과
`giip-commands.js`의 등록 트리거(`/^(?:등록|登録|register)/i`)와 `handlers.js`의 `issueTrigger`(`issue|이슈|イシュー` × `등록|登録|register`)를 추적한 결과, **트리거 인식과 등록 내용(content) 전달 자체는 이미 완전히 다국어로 동작하고 있었다** — 한국어 키워드만 매칭하는 분기나 한국어 전용 파싱은 없었음. 실제 문제는 **봇이 사용자에게 보여주는 확인/에러 메시지가 전부 한국어로 하드코딩**돼 있던 것(사용법 안내, 계정 미설정 경고, 분석중 안내, 등록완료/실패 메시지 등 7종, `handlers.js` 712~792행 부근) — 비한국어 사용자는 등록은 되지만 결과를 못 읽는 상태였다.
- `slack-bot/i18n-issue-reg.js`(신규)로 이 7종 메시지를 ko/ja/en/zh-CN/zh-TW로 번역, `config.resolveLangForProject`(1번 항목의 csn 우선순위 포함) 기준으로 선택해 응답하도록 `handlers.js`의 `issueTrigger` 블록을 수정. 미지원/미상 언어코드는 ko로 폴백.
- **범위 한정**: 이슈 등록 관련 확인 메시지에만 한정했다. 트리거/파싱 로직 자체는 변경 없음(원래 정상이었으므로).

### (c) 후속 이슈 후보 — 광범위한 한국어 하드코딩 (직접 고치지 않음, 범위 밖)
`handlers.js`(`!help` 명령 안내, 각종 상태 메시지), `giip-commands.js`(`giip project/channel` 사용법 안내), `giip-task.js`, `dashboard.js`, `task-manager.js` 등 이 코드베이스 전반에 하드코딩 한국어(및 일부 일본어) UI 문자열이 매우 광범위하게 퍼져 있음(수천 개 한글 문자, 대부분 주석이지만 `postMessage`로 사용자에게 직접 나가는 문자열도 다수). 전면 다국어화는 별도 이슈로 분리해야 할 규모 — 이번 PR은 원본 요청이 명시한 "csn 언어 자동응답"과 "issue 등록 확인 메시지"에만 한정했다.

## 검증
- `node --check`로 전체 신규/수정 파일 문법 검증 통과.
- 신규 모듈(`csn-lang-cache.js`, `i18n-issue-reg.js`, `config.js` 우선순위 로직) 노드 스크립트로 직접 호출해 동작 확인: 캐시 미스→폴백, 캐시 워밍 후 우선 적용, TTL 만료 후 재폴백, 5개 언어 메시지 텍스트 출력, `apiCall`의 실제 전송 페이로드(mock https) 확인.
- 전체 slack-bot 모듈 그래프(`config`/`giip-api`/`giip-accounts`/`csn-lang-cache`/`i18n-issue-reg`/`giip-task`/`giip-commands`/`handlers`) require 성공, 순환참조 없음.
- 실 Slack 라이브 테스트 및 실제 giipdb SP 200 응답 여부는 이번 세션 범위 밖(csn 70424 SK 미보유) — 코드 정적 검증까지만 수행.

## 테스트 체크리스트
- [ ] giipdb SP `pApiCorpLangGetbySk`를 테넌트 SK 검증 방식으로 완화(또는 이 봇 전용 admin SK 프로비저닝) — giipprj 별도 작업
- [ ] 실제 csn 70424로 라이브 Slack에서 clang 응답언어 전환 확인
- [ ] 5개 언어(ko/ja/en/zh-CN/zh-TW) 각각으로 `issue 등록` 실행해 확인 메시지 언어 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)