### PR TITLE
fix(gissue): orphan .worktrees 자가정리 로직을 lowyworkenv에서 이식 (giip #1547)

### DIFF
--- a/docs/60-operations/hourly-issue-scheduler.md
+++ b/docs/60-operations/hourly-issue-scheduler.md
@@ -112,7 +112,124 @@ powershell.exe -WindowStyle Hidden -NonInteractive -ExecutionPolicy Bypass `
 등록 스크립트: `giip-fde-agent/scripts/register-hourly-issue-scheduler.ps1`(파라미터화된 Windows
 Task Scheduler 등록 스크립트, 이 문서의 §2~§3 스펙을 그대로 구현).
 
-## 8) 배포 절차(신규 CSN/PC — 복사만으로 이식)
+## 8) 등록 스크립트 상세 (`register-hourly-issue-scheduler.ps1`)
+
+`scripts/register-hourly-issue-scheduler.ps1`은 이 문서 §2~§3 스펙을 그대로 구현하는, 파라미터화된
+Windows Task Scheduler 등록/해제/확인 스크립트다. `-Action` 셋(기본값 `Status`) 3가지:
+
+- **`Register`**: `-RepoRoot`(필수 — 이 스케줄러 스크립트 세트를 배치한 오케스트레이션 레포 루트,
+  원본 배포는 `lowyworkenv`)를 받아 `-RunnerRelativePath`(기본
+  `scripts/gissue/run-gissue-claude.ps1`)와 조합해 실제 러너 경로를 확인(`Test-Path`, 없으면 즉시
+  에러)한 뒤, 다음을 등록한다:
+  - **Action**: `powershell.exe -WindowStyle Hidden -NonInteractive -ExecutionPolicy Bypass -File
+    "<runner경로>"`
+  - **Trigger**: `-StartTime`(기본 `00:07:00`)에 1회 시작해 `-RepetitionMinutes`(기본 60분)마다
+    반복. `-RepetitionDuration`을 `[TimeSpan]::MaxValue`로 주면 ISO8601 직렬화 시 Task Scheduler
+    XML의 duration 상한을 넘어 등록 자체가 거부되므로(HRESULT 0x80041318, giip #1275 실측), 대신
+    `New-TimeSpan -Days 3650`(약 10년)으로 사실상 무기한 반복을 구현한다.
+  - **Settings**: `AllowStartIfOnBatteries`+`DontStopIfGoingOnBatteries`(배터리 전원과 무관하게
+    실행/지속), `StartWhenAvailable`(예정 시각에 PC가 꺼져 있었으면 켜지는 즉시 실행),
+    `MultipleInstances IgnoreNew`(이전 실행이 아직 끝나지 않았으면 새 트리거를 무시 — 스크립트
+    자체의 CSN별 age-based lock과는 별개의 이중 안전장치), `ExecutionTimeLimit`2시간(러너 자신의
+    `$RunTimeoutMin`=90분보다 넉넉하게 상한).
+  - **실행 계정**: 기본값은 현재 로그온 사용자(`$env:USERDOMAIN\$env:USERNAME`), `RunLevel Limited`.
+    `-Password`를 넘기면 PSCredential로 비밀번호 인증 등록을 해 그 계정이 로그오프 상태여도(재부팅
+    후 로그인 안 해도) 스케줄이 동작한다 — 넘기지 않으면 `Register-ScheduledTask`가 최초 등록 시
+    대화형 자격증명 프롬프트를 띄울 수 있어 무인 등록(원격 세션 등)에서는 걸릴 수 있다.
+  - **`-TaskName`**(기본 `GIIP_Gissue_Claude`): 같은 PC에 여러 배포를 동시에 등록하려면(예: 서로
+    다른 오케스트레이션 레포/CSN 세트) 배포마다 고유한 이름을 지정해야 한다 — 기본값 그대로 두 번
+    등록하면 `-Force`로 앞선 등록을 덮어쓴다.
+- **`Unregister`**: 해당 `-TaskName`의 태스크를 확인 프롬프트 없이(`-Confirm:$false`) 제거. 이미
+  없으면 에러 대신 안내 메시지만 출력(멱등).
+- **`Status`**(기본값, `-RepoRoot` 불필요): `Get-ScheduledTask`+`Get-ScheduledTaskInfo`로 태스크
+  이름·State·Enabled·등록된 Action 문자열·LastRunTime·LastTaskResult·NextRunTime을 한 번에 출력한다.
+
+## 9) 등록 확인 방법
+
+등록 스크립트의 `-Action Status`가 가장 빠른 확인 경로다:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\register-hourly-issue-scheduler.ps1 -Action Status -TaskName GIIP_Gissue_Claude
+```
+
+직접 표준 cmdlet으로 확인해도 동일하다:
+
+```powershell
+Get-ScheduledTask -TaskName GIIP_Gissue_Claude
+Get-ScheduledTaskInfo -TaskName GIIP_Gissue_Claude | Select-Object LastRunTime, LastTaskResult, NextRunTime
+```
+
+`LastTaskResult`가 `0`이면 프로세스 자체는 정상 종료됐다는 뜻이지만(러너 내부는 CSN별로 try/catch로
+감싸 개별 실패를 삼키므로 스크립트가 통째로 비정상 종료하는 경우는 드물다), **그것만으로 "이슈 처리가
+실제로 진행되고 있다"를 확인했다고 보지 말 것** — 등록/기동 성공과 실제 큐 처리 진행은 별개다. 반드시
+로그를 직접 열어 최근 사이클이 실제로 돌았는지 확인한다:
+
+```powershell
+Get-Content -Tail 20 -Encoding UTF8 .\scripts\gissue\logs\gissue_csn<CSN번호>.log
+```
+
+- `gissue_csn<N>.log`: `Write-Log`가 남기는 사람이 읽는 이벤트 로그. 정상 사이클이면 `START
+  (cwd=...)`로 시작해(잡이 실제로 기동됐다는 뜻) 잡 종료 시 `DONE`(또는 타임아웃 시 `TIMEOUT`류
+  메시지)으로 끝난다. `SKIP: ...`만 반복되면(workdir 없음/lock 미해제/스케줄러 비활성 등) 원인을
+  그 SKIP 사유 문자열에서 바로 확인할 수 있다.
+- `gissue_csn<N>.out.log`: claude/MiniMax 잡의 원시 stdout(프롬프트에 대한 실제 응답, 무엇을
+  처리했는지 서술). 이슈가 실제로 처리됐는지 세부를 보려면 여기를 본다.
+- `gissue_csn<N>.lock`: 실행 중 표시용 파일(내용은 PID). `$LockMaxAgeHr`(2시간)보다 오래됐으면 다음
+  실행이 stale로 간주해 자동 제거하고 이어서 실행한다 — 사람이 수동으로 지울 필요는 보통 없다.
+
+"최근 사이클이 실제로 새 코드로 돌았는지"까지 확인하려면(아래 §11 참고) 로그 타임스탬프가 최근
+`git log`/`git pull` 이후인지 대조한다.
+
+## 10) orphan `.worktrees` 자가정리 — 왜 존재하는가 (giip #1540/#1544/#1547)
+
+`run-gissue-claude.ps1`은 각 CSN 처리마다(Phase 1 busy-wait 대기보다 먼저) `Remove-GissueOrphanWorktrees`
+함수로 담당 프로젝트(+nested repo) 안의 `.worktrees/` 디렉터리를 스캔해, **git worktree로 정식
+등록되지 않은(orphan) + 이슈 상태가 DONE이거나 이슈 자체가 없는 + 24시간 이상 방치된** 디렉터리만
+안전하게 삭제한다. 존재 이유:
+
+- **giip #1540** (2026-08-26): lowyworkenv의 동일 러너에서, 이미 DONE 처리된 이슈의 `.worktrees/`
+  잔해 안에 orphan `node_modules`(pnpm 구조, 매우 깊은 경로)가 남아 있어 Windows git이
+  "Filename too long"을 반복 발생시켰다. 이 러너의 `[F]` orphan-stash 자동언블록(`stash -u`) 로직이
+  이 잔해를 건드릴 때마다 실패해, 그 실패가 **20,236회** 반복되며 CSN47 이슈 큐 전체가 완전히
+  마비됐다(어떤 이슈도 처리되지 못함).
+- **giip #1544**: 위 인시던트의 재발 방지로, lowyworkenv 쪽 러너 자신에게 이 결정적(비-LLM)
+  PowerShell 정리 로직을 추가했다(`Get-GissueIsnStatusMap`/`Remove-GissueOrphanWorktrees`, DB
+  직접 조회 경로 사용).
+- **giip #1547** (이 변경): 이 레포(`giip-fde-agent`)의 `run-gissue-claude.ps1`도 동일한
+  `[F]`/`stash -u`/AUTO-UNBLOCK 구조를 그대로 갖고 있어 같은 취약점에 노출될 수 있으므로, 원본
+  레포 자신에도 동일 취지의 방어 로직을 이식했다. 이 레포는 DB 직접 접근이 없어(§4 참고), isn 상태
+  조회를 giipfaw API(`scripts/gissue/lib/get-isn-status.js`, 신규)로 대체한 것이 lowyworkenv 판과의
+  유일한 구조적 차이다.
+
+READY/PENDING/IN_PROGRESS/REVIEW/TESTED 상태의 이슈에 연결된 워크트리, 그리고 `git worktree list`에
+정식 등록된 워크트리는 이 로직이 **절대** 건드리지 않는다 — 사람이 지금 그 워크트리에서 작업 중일 수
+있기 때문이다. 삭제 자체도 Windows `MAX_PATH`(260자) 제한을 우회하기 위해 robocopy 빈 폴더 `/MIR`
+미러 트릭을 쓴다(`Remove-Item` 단독으로는 깊은 pnpm 경로 등에서 실패할 수 있다 — 이번 인시던트 수동
+조치에서 실제로 쓴 방법). 실행 로그에서 `[ORPHAN-CLEANUP]` 접두어로 필터링하면 무엇을 왜 지웠는지(또는
+왜 보류했는지) 바로 확인할 수 있다.
+
+## 11) 운영 함정 — **PR 머지 ≠ 스케줄러가 새 코드로 도는 것** (반드시 숙지)
+
+**GitHub에서 PR을 머지해도, Windows Task Scheduler가 실제로 실행하는 파일은 그 태스크가 가리키는
+로컬 워킹카피(§8 등록 시의 `-RepoRoot`/`-RunnerRelativePath`가 가리키는 로컬 경로)다.** 원격
+`main`이 갱신됐다는 사실 자체는 로컬 체크아웃에 아무 영향을 주지 않는다 — **그 로컬 디렉터리에서
+`git pull`을 실행하기 전까지, 스케줄러는 다음 `:07` 사이클에도, 그 다음 사이클에도 계속 머지 전 옛
+코드로 돈다.** CI가 green이고 PR이 머지됐다는 사실만으로 "다음 실행부터는 반영됐겠지"라고 가정하지
+말 것.
+
+**실제 사고 사례(2026-08-26, lowyworkenv)**: giip #1544(위 §10의 orphan-worktree 정리 fix) PR을
+GitHub에서 머지했지만, 그 PR을 병합한 세션이 로컬 `lowyworkenv` 체크아웃에서 `git pull`을 깜빡했다.
+그 결과 **11:07 사이클이 머지된 새 코드가 아니라 머지 전 옛 코드로 그대로 실행됐다** — 스케줄러
+자신은 아무 에러도 내지 않고 "정상적으로" 옛 로직을 돌렸을 뿐이라, 로그만 봐서는 문제를 알아채기
+어렵다(태스크 State/LastTaskResult 모두 정상으로 보인다).
+
+**따라서: 이 스케줄러가 실행하는 스크립트(`run-gissue-claude.ps1` 자신, 또는 그것이 참조하는
+`lib/*.js`, 프롬프트 템플릿 등)를 수정하는 PR을 머지한 뒤에는, 그 즉시 해당 로컬 체크아웃에서
+`git pull`까지 실행해야 다음 `:07` 사이클부터 실제로 반영된다.** PR 머지만으로 배포가 끝났다고
+보고하지 말 것 — `git pull` 완료(그리고 가능하면 `git log -1`로 반영된 커밋 해시 확인)까지가 "이
+변경이 실제로 스케줄러에 배포됐다"의 완료 정의다.
+
+## 12) 배포 절차(신규 CSN/PC — 복사만으로 이식)
 
 이 레포 자체가 이제 실행 가능한 구현체입니다(스펙 문서만이 아님). 새 프로젝트/PC에 이식하려면:
 
@@ -131,7 +248,7 @@ Task Scheduler 등록 스크립트, 이 문서의 §2~§3 스펙을 그대로 �
 자주 쓰는 저장소라면, 스케줄러 전용 별도 clone을 workdir로 쓰는 것을 권장한다(원본 저장소와는 git
 remote로만 연결된, 완전히 독립적인 워킹트리).
 
-## 8) 연결 문서
+## 13) 연결 문서
 
 - KPI 표준: `./ai-native-kpi.md`
 - 장애/롤백 플레이북: `./incident-rollback-playbook.md`

--- a/scripts/gissue/lib/get-isn-status.js
+++ b/scripts/gissue/lib/get-isn-status.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * isn 목록의 giip issue 상태를 배치 조회한다 (giip #1547 — orphan .worktrees 자가정리용).
+ *
+ * 배경: run-gissue-claude.ps1 의 Remove-GissueOrphanWorktrees(giip #1544 를 lowyworkenv 에서
+ * 이식, giip #1547)가 .worktrees/ 아래 orphan(=git worktree 미등록) 디렉토리 후보들의 isn 을
+ * 뽑아낸 뒤, 그 이슈가 DONE 이거나 더 이상 존재하지 않는지 확인해야 안전하게 삭제할 수 있다.
+ * 이 레포는 DB 직접 접근(dbconfig.json/execSQLFile.ps1) 이 없고 giipfaw API(x-api-key 인증)만
+ * 쓰므로, lib/check-csn.js 가 이미 쓰는 GET {apiBase}/giipIssues?isn=<isn> 패턴을 그대로 재사용해
+ * isn 마다 순차 조회한다(배치 엔드포인트가 없어 여러 번 호출 — orphan 후보 수는 보통 소수라
+ * 실용적으로 충분하다).
+ *
+ * 사용: node get-isn-status.js <apiBase> <sk> <isn1,isn2,...>
+ * stdout: 조회에 성공한 isn 만 "isn|status" 한 줄씩(순서 무관). 조회 실패/파싱 실패 isn 은 아무
+ * 것도 출력하지 않는다(호출측이 "이슈 없음"으로 해석 — lowyworkenv 의 Get-GissueIsnStatusMap 과
+ * 동일 컨벤션).
+ * 종료코드: 항상 0(가용성 우선 — 개별 isn 조회 실패가 나머지 조회를 막지 않는다).
+ */
+const https = require('https');
+const { URL } = require('url');
+
+const [, , apiBase, sk, isnCsv] = process.argv;
+if (!apiBase || !sk || !isnCsv) {
+  console.error('사용법: node get-isn-status.js <apiBase> <sk> <isn1,isn2,...>');
+  process.exit(0);
+}
+
+const isnList = [...new Set(
+  isnCsv.split(',').map((s) => s.trim()).filter((s) => /^\d+$/.test(s))
+)];
+
+function fetchStatus(isn) {
+  return new Promise((resolve) => {
+    const u = new URL(`${apiBase}/giipIssues?isn=${encodeURIComponent(isn)}`);
+    const req = https.get(u, { headers: { 'x-api-key': sk } }, (res) => {
+      let data = '';
+      res.on('data', (c) => { data += c; });
+      res.on('end', () => {
+        try {
+          const j = JSON.parse(data);
+          const issue = j.issue || j;
+          if (issue && issue.status) {
+            resolve(`${isn}|${issue.status}`);
+            return;
+          }
+        } catch (e) {
+          // 파싱 실패 — 아래 resolve(null)로 "이슈 없음/조회 불가"와 동일하게 처리
+        }
+        resolve(null);
+      });
+    });
+    req.on('error', () => resolve(null));
+    req.setTimeout(30000, () => { req.destroy(); resolve(null); });
+  });
+}
+
+(async () => {
+  for (const isn of isnList) {
+    // 배치 엔드포인트가 없어 순차 처리 — 후보 수가 많아지면 병렬화 고려(현재는 불필요).
+    // eslint-disable-next-line no-await-in-loop
+    const line = await fetchStatus(isn);
+    if (line) console.log(line);
+  }
+  process.exit(0);
+})();

--- a/scripts/gissue/run-gissue-claude.ps1
+++ b/scripts/gissue/run-gissue-claude.ps1
@@ -44,6 +44,29 @@
 # 엔진: claude -p --dangerously-skip-permissions (컨펌 없이 끝까지 자율)
 #   2026-08-07: MINIMAX_API_KEY 있으면 MiniMax 우선 시도 → 실패/한도 시 같은 실행에서 즉시 claude 폴백
 #   (slack-bot 과 동일 우선순위 정책, MODEL_USAGE_SPEC.md 참고). 키 없으면 기존과 100% 동일.
+#   orphan 워크트리 자가정리(giip #1547, 2026-08-26 신설 — lowyworkenv 쪽 giip #1540/#1544 인시던트
+#   재발 방지 로직을 이 원본 레포로 이식): lowyworkenv/scripts/gissue/run-gissue-claude.ps1(giip #1544,
+#   커밋 bd5904b2)에서 완료된 이슈의 .worktrees/ 잔해(pnpm node_modules 등 매우 깊은 경로)가 Windows git
+#   "Filename too long"을 유발해 [F] AUTO-UNBLOCK stash -u 가 20,236회 반복 실패하며 CSN47 큐 전체가
+#   마비된 사고가 있었다. 이 레포(giip-fde-agent)의 run-gissue-claude.ps1 도 동일한 AUTO-UNBLOCK/stash -u
+#   구조([F], 위 참고)를 그대로 갖고 있어 같은 취약점에 노출될 수 있으므로, 스케줄러 자신이 각 CSN 처리마다
+#   (Phase 1 busy-wait 대기보다 먼저) `.worktrees/`(및 그 안 nested git 레포 각각의 `.worktrees/`)를 스캔해
+#   디렉토리명에서 `(?:isn|giip|issue)-?(\d+)` 정규식으로 이슈번호를 추출하고(매칭 안 되면 절대 안 건드림),
+#   `git worktree list --porcelain` 에 실제 등록된 정식 워크트리는 제외한 뒤, 남은 후보의 이슈 상태가
+#   DONE 이거나 이슈 자체가 존재하지 않고 디렉토리 최종수정시각이 24시간 이상 지난 것만(사람이 방금 끝낸
+#   작업을 아직 보고 있을 안전마진) robocopy 빈 폴더 `/MIR` 미러 트릭(Windows MAX_PATH 260자 제한 회피,
+#   lowyworkenv 인시던트 수동조치에서 실제로 쓴 방법)으로 비운 뒤 디렉토리 자체를 지운다.
+#   READY/PENDING/IN_PROGRESS/REVIEW/TESTED 는 절대 건드리지 않는다.
+#   [이식 시 이 레포 컨벤션에 맞춘 차이점] lowyworkenv 는 giipprj/giipdb\mgmt\execSQLFile.ps1 로 DB를 직접
+#   조회하지만, 이 레포는(위 "이슈 조회/코멘트/상태전이는 전부 giipfaw API 경유" 참고) DB 직접 접근 수단이
+#   없다 — 대신 lib/check-csn.js 가 이미 쓰는 GET {ApiBase}/giipIssues?isn=<isn> (x-api-key 인증) 패턴을
+#   재사용하는 신규 lib/get-isn-status.js 로 isn 목록의 상태를 순차 배치 조회한다(sk 는 giip-accounts.json
+#   기존 헬퍼 Get-GissueCsnSk 로 CSN 47 등 이 배포에 등록된 아무 csn 이나 사용 — sysadmin sk 는 csn 과
+#   무관하게 모든 isn 을 조회할 수 있음, get-issue.sh 상단 주석 참고). claude/MiniMax 세션을 띄우지 않는
+#   순수 PowerShell(+node) 기계적 로직이며, DB/API 조회·robocopy 실패 등 어떤 예외가 나도 try/catch 로
+#   감싸 경고 로그만 남기고 스케줄러 전체를 죽이지 않는다(Invoke-GissuePrGateSweep 등 기존 안전 실패
+#   처리 패턴과 동일 원칙). 구현: Get-GissueFdeIsnStatusMap/Remove-GissueOrphanWorktrees 함수(위
+#   Get-GissueBusyRepo 직후에 정의), lib/get-isn-status.js(신규 파일).
 # 매핑: csn-projects.json (CSN → 처리 프로젝트 폴더). 규칙 상세는 README.md.
 param(
     [switch]$DryRun,          # claude 미기동, 무엇을 실행할지 로그만
@@ -542,6 +565,119 @@ function Get-GissueBusyRepo($workdir, $restBranch = '') {
     return $null
 }
 
+# ── Orphan 워크트리 자가정리(giip #1547, lowyworkenv giip #1544 이식) ── 배경/근거는 파일 상단
+# giip #1547 변경이력 참고. isn 목록의 상태를 giipfaw API(GET {ApiBase}/giipIssues?isn=)로 배치
+# 조회한다(이 레포엔 DB 직접 접근이 없다 — get-issue.sh/lib/check-csn.js 와 동일 인증 경로 재사용).
+# csn 인자는 sk 선택(계정 매칭)에만 쓰인다 — sysadmin sk 는 csn 과 무관하게 모든 isn 을 조회할 수
+# 있으므로(get-issue.sh 상단 주석 참고), 워크트리 디렉토리명에 박힌 isn 이 이 CSN 소속이 아니어도
+# (예: 다른 CSN 이슈) 정확한 상태를 돌려받는다. 반환: isn(string) -> status(string) 해시테이블.
+# 조회 결과에 없는 isn 은 채워 넣지 않는다(호출측이 "이슈 없음"으로 해석).
+function Get-GissueFdeIsnStatusMap($root, $sk, $isnList) {
+    $result = @{}
+    $isnList = @($isnList | Where-Object { $_ -match '^\d+$' } | Select-Object -Unique)
+    if (-not $isnList -or -not $sk) { return $result }
+    try {
+        $isnCsv = ($isnList -join ',')
+        $rows = & node (Join-Path $root 'lib\get-isn-status.js') $ApiBase $sk $isnCsv 2>&1
+        foreach ($ln in @($rows)) {
+            $t = "$ln".Trim()
+            if (-not $t -or $t -notmatch '^\d+\|') { continue }
+            $parts = $t -split '\|', 2
+            if ($parts.Count -eq 2) { $result[$parts[0]] = $parts[1].Trim() }
+        }
+    } catch {}
+    return $result
+}
+
+# {PROJECT}(=$workdir) 및 그 안의 nested git 레포 각각의 `.worktrees/` 아래, git worktree 로 등록되지
+# 않은(=orphan plain) 디렉토리 중 완료(DONE)/존재하지 않는 이슈의 것만, 24시간 이상 경과한 경우에 한해
+# robocopy 빈 폴더 `/MIR` 미러 트릭으로 삭제한다. READY/PENDING/IN_PROGRESS/REVIEW/TESTED 는 대상에서
+# 완전히 제외한다(사람이 지금 그 워크트리에서 작업 중일 수 있음). 실패해도(API 조회 실패, robocopy 실패
+# 등) 이 함수 자체가 예외를 삼켜 경고 로그만 남기고 호출부(CSN 처리 루프)를 절대 막지 않는다.
+function Remove-GissueOrphanWorktrees($csn, $workdir) {
+    try {
+        $repoPaths = @(@($workdir) + (Get-GissueGitRepoPaths $workdir) | Select-Object -Unique)
+        $wtreeRoots = @()
+        foreach ($rp in $repoPaths) {
+            $cand = Join-Path $rp '.worktrees'
+            if (Test-Path -LiteralPath $cand) { $wtreeRoots += $cand }
+        }
+        $wtreeRoots = @($wtreeRoots | Select-Object -Unique)
+        if (-not $wtreeRoots) { return }  # .worktrees 자체가 없으면 조용히 스킵(로그 스팸 금지)
+
+        # 정식 등록된 git worktree 경로 수집(이 프로젝트 안의 모든 nested git 레포 대상) — 이건 절대 건드리지 않는다.
+        $registeredPaths = @()
+        foreach ($repo in ($repoPaths | Where-Object { Test-Path -LiteralPath (Join-Path $_ '.git') })) {
+            try {
+                $wtOut = git -C $repo worktree list --porcelain 2>$null
+                foreach ($line in @($wtOut)) {
+                    if ("$line" -match '^worktree\s+(.+)$') {
+                        $p = $Matches[1].Trim()
+                        $rp2 = try { (Resolve-Path -LiteralPath $p -ErrorAction Stop).Path } catch { $p }
+                        $registeredPaths += $rp2
+                    }
+                }
+            } catch {}
+        }
+        $registeredPaths = @($registeredPaths | Select-Object -Unique)
+
+        $candidates = @()
+        foreach ($wroot in $wtreeRoots) {
+            foreach ($item in (Get-ChildItem -LiteralPath $wroot -Directory -ErrorAction SilentlyContinue)) {
+                # isn/giip/issue 세 접두어 뒤 숫자를 이슈번호로 인식(예: giipv3-isn1467-x, giipdb-isn1468-y,
+                # giip917-styleguide, hub-issue1008-actionflow). 매칭 안 되는 이름은 절대 건드리지 않고 스킵.
+                $m = [regex]::Match($item.Name, '(?:isn|giip|issue)-?(\d+)', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+                if (-not $m.Success) { continue }
+                $fullPath = try { (Resolve-Path -LiteralPath $item.FullName -ErrorAction Stop).Path } catch { $item.FullName }
+                if ($registeredPaths -contains $fullPath) { continue }  # 정식 git worktree — orphan 아님, 제외
+                $candidates += [pscustomobject]@{ Path = $item.FullName; Isn = $m.Groups[1].Value; AgeHr = ((Get-Date) - $item.LastWriteTime).TotalHours }
+            }
+        }
+        if (-not $candidates) { return }
+
+        $sk = Get-GissueCsnSk $csn
+        if (-not $sk) {
+            Write-Log $csn "[ORPHAN-CLEANUP] SKIP: csn=$csn 의 sk 를 찾지 못함(giip-accounts.json) — isn 상태 조회 불가, 이번엔 건너뜀"
+            return
+        }
+        $statusMap = Get-GissueFdeIsnStatusMap $Root $sk ($candidates.Isn)
+
+        foreach ($c in $candidates) {
+            $status = $statusMap[$c.Isn]
+            $isDoneOrMissing = (-not $status) -or ($status -eq 'DONE')
+            if (-not $isDoneOrMissing) { continue }  # READY/PENDING/IN_PROGRESS/REVIEW/TESTED 등은 절대 건드리지 않음
+            $reasonNote = if ($status) { "$status 확인" } else { "이슈 없음(조회 결과 없음)" }
+            if ($c.AgeHr -lt 24) {
+                # [giip #1547 검증 중 실측] `$reasonNote이나`처럼 한글이 변수명 뒤에 바로 붙으면 PowerShell 이
+                # 한글도 포함한 하나의 변수명(예: `$reasonNote이나`, 미정의)으로 파싱해 조용히 빈 문자열이 되는
+                # 버그가 실행 확인됨(lowyworkenv 원본 giip #1544 코드에도 동일 패턴 존재) — `${reasonNote}`로 감싸 회피.
+                Write-Log $csn "[ORPHAN-CLEANUP] isn$($c.Isn) ${reasonNote}이나 최근 수정($([Math]::Round($c.AgeHr,1))h 전, 24h 미만) — 안전마진으로 이번엔 보류: $($c.Path)"
+                continue
+            }
+            if ($DryRun) {
+                Write-Log $csn "[ORPHAN-CLEANUP][DRY-RUN] isn$($c.Isn) $reasonNote, $([Math]::Round($c.AgeHr,1))h 경과 — 삭제 예정: $($c.Path)"
+                continue
+            }
+            try {
+                $emptyDir = Join-Path $env:TEMP ("gissue_orphanwt_empty_{0}" -f ([guid]::NewGuid().ToString('N')))
+                New-Item -ItemType Directory -Path $emptyDir -Force | Out-Null
+                try {
+                    robocopy $emptyDir $c.Path /MIR /NFL /NDL /NJH /NJS /NC /NS /NP | Out-Null
+                    if ($LASTEXITCODE -ge 8) { throw "robocopy exit $LASTEXITCODE" }
+                    Remove-Item -LiteralPath $c.Path -Recurse -Force -ErrorAction Stop
+                    Write-Log $csn "[ORPHAN-CLEANUP] isn$($c.Isn) $reasonNote, .worktrees/$(Split-Path -Leaf $c.Path) 삭제"
+                } finally {
+                    Remove-Item -LiteralPath $emptyDir -Recurse -Force -ErrorAction SilentlyContinue
+                }
+            } catch {
+                Write-Log $csn "[ORPHAN-CLEANUP] WARN: $($c.Path) 삭제 실패 — $($_.Exception.Message)"
+            }
+        }
+    } catch {
+        Write-Log $csn "[ORPHAN-CLEANUP] WARN: orphan worktree 정리 중 예외 — $($_.Exception.Message)"
+    }
+}
+
 # ── Phase -1: 열린 PR 자동머지(merge-standing-prs) ──
 # 이 :07 실행의 가장 첫 동작으로, 아래 merge-standing-prs.ps1이 정의한 고정 7개 레포
 # (giipprj/giipv3, giipprj/giipdb, giipprj/giipfaw, lowyworkenv, giipprj, uamath,
@@ -693,6 +829,11 @@ foreach ($csn in $map.PSObject.Properties.Name) {
     $lock    = Join-Path $LogDir "gissue_csn$csn.lock"
 
     if (-not (Test-Path $workdir)) { Write-Log $csn "SKIP: workdir 없음 ($workdir)"; continue }
+
+    # orphan 워크트리 자가정리(giip #1547) — busy-wait/AUTO-UNBLOCK 로직보다 먼저, CSN마다 매번 수행
+    # (lowyworkenv giip #1544 와 동일 원칙 — 잔해가 stash -u 를 깨뜨리기 전에 먼저 치운다).
+    # DryRun 이든 아니든 항상 호출한다(읽기+판단은 항상 하고, 실제 삭제 여부만 함수 내부에서 $DryRun 으로 분기).
+    Remove-GissueOrphanWorktrees $csn $workdir
 
     # 다른 프로세스(slack-bot 등)가 이 workdir/nested repo 를 지금 쓰는 중인지(base 브랜치 아님) 확인 — 정보성.
     # 실제 대기(폴링)는 더 이상 여기서 포기하지 않고 잡 내부(아래 스크립트블록)에서 수행한다.


### PR DESCRIPTION
## Summary
- giip #1540/#1544 인시던트(lowyworkenv 러너에서 완료 이슈의 `.worktrees/` 잔해가 Windows git "Filename too long"을 유발해 auto-unblock stash -u가 20,236회 반복 실패, CSN47 큐 전체 마비)의 재발 방지 로직을 이 원본 레포(giip-fde-agent)에도 이식.
- 이 레포는 DB 직접 접근이 없어(giipfaw API만 사용) `scripts/gissue/lib/get-isn-status.js`를 신설, 기존 `lib/check-csn.js`와 동일한 API 패턴으로 isn 상태를 배치 조회.
- `docs/60-operations/hourly-issue-scheduler.md`에 등록 스크립트 상세/등록 확인법/orphan 정리 배경, 그리고 오늘 lowyworkenv에서 실제로 겪은 "PR 머지 ≠ 스케줄러 반영(로컬 git pull 필수)" 운영 함정을 신규 문서화.

## Test plan
- [x] `[System.Management.Automation.Language.Parser]::ParseFile`로 `run-gissue-claude.ps1` 문법 검증 통과
- [x] `node --check scripts/gissue/lib/get-isn-status.js` 통과
- [x] 실제 giipfaw API로 `get-isn-status.js` 라이브 호출 확인 (isn 1547→IN_PROGRESS, isn 1544→REVIEW, 존재하지 않는 isn→미검출)
- [x] 임시 `csn-projects.json`(커밋 안 함)으로 `-DryRun -OnlyCsn 47` 실행해 orphan 후보 탐지→sk 조회→API 상태조회 전 구간 라이브 확인
- [x] 별도 스크래치 하네스로 non-DryRun 실제 삭제 경로(robocopy `/MIR` 빈 폴더 트릭, 중첩 서브디렉터리 포함)까지 실행해 대상 삭제 확인

giip issue: #1547

🤖 Generated with [Claude Code](https://claude.com/claude-code)