### PR TITLE
feat(skills): add ast-grep and init-deep-context skills (from oh-my-openagent review)

### DIFF
--- a/.agent/skills/ast-grep/SKILL.md
+++ b/.agent/skills/ast-grep/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: ast-grep
+description: |
+  Structural, AST-pattern-aware code search and rewrite across 25+ languages using the
+  standalone `ast-grep` (`sg`) CLI. Use instead of plain grep/ripgrep whenever the task needs
+  to match code by its *shape* rather than its text — e.g. "find every call to `foo()` whose
+  second argument is an object literal", "find all React components missing a `key` prop",
+  "rewrite every `.then(x => x.y)` into `.then(({ y }) => y)` across the repo" — comments,
+  string contents, and formatting/whitespace differences are ignored automatically.
+
+  Use proactively when the user asks for a structural refactor, a codebase-wide rename of a
+  call pattern, or a precise "find all usages that match this shape" query that plain text
+  search would over- or under-match.
+
+  Triggers: ast-grep, sg, structural search, structural rewrite, AST pattern, pattern-based
+  refactor, codemod, find all calls to, rewrite all instances of,
+  구조 검색, 구조적 리팩터링, 패턴 기반 리팩터링, AST 패턴, 코드모드,
+  構造検索, パターンベースのリファクタリング, コードモッド,
+  结构化搜索, 结构化重构, 代码模式改写
+
+  Do NOT use for: single-file small edits (use Edit directly), plain text/non-code search (use
+  Grep/jikji), or renaming a single known symbol (a normal find-and-replace is faster and the
+  AST pattern engine adds no value there).
+argument-hint: "[pattern] [lang] [--rewrite <replacement>]"
+user-invocable: true
+allowed-tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+pdca-phase: do
+task-template: "[ast-grep] {pattern}"
+---
+
+# ast-grep — Structural Code Search & Rewrite
+
+> pattern matches code *structure* (AST), not raw text — comments, string literals, and
+> whitespace differences don't cause false matches or misses the way grep/ripgrep can.
+
+## When to Use This Instead of grep/ripgrep
+
+| Need | Tool |
+|------|------|
+| "find the text `TODO`" | `Grep` / ripgrep |
+| "find every call to `apiClient.get(...)` whose first arg is a string literal" | `ast-grep` |
+| "find every React component that renders a `<Modal>` without an `onClose` prop" | `ast-grep` |
+| "rewrite every `foo.bar(a, b)` to `foo.bar({ a, b })` across the repo" | `ast-grep` (rewrite mode) |
+| local file/folder discovery by natural-language clue | `jikji` (see `.agent/skills/jikji/SKILL.md`) |
+
+Plain text search can't express "the second argument to this call is an object literal" or
+"this JSX element is missing a specific prop" — it only knows about characters. `ast-grep`
+parses the file into its real syntax tree per language and matches on that tree, so a pattern
+like `$OBJ.map($FN)` matches every method call shaped that way regardless of variable names,
+formatting, or surrounding comments.
+
+## Install Check
+
+`ast-grep` is a standalone binary (Rust), not tied to any Node/plugin runtime. Check first:
+
+```bash
+sg --version
+```
+
+If missing, install with whichever package manager is already available on this machine — no
+need to guess, check what's on PATH first (`env-check` skill), then pick one:
+
+```bash
+npm i -g @ast-grep/cli      # Node/npm environments (this PC has Node — use this by default)
+# or
+pip install ast-grep-cli    # Python environments
+# or
+cargo install ast-grep --locked   # if Rust toolchain is available
+```
+
+Reference: https://ast-grep.github.io/
+
+## Usage
+
+### 1. Search — print every match
+
+```bash
+sg -p '$OBJ.map($FN)' -l ts
+```
+
+- `$FOO` (uppercase) is a single-node metavariable — matches any one expression/identifier.
+- `$$$FOO` matches zero or more nodes (e.g. a variable-length argument list).
+- `-l` (or `--lang`) picks the parser: `ts`, `tsx`, `js`, `jsx`, `python`, `go`, `rust`, `java`,
+  `csharp`, `html`, `css`, and 15+ more — run `sg --help` for the full list.
+- Omit `-l` and pass a path with `sg -p '...' path/` to let it infer language per file
+  extension across a whole tree.
+
+### 2. Search scoped to a directory
+
+```bash
+sg -p 'console.log($$$ARGS)' -l ts src/
+```
+
+### 3. Search with a YAML rule (for multi-condition patterns)
+
+For patterns needing constraints beyond a single expression (e.g. "match `$FN` only when it's
+NOT already wrapped"), write a rule file — see `sg new` / `ast-grep --help scan` for the rule
+schema. For the common case, an inline `-p` pattern is enough; reach for a rule file only when
+`-p` genuinely can't express the constraint.
+
+### 4. Rewrite — ALWAYS dry-run/preview before writing
+
+Matching this repo's general caution-before-destructive-action posture (see
+`.agent/skills/gstack-safety/SKILL.md`): a rewrite touches multiple files in one shot, so treat
+it like any other bulk file-modifying operation — preview first, then apply deliberately.
+
+```bash
+# Step 1 — preview only, writes nothing (no -i, no --update-all)
+sg -p '$OBJ.then($FN => $FN.$PROP)' -r '$OBJ.then(({ $PROP }) => $PROP)' -l ts
+
+# Step 2a — apply interactively, confirm each hunk one at a time
+sg -p '$OBJ.then($FN => $FN.$PROP)' -r '$OBJ.then(({ $PROP }) => $PROP)' -l ts --interactive
+
+# Step 2b — apply everywhere at once (only after the dry-run preview in Step 1 looked correct
+# across ALL matches, not just the first few)
+sg -p '$OBJ.then($FN => $FN.$PROP)' -r '$OBJ.then(({ $PROP }) => $PROP)' -l ts --update-all
+```
+
+Never jump straight to `--update-all` — always run the plain `-p ... -r ...` preview (no write
+flag) first and read through the diff it prints, the same way any other multi-file
+find-and-replace in this repo gets a dry run before it's allowed to touch disk.
+
+## When NOT to Use ast-grep
+
+- **Single small edit in one known file** — use `Edit` directly, it's faster and the AST engine
+  adds no value for a one-off change you can already point at.
+- **Plain text / non-code content** — Markdown prose, config values, log lines: use `Grep` or
+  `jikji`, not `ast-grep` (its parsers are for programming-language syntax, not free text).
+- **Renaming one already-known symbol everywhere** — a straightforward project-wide rename is
+  usually better served by the editor's / language server's rename-symbol facility (if
+  available) or a simple text find-and-replace; reach for `ast-grep` when the *shape* of the
+  match matters, not just the name.

--- a/.agent/skills/init-deep-context/SKILL.md
+++ b/.agent/skills/init-deep-context/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: init-deep-context
+description: |
+  Guides generating hierarchical, subsystem-scoped AGENTS.md/CLAUDE.md files for a large
+  multi-subsystem repository, instead of one giant root file every agent invocation has to
+  read in full. Walks the project tree, identifies real subsystem boundaries, drafts a
+  focused instruction file at each boundary containing only that subtree's local conventions,
+  and leaves the root file as a high-level index that points to them.
+
+  Use proactively when a repository has grown multiple distinct subsystems/packages/apps
+  (each with its own conventions, stack, or gotchas) and the root AGENTS.md/CLAUDE.md has
+  become a long grab-bag mixing all of them together, or when the user explicitly asks to
+  split/restructure/deepen the project's agent instructions.
+
+  Triggers: init deep, deep init, hierarchical AGENTS.md, split CLAUDE.md, subsystem context,
+  nested AGENTS.md, per-package instructions, context locality,
+  계층형 AGENTS.md, 서브시스템 컨텍스트 분리, 하위 폴더 지침 파일,
+  階層AGENTS.md, サブシステム別コンテキスト,
+  分层AGENTS.md, 子系统上下文拆分
+
+  Do NOT use for: a small or single-purpose repo where the root file is short and already
+  covers everything (splitting it adds maintenance overhead with no locality benefit) — see
+  "When NOT to Use" below before starting.
+argument-hint: "[optional: subtree to scope the pass to]"
+user-invocable: true
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+  - Write
+  - Edit
+pdca-phase: plan
+task-template: "[init-deep-context] {scope}"
+---
+
+# init-deep-context — Hierarchical AGENTS.md Generator
+
+> This is a guided procedure for an agent invocation to walk through, not a script that runs
+> unattended — every judgment call below (which boundaries are real, what's worth its own
+> file) needs the model's read of the actual codebase, the same way every other prompt-guidance
+> skill in this repo works.
+
+## Purpose
+
+A single root `AGENTS.md`/`CLAUDE.md` that tries to cover an entire large repository — several
+subsystems, packages, or apps in one tree — forces every agent invocation to read context that
+is irrelevant to the specific subtree it's actually working in. Splitting subsystem-specific
+conventions into their own `AGENTS.md` files at meaningful directory boundaries means an agent
+working in `src/payments/` only loads `src/payments/AGENTS.md` plus the root index, not the
+full detail of `src/notifications/` or `src/admin/` as well. The root file shrinks to a
+high-level pointer/index, matching the same "pointer, not duplicate content" philosophy this
+ecosystem already uses elsewhere (e.g. a git-tracked canonical file with thin pointers to it
+from other locations) — applied here along the directory axis instead.
+
+## When NOT to Use
+
+**Skip this skill entirely if the repo is small or single-purpose and the root file already
+covers it without strain.** The entire point is token efficiency and locality for large,
+multi-subsystem repos — fragmenting a small repo into many tiny `AGENTS.md` files adds
+maintenance overhead (more files to keep in sync, more places a convention can go stale) for no
+locality benefit, since a small repo's root file was cheap to read in full anyway. Before
+starting, check: does the root file mix together conventions from clearly distinct subsystems
+that don't apply to each other? If not, stop here and say so instead of proceeding.
+
+## Process
+
+### 1. Identify meaningful subsystem boundaries
+
+Look at the project's own structure to find natural boundaries — don't impose an arbitrary
+depth. Candidates, roughly in order of how likely they are to be real boundaries:
+
+- Top-level directories under `src/` (or the repo's equivalent) that are independently
+  deployable, independently owned, or built on a different stack (e.g. `apps/web/`,
+  `apps/api/`, `packages/shared-ui/`).
+- A directory whose `README.md`, existing comments, or file layout already signal it plays by
+  different rules than its siblings (different test framework, different naming convention,
+  different external dependency).
+- A directory the user names explicitly when invoking this skill (via the `[optional: subtree]`
+  argument).
+
+**A boundary needs enough distinct local convention or context to be worth its own file.** If a
+subdirectory's "local conventions" would just restate the root file, it's not a boundary —
+don't create a file for it. When in doubt, read the directory's actual code before deciding;
+don't guess a boundary exists from the directory name alone.
+
+### 2. For each boundary, draft a focused AGENTS.md
+
+For every real boundary found in step 1, write `<subtree>/AGENTS.md` (and a `CLAUDE.md` twin
+only if this repo's existing convention mirrors instruction files per engine — check whether
+the root already has both before deciding to duplicate at the subtree level too) covering ONLY
+that subtree's specifics:
+
+- The subtree's stack/framework, if different from the root (e.g. "this package uses Vitest,
+  not the Jest the rest of the repo uses").
+- Conventions genuinely local to this subtree (naming, folder layout, an internal API contract
+  other parts of the repo don't need to know about).
+- Gotchas specific to this subtree (a flaky test, a manual step CI doesn't cover, a legacy
+  pattern still in use here only).
+
+Do **not** repeat anything already covered by the root file (build commands, repo-wide commit
+conventions, global safety rules) — an agent reading the subtree file will have already read
+the root file first; restating shared content just adds drift risk between the two copies.
+
+### 3. Leave the root file as a high-level index
+
+Update the root `AGENTS.md`/`CLAUDE.md` (or add a short new section to it) to:
+
+- Keep everything that genuinely applies repo-wide (this does not move).
+- Add pointers to each new subtree file, e.g.:
+  ```markdown
+  ## Subsystem-specific context
+  - `apps/web/` conventions: see `apps/web/AGENTS.md`
+  - `apps/api/` conventions: see `apps/api/AGENTS.md`
+  - `packages/shared-ui/` conventions: see `packages/shared-ui/AGENTS.md`
+  ```
+- Not inline-duplicate the subtree files' content — the root file's job after this pass is
+  "what's true everywhere, plus where to look for what's true locally," nothing more.
+
+### 4. Verify no orphaned or contradicting content
+
+Before finishing:
+
+- Re-read the root file — confirm nothing left behind still describes a subsystem in detail
+  that now has its own file (that content should have moved, not been copied).
+- Confirm no subtree file contradicts the root file (e.g. root says "always use npm", a subtree
+  file silently assumes yarn without saying it's an intentional local exception — call out the
+  exception explicitly if it's real, don't leave it implicit).
+- Report back which boundaries were created, which candidate boundaries were considered and
+  rejected (and why), and what stayed in the root file.
+
+## Example Outcome
+
+```
+repo/
+├── AGENTS.md                 # repo-wide rules + index pointing to the two files below
+├── apps/
+│   ├── web/
+│   │   └── AGENTS.md         # Next.js conventions, this app's component structure only
+│   └── worker/
+│       └── AGENTS.md         # queue processing conventions, retry/backoff rules only
+└── packages/
+    └── shared-ui/            # (no AGENTS.md — conventions here are just "root rules apply",
+                               #  not a real boundary; don't create a file with nothing to say)
+```

--- a/docs/50-technical/ai-repositories-index.md
+++ b/docs/50-technical/ai-repositories-index.md
@@ -52,6 +52,10 @@ AI 에이전트 시스템과 연동하거나 활용할 수 있는 외부 유용�
 ### [jikji](https://github.com/NomaDamas/jikji) ([도구 소개](../../docs/04-tools/jikji.md))
 - **한줄 소개**: AI 에이전트가 로컬 파일을 탐색할 때 토큰 소비를 최대 86배 절약하는 비파괴적 파일 탐색 레이어로, `grep`/`find` 대신 먼저 사용합니다.
 
+### [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent)
+- **한줄 소개**: OpenCode/Codex CLI용 68k+ star TypeScript 플러그인 프레임워크로, 멀티 에이전트 디스패치·코드 리뷰 파이프라인·PDCA형 플래닝에 더해 Hashline(콘텐츠 해시 태깅 편집 도구)·Team Mode(tmux 시각화 + `team_*` 툴 패밀리)·LSP MCP 서버 연동 같은 자체 런타임 엔지니어링 기능을 제공합니다.
+- **적용 상태**: 멀티 에이전트 디스패치/코드 리뷰/PDCA 계열은 본 레포의 `dispatching-parallel-agents`, `code-review`, `receiving-code-review`/`requesting-code-review`, `pdca`, `systematic-debugging` 등 기존 스킬과 중복되어 미이식. Hashline/Team Mode/LSP MCP는 TypeScript 플러그인 런타임에 종속되어 있어 이 레포의 instruction-file 아키텍처로는 새 엔지니어링 인프라 구축 없이는 이식 불가 — 범위 제외. 독립 실행형이라 이식 가능한 두 가지만 신규 Skill로 이식: 내장 `ast-grep` 스킬 → `.agent/skills/ast-grep/` (구조적 코드 검색·리라이트), `/init-deep` 명령 → `.agent/skills/init-deep-context/` (계층형 AGENTS.md 생성 가이드)
+
 ## 🎨 디자인 및 문서화 도구
 
 ### [Open Design](https://github.com/nexu-io/open-design) ([소개 페이지](../../docs/50-technical/open-design-intro.md))
@@ -88,3 +92,4 @@ AI 에이전트 시스템과 연동하거나 활용할 수 있는 외부 유용�
 *작업 이력: 20260624: jikji 추가 (PR #24), moa 분석 리포트 링크 보완 (PR #26)*
 *작업 이력: 20260706: paperthin 추가 및 스킬 14종 `.agent/skills/` 이식*
 *작업 이력: 20260706: keep-codex-fast 유지관리 도구 섹션에 등록 (스킬은 기존 이식 완료)*
+*작업 이력: 20260910: oh-my-openagent 추가, 이식 가능한 항목 검토 후 `ast-grep`/`init-deep-context` 스킬 2종 신규 이식 (giip-fde-agent PR)*


### PR DESCRIPTION
## Summary
- Reviewed github.com/code-yeongyu/oh-my-openagent (68k-star TypeScript plugin framework for OpenCode/Codex CLI) for ideas portable into this repo's instruction-file/`.agent/` architecture.
- Most of its concepts (multi-agent dispatch, code review pipelines, PDCA-style planning) are already covered by existing skills here (`dispatching-parallel-agents`, `code-review`, `receiving-code-review`/`requesting-code-review`, `pdca`, `systematic-debugging`) — not duplicated.
- Its deeper engineering features (Hashline content-hash-tagged edit tool, Team Mode's tmux visualization + `team_*` tool family, LSP MCP server integration) are tied to its TypeScript plugin runtime and out of scope — building that infra here isn't reasonable, so they were not attempted.
- Two genuinely novel, safely-portable gaps were adopted as new skills:
  - `.agent/skills/ast-grep/SKILL.md` — structural/AST-pattern code search & rewrite via the standalone `sg` CLI (a real independent binary, not tied to any plugin runtime). Modeled on `.agent/skills/jikji/SKILL.md` (external-tool skill format: install check, usage examples) with the dry-run-before-write caution phrasing matching `.agent/skills/gstack-safety/SKILL.md`'s tone.
  - `.agent/skills/init-deep-context/SKILL.md` — guided procedure (prompt-guidance only, no bundled script) for generating hierarchical, subsystem-scoped `AGENTS.md` files in large multi-subsystem repos while keeping the root file as a high-level index/pointer. Modeled on `.agent/skills/dispatching-parallel-agents/SKILL.md` and `.agent/skills/systematic-debugging/SKILL.md`'s plain `name`+`description` frontmatter format.
- Added an `oh-my-openagent` entry to `docs/50-technical/ai-repositories-index.md` documenting what was/wasn't adopted and why, matching the existing entries' format (`한줄 소개` + `적용 상태`).

## Test plan
- [x] Both new `SKILL.md` files follow this repo's existing conventions (verified against `jikji`, `dispatching-parallel-agents`, `systematic-debugging`, `gstack-safety`, `env-check`).
- [x] `docs/50-technical/ai-repositories-index.md` entry matches existing entries' format exactly.
- [ ] No CI configured for markdown-only skill additions in this repo (additive-only, no code paths touched) — flag if CI appears and fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Acy2sG7HERMzApPazuompx