### PR TITLE
fix(gissue): get-isn-status.js 오류 시 exit 1로 변경 — 조희 실패 시 orphan worktree 삭제 방지 (giip #1547 FINAL-REVIEW)

### DIFF
--- a/scripts/gissue/lib/get-isn-status.js
+++ b/scripts/gissue/lib/get-isn-status.js
@@ -11,10 +11,11 @@
  * 실용적으로 충분하다).
  *
  * 사용: node get-isn-status.js <apiBase> <sk> <isn1,isn2,...>
- * stdout: 조회에 성공한 isn 만 "isn|status" 한 줄씩(순서 무관). 조회 실패/파싱 실패 isn 은 아무
- * 것도 출력하지 않는다(호출측이 "이슈 없음"으로 해석 — lowyworkenv 의 Get-GissueIsnStatusMap 과
- * 동일 컨벤션).
- * 종료코드: 항상 0(가용성 우선 — 개별 isn 조회 실패가 나머지 조회를 막지 않는다).
+ * stdout: 조회에 성공한 isn 만 "isn|status" 한 줄씩(순서 무관). 조회 실패/파싱 실패 isn 은
+ * stderr 로 "ERROR: <isn>: <원인>" 출력 후 전체를 실패로 처리한다.
+ * 종료코드: 모든 isn 조회 성공 시 0, 조회 실패(네트워크 오류/시간초과/파싱실패)가 1건이라도 있으면 1.
+ *   호출측 PowerShell(Get-GissueFdeIsnStatusMap)은 이 종료코드를 확인해, 실패 시 전체 정리를
+ *   중단한다(단순 "이슈 없음"으로 오해해 활성 이슈 worktree를 삭제하는 것을 방지 — giip #1547 FINAL-REVIEW).
  */
 const https = require('https');
 const { URL } = require('url');
@@ -22,7 +23,7 @@ const { URL } = require('url');
 const [, , apiBase, sk, isnCsv] = process.argv;
 if (!apiBase || !sk || !isnCsv) {
   console.error('사용법: node get-isn-status.js <apiBase> <sk> <isn1,isn2,...>');
-  process.exit(0);
+  process.exit(1);
 }
 
 const isnList = [...new Set(
@@ -40,26 +41,39 @@ function fetchStatus(isn) {
           const j = JSON.parse(data);
           const issue = j.issue || j;
           if (issue && issue.status) {
-            resolve(`${isn}|${issue.status}`);
+            resolve({ ok: true, line: `${isn}|${issue.status}` });
             return;
           }
         } catch (e) {
-          // 파싱 실패 — 아래 resolve(null)로 "이슈 없음/조회 불가"와 동일하게 처리
+          // 파싱 실패 — 실패로 처리
         }
-        resolve(null);
+        console.error(`ERROR: ${isn}: parse_error`);  // giip #1547 FINAL-REVIEW
+        resolve({ ok: false, isn });
       });
     });
-    req.on('error', () => resolve(null));
-    req.setTimeout(30000, () => { req.destroy(); resolve(null); });
+    req.on('error', (err) => {
+      console.error(`ERROR: ${isn}: ${err.message}`);  // giip #1547 FINAL-REVIEW
+      resolve({ ok: false, isn });
+    });
+    req.setTimeout(30000, () => {
+      req.destroy();
+      console.error(`ERROR: ${isn}: timeout`);  // giip #1547 FINAL-REVIEW
+      resolve({ ok: false, isn });
+    });
   });
 }
 
 (async () => {
+  let hasFailure = false;
   for (const isn of isnList) {
     // 배치 엔드포인트가 없어 순차 처리 — 후보 수가 많아지면 병렬화 고려(현재는 불필요).
     // eslint-disable-next-line no-await-in-loop
-    const line = await fetchStatus(isn);
-    if (line) console.log(line);
+    const result = await fetchStatus(isn);
+    if (result.ok) {
+      console.log(result.line);
+    } else {
+      hasFailure = true;  // 조회 실패가 1건이라도 있으면 exit 1 (giip #1547 FINAL-REVIEW)
+    }
   }
-  process.exit(0);
+  process.exit(hasFailure ? 1 : 0);
 })();

--- a/scripts/gissue/run-gissue-claude.ps1
+++ b/scripts/gissue/run-gissue-claude.ps1
@@ -572,13 +572,20 @@ function Get-GissueBusyRepo($workdir, $restBranch = '') {
 # 있으므로(get-issue.sh 상단 주석 참고), 워크트리 디렉토리명에 박힌 isn 이 이 CSN 소속이 아니어도
 # (예: 다른 CSN 이슈) 정확한 상태를 돌려받는다. 반환: isn(string) -> status(string) 해시테이블.
 # 조회 결과에 없는 isn 은 채워 넣지 않는다(호출측이 "이슈 없음"으로 해석).
-function Get-GissueFdeIsnStatusMap($root, $sk, $isnList) {
+function Get-GissueFdeIsnStatusMap($root, $sk, $csn, $isnList) {
     $result = @{}
     $isnList = @($isnList | Where-Object { $_ -match '^\d+$' } | Select-Object -Unique)
     if (-not $isnList -or -not $sk) { return $result }
     try {
         $isnCsv = ($isnList -join ',')
         $rows = & node (Join-Path $root 'lib\get-isn-status.js') $ApiBase $sk $isnCsv 2>&1
+        # giip #1547 FINAL-REVIEW: get-isn-status.js 가 오류 시 exit 1을 반환하므로, LASTEXITCODE가
+        # 0이 아니면 조회 실패(네트워크/타임아웃/파싱 오류) — 활성 worktree를 "이슈 없음"으로 오해해
+        # 삭제하는 것을 방지하기 위해 빈 result를 반환(정리 단계 안전 중단).
+        if ($LASTEXITCODE -ne 0) {
+            Write-Log $csn "[ORPHAN-CLEANUP] SKIP: get-isn-status.js 조회 실패(exit=$LASTEXITCODE) — 활성 worktree 안전 보호"
+            return $result
+        }
         foreach ($ln in @($rows)) {
             $t = "$ln".Trim()
             if (-not $t -or $t -notmatch '^\d+\|') { continue }
@@ -640,7 +647,7 @@ function Remove-GissueOrphanWorktrees($csn, $workdir) {
             Write-Log $csn "[ORPHAN-CLEANUP] SKIP: csn=$csn 의 sk 를 찾지 못함(giip-accounts.json) — isn 상태 조회 불가, 이번엔 건너뜀"
             return
         }
-        $statusMap = Get-GissueFdeIsnStatusMap $Root $sk ($candidates.Isn)
+        $statusMap = Get-GissueFdeIsnStatusMap $Root $sk $csn ($candidates.Isn)
 
         foreach ($c in $candidates) {
             $status = $statusMap[$c.Isn]


### PR DESCRIPTION
## 요약

giip #1547 FINAL-REVIEW FAIL 대응: 가 HTTP 오류/시간초과/파싱실패 시 출력 없이 exit 0을 반환해, 호출側 PowerShell이 "이슈 없음"으로 오해하고 24시간 경과 활성 orphan worktree를 삭제대상으로 오인할 수 있던 데이터 손실 위험을 수정.

## 변경 내용

### lib/get-isn-status.js
- **오류 시 exit 1 + stderr에 ERROR 행 출력** (기존: exit 0, stdout 무출력)
- 가  또는  객체를 반환하도록 변경
- 모든 조회 성공 시만 exit 0

### run-gissue-claude.ps1 — Get-GissueFdeIsnStatusMap
-  시 경고 로그 + **빈 result 반환** (정리 단계 안전 중단)
-  파라미터 추가 (호출부 컨텍스트 일치)

## 검증

- [ ] JS 문법:  통과
- [ ] 4가지 실패 주입 테스트(인증실패/5xx/timeout/파싱실패) 각각 exit 1 확인
- [ ] DONE/isn없음/활성READ 등 정상 케이스에서 exit 0 및 올바른 status line 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)