### PR TITLE
fix(slack-bot): giip 연동 태스크 pending 재구성 isn 누락 수정 (giip #2039 이식)

### DIFF
--- a/slack-bot-minimax/handlers.js
+++ b/slack-bot-minimax/handlers.js
@@ -1113,7 +1113,9 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
         const titleMatch = fc.match(/^# TASK:\s*(.+)$/m);
         const taskTitle = titleMatch ? titleMatch[1].trim() : `タスク ${targetId}`;
         const pendingKeyNew = `${channelId}:${replyTs}`;
-        taskState.pending[pendingKeyNew] = { taskId: targetId, taskTitle, taskFile: taskFileFallback, requestText: '', workDir };
+        const isnMatch = /^giip-(\d+)$/.exec(targetId);
+        const isn = isnMatch ? parseInt(isnMatch[1], 10) : undefined;
+        taskState.pending[pendingKeyNew] = { taskId: targetId, taskTitle, taskFile: taskFileFallback, requestText: '', workDir, isn };
         saveJSON(TASK_STATE_FILE, taskState);
         if (extraNote && tm.appendTaskNote(targetId, extraNote)) {
           await postMessage(channelId, `📎 追加指示 (${extraNote.length}字) を Task \`${targetId}\` に反映しました。`, replyTs);

--- a/slack-bot/handlers.js
+++ b/slack-bot/handlers.js
@@ -1237,7 +1237,9 @@ async function handleChannelMention({ channelId, ts, threadTs, text, workDir = B
         const titleMatch = fc.match(/^# TASK:\s*(.+)$/m);
         const taskTitle = titleMatch ? titleMatch[1].trim() : `タスク ${targetId}`;
         const pendingKeyNew = `${channelId}:${replyTs}`;
-        taskState.pending[pendingKeyNew] = { taskId: targetId, taskTitle, taskFile: taskFileFallback, requestText: '', workDir };
+        const isnMatch = /^giip-(\d+)$/.exec(targetId);
+        const isn = isnMatch ? parseInt(isnMatch[1], 10) : undefined;
+        taskState.pending[pendingKeyNew] = { taskId: targetId, taskTitle, taskFile: taskFileFallback, requestText: '', workDir, isn };
         saveJSON(TASK_STATE_FILE, taskState);
         if (extraNote && tm.appendTaskNote(targetId, extraNote)) {
           await postMessage(channelId, `📎 追加指示 (${extraNote.length}字) を Task \`${targetId}\` に反映しました。`, replyTs);


### PR DESCRIPTION
## 배경 (lowyworkenv giip #2039 이식)
`go giip-<번호>` Slack 명령 처리 중 `taskState.pending` 에 항목이 없고 로컬 `.agent/tasks/<번호>.md` 파일만 있을 때, 그 파일 기준으로 pending 객체를 재구성하는 fallback 분기가 있다.

## 원인
재구성 시 `isn` 필드를 설정하지 않아, 이후 자가치유(DB 복원) 로직(`if (pendingTask.isn && (!pendingTask.taskFile || !fs.existsSync(pendingTask.taskFile)))`)이 `pendingTask.isn` 이 있어야만 동작하는데 `isn` 이 없어 조건이 성립하지 않는다. 그 결과 로컬 태스크 파일이 사라졌을 때 DB 복원을 시도하지 않고 "태스크 파일을 찾을 수 없습니다: <taskId>" 하드 에러가 그대로 Slack 사용자에게 노출된다.

`targetId` 는 이미 `giip-2022` 같은 형식이므로 `/^giip-(\d+)$/` 정규식으로 `isn` 을 바로 추출 가능한데 그걸 안 하는 게 버그의 전부였다.

## 수정 내용
- `slack-bot/handlers.js` (`handleChannelMention` 내 `go <Task番号>` fallback 분기): pending 객체 재구성 시 `targetId` 에서 `isn` 을 파싱해 필드에 포함.
- `slack-bot-minimax/handlers.js`: 동일 패턴 동일 수정.

수정 범위는 isn 누락 보정만이며, 자가치유 알림 메시지 톤이나 DB-우선 재구성 등 다른 설계 변경은 포함하지 않음.

## 검증
- `node -c slack-bot/handlers.js` — 통과
- `node -c slack-bot-minimax/handlers.js` — 통과