### PR TITLE
fix(scheduler): RepetitionDuration MaxValue를 유효 범위 값으로 교체 (giip #1275)

### DIFF
--- a/docs/60-operations/hourly-issue-scheduler.md
+++ b/docs/60-operations/hourly-issue-scheduler.md
@@ -19,7 +19,10 @@ giip issue 상태머신(PENDING→READY→IN_PROGRESS→REVIEW/DONE, +REVIEW→T
 
 - **매시 :07** 시작(임의로 고른 분 — 정각/일반적인 :00, :05, :10 트리거들과 충돌을 피하기 위한 선택).
 - cron 표현식(다른 플랫폼/Linux 참고용): `7 * * * *`
-- Windows Task Scheduler 기준: 최초 트리거 `00:07:00` 시작, `1시간마다 반복`, 무기한 지속.
+- Windows Task Scheduler 기준: 최초 트리거 `00:07:00` 시작, `1시간마다 반복`, 사실상 무기한 지속
+  (`[TimeSpan]::MaxValue`는 ISO8601 직렬화 시 Task Scheduler XML의 duration 상한을 초과해
+  `Register-ScheduledTask`가 거부하므로(HRESULT 0x80041318, giip #1275), 실제로는 유효 범위 내
+  충분히 큰 값 — 약 10년(`New-TimeSpan -Days 3650`) — 을 사용).
 
 ## 3) 실행 커맨드 템플릿
 

--- a/scripts/register-hourly-issue-scheduler.ps1
+++ b/scripts/register-hourly-issue-scheduler.ps1
@@ -85,9 +85,14 @@ function Register-HourlyTask {
     $execArgs = "-WindowStyle Hidden -NonInteractive -ExecutionPolicy Bypass -File `"$runner`""
     $action = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument $execArgs
 
+    # 주의: [TimeSpan]::MaxValue 는 "무기한 반복" 의도로 쓰였으나, ISO8601 duration으로 직렬화하면
+    # P99999999DT23H59M59S 가 되어 Task Scheduler XML 스키마의 duration 상한을 초과한다. 그 결과
+    # Register-ScheduledTask 가 "태스크 XML에 부적절한 설정이 있거나 범위 외의 값이 포함되어 있습니다"
+    # (HRESULT 0x80041318)로 등록 자체를 거부한다(giip #1275, 실측). 대신 유효 범위 내에서 충분히 큰
+    # 값(약 10년)을 써서 사실상 무기한 반복을 구현한다.
     $trigger = New-ScheduledTaskTrigger -Once -At $StartTime `
         -RepetitionInterval (New-TimeSpan -Minutes $RepetitionMinutes) `
-        -RepetitionDuration ([TimeSpan]::MaxValue)
+        -RepetitionDuration (New-TimeSpan -Days 3650)
 
     $settings = New-ScheduledTaskSettingsSet `
         -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `


### PR DESCRIPTION
## Summary
- `register-hourly-issue-scheduler.ps1`의 `Register-HourlyTask`에서 `New-ScheduledTaskTrigger -RepetitionDuration ([TimeSpan]::MaxValue)`가 ISO8601 직렬화 시 `P99999999DT23H59M59S`가 되어 Task Scheduler XML 스키마 duration 상한을 초과, `Register-ScheduledTask`가 HRESULT 0x80041318로 등록 자체를 거부하던 버그 수정(giip #1271 산출물의 회귀, giip #1275에서 실측 재현).
- `New-TimeSpan -Days 3650`(약 10년)으로 교체해 "사실상 무기한 반복" 의도를 Task Scheduler가 실제로 허용하는 범위 내에서 구현.
- `docs/60-operations/hourly-issue-scheduler.md` 정본 스펙(§2 트리거 스펙)에도 실제 duration 값과 근거를 반영.

## Test plan
- [x] 로컬에서 `-Action Register -TaskName GIIP_Gissue_Claude_DRYRUN_TEST2`로 실제 등록 시도 → 성공 (State=Ready, NextRunTime 정상 산출)
- [x] `-Action Status`로 등록 상태 확인
- [x] `Get-ScheduledTask`/`schtasks /XML`로 실제 등록된 XML의 `Duration` 값이 `P3650D`(유효 범위 내)임을 직접 확인
- [x] `-Action Unregister`로 테스트 태스크 정리, 잔여 없음 확인
- [x] 운영 태스크(`GIIP_Gissue_Claude`)는 건드리지 않음

🤖 Generated with [Claude Code](https://claude.com/claude-code)