### PR TITLE
feat(hooks): add Windows hook doctor

### DIFF
--- a/.agent/hooks/hooks.json
+++ b/.agent/hooks/hooks.json
@@ -8,6 +8,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/windows-hook-doctor.js --repair --quiet",
+            "timeout": 5000
+          },
+          {
+            "type": "command",
             "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start.js",
             "timeout": 5000
           }

--- a/.agent/knowledge/notes/claude-code-hooks.md
+++ b/.agent/knowledge/notes/claude-code-hooks.md
@@ -77,3 +77,12 @@ CLAIM-036: PowerShell variables (`$r`, `$x`, etc.) inside `.claude/settings.json
   ```
   "if (Test-Path (Join-Path (git rev-parse --show-toplevel) '.agent/hooks/post-task.js')) { Set-Location (git rev-parse --show-toplevel) } ..."
   ```
+
+CLAIM-037: Windows hook repair must stay inside the FDE-owned agent root and verify after repair
+- **evidence**: `.agent/lib/windows-hook-doctor.js` resolves real paths, rejects root escapes, creates a backup only once under ignored runtime storage, normalizes only UTF-8 BOM/CRLF, and performs a second inspection after repair
+- **source**: `.agent/lib/windows-hook-doctor.js`, `.agent/tests/windows-hook-doctor.test.js`
+- **observed_at**: 20260910
+- **invalidated_at**: null
+- **confidence**: high
+- **rule**: Do not mutate external plugins or user settings from the FDE doctor. Missing `PreToolUse` targets and a non-functional Node runtime are blocking health states; availability-only hook gaps remain warnings.
+- **verification**: `node .agent/tests/windows-hook-doctor.test.js` and Windows CI workflow `.github/workflows/windows-hook-doctor.yml`

--- a/.agent/lib/windows-hook-doctor.js
+++ b/.agent/lib/windows-hook-doctor.js
@@ -1,0 +1,228 @@
+/**
+ * Windows Hook Doctor
+ *
+ * FDE가 소유한 .agent 훅만 진단한다. 외부 플러그인, 사용자 설정, 명령 내용은
+ * 수정하지 않으며 UTF-8 BOM/CRLF 정규화만 backup-once 방식으로 복구한다.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const MANIFEST_PATH = path.join('hooks', 'hooks.json');
+const CRITICAL_EVENTS = new Set(['PreToolUse']);
+const MAX_HEALTH_LOG_LINES = 50;
+
+function relativePortable(root, target) {
+  return path.relative(root, target).split(path.sep).join('/');
+}
+
+function isInside(root, target) {
+  const resolvedRoot = fs.existsSync(root) ? fs.realpathSync(root) : path.resolve(root);
+  const resolvedTarget = fs.existsSync(target) ? fs.realpathSync(target) : path.resolve(target);
+  const relative = path.relative(resolvedRoot, resolvedTarget);
+  return relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
+}
+
+function normalizeText(raw) {
+  return raw.replace(/^\uFEFF/, '').replace(/\r\n/g, '\n');
+}
+
+function commandTarget(command) {
+  if (typeof command !== 'string') return null;
+  const match = command.match(/\$\{CLAUDE_PLUGIN_ROOT\}[\\/]+([^\s"'`;&|]+)/);
+  return match ? match[1].replace(/[\\/]+/g, path.sep) : null;
+}
+
+function collectCommandHooks(manifest) {
+  const commands = [];
+  const eventMap = manifest && manifest.hooks;
+  if (!eventMap || typeof eventMap !== 'object') return commands;
+
+  for (const [event, groups] of Object.entries(eventMap)) {
+    if (!Array.isArray(groups)) continue;
+    for (const group of groups) {
+      if (!group || !Array.isArray(group.hooks)) continue;
+      for (const hook of group.hooks) {
+        if (hook && hook.type === 'command') {
+          commands.push({ event, command: hook.command });
+        }
+      }
+    }
+  }
+  return commands;
+}
+
+function defaultProbeNode() {
+  const result = spawnSync(process.execPath, ['-e', 'process.exit(0)'], {
+    windowsHide: true,
+    timeout: 3000,
+    stdio: 'ignore',
+  });
+  return !result.error && result.status === 0;
+}
+
+function issue(code, severity, event, target) {
+  const value = { code, severity };
+  if (event) value.event = event;
+  if (target) value.target = target;
+  return value;
+}
+
+function inspect(root, probeNode) {
+  const issues = [];
+  const manifestFile = path.join(root, MANIFEST_PATH);
+  let raw;
+
+  if (!isInside(root, manifestFile)) {
+    return { issues: [issue('manifest-outside-agent-root', 'critical')], commands: [] };
+  }
+
+  try {
+    raw = fs.readFileSync(manifestFile, 'utf8');
+  } catch (_error) {
+    return { issues: [issue('manifest-unreadable', 'critical')], commands: [] };
+  }
+
+  if (raw.startsWith('\uFEFF')) issues.push(issue('utf8-bom', 'repairable', null, MANIFEST_PATH));
+  if (raw.includes('\r\n')) issues.push(issue('crlf', 'repairable', null, MANIFEST_PATH));
+
+  let manifest;
+  try {
+    manifest = JSON.parse(raw.replace(/^\uFEFF/, ''));
+  } catch (_error) {
+    return { issues: [...issues, issue('manifest-invalid-json', 'critical')], commands: [] };
+  }
+
+  const commands = collectCommandHooks(manifest);
+  if (!probeNode()) issues.push(issue('node-unavailable', 'critical'));
+
+  for (const entry of commands) {
+    const relativeTarget = commandTarget(entry.command);
+    if (!relativeTarget) continue;
+    const target = path.resolve(root, relativeTarget);
+    const severity = CRITICAL_EVENTS.has(entry.event) ? 'critical' : 'warning';
+
+    if (!isInside(root, target)) {
+      issues.push(issue('outside-agent-root', severity, entry.event, relativeTarget.split(path.sep).join('/')));
+      continue;
+    }
+
+    if (!fs.existsSync(target)) {
+      issues.push(issue('missing-target', severity, entry.event, relativeTarget.split(path.sep).join('/')));
+      continue;
+    }
+
+    let targetRaw;
+    try {
+      targetRaw = fs.readFileSync(target, 'utf8');
+    } catch (_error) {
+      issues.push(issue('target-unreadable', severity, entry.event, relativeTarget.split(path.sep).join('/')));
+      continue;
+    }
+    if (targetRaw.startsWith('\uFEFF')) issues.push(issue('utf8-bom', 'repairable', entry.event, relativeTarget.split(path.sep).join('/')));
+    if (targetRaw.includes('\r\n')) issues.push(issue('crlf', 'repairable', entry.event, relativeTarget.split(path.sep).join('/')));
+  }
+
+  return { issues, commands };
+}
+
+function repairFile(root, target, changedFiles) {
+  if (!isInside(root, target) || !fs.existsSync(target)) return;
+  const raw = fs.readFileSync(target, 'utf8');
+  const normalized = normalizeText(raw);
+  if (normalized === raw) return;
+
+  const backup = path.join(root, 'runtime', 'hook-backups', `${relativePortable(root, target)}.bak`);
+  if (!fs.existsSync(backup)) {
+    fs.mkdirSync(path.dirname(backup), { recursive: true });
+    fs.copyFileSync(target, backup);
+  }
+  fs.writeFileSync(target, normalized, 'utf8');
+  changedFiles.push(relativePortable(root, target));
+}
+
+function repairOwnedFiles(root, commands) {
+  const changedFiles = [];
+  repairFile(root, path.join(root, MANIFEST_PATH), changedFiles);
+
+  const targets = new Set();
+  for (const entry of commands) {
+    const relativeTarget = commandTarget(entry.command);
+    if (!relativeTarget) continue;
+    const target = path.resolve(root, relativeTarget);
+    if (isInside(root, target)) targets.add(target);
+  }
+  for (const target of targets) repairFile(root, target, changedFiles);
+  return changedFiles;
+}
+
+function statusFor(issues) {
+  if (issues.some((entry) => entry.severity === 'critical')) return 'blocked';
+  if (issues.some((entry) => entry.severity === 'warning')) return 'warning';
+  if (issues.some((entry) => entry.severity === 'repairable')) return 'repairable';
+  return 'healthy';
+}
+
+function appendHealthLog(root, result) {
+  const runtimeDir = path.join(root, 'runtime');
+  const logFile = path.join(runtimeDir, 'windows-hook-health.jsonl');
+  fs.mkdirSync(runtimeDir, { recursive: true });
+
+  let previous = [];
+  if (fs.existsSync(logFile)) {
+    previous = fs.readFileSync(logFile, 'utf8').split('\n').filter(Boolean);
+  }
+  const record = JSON.stringify({
+    at: new Date().toISOString(),
+    status: result.status,
+    issueCodes: result.issues.map((entry) => entry.code),
+    changedFiles: result.changedFiles,
+  });
+  const lines = [...previous, record].slice(-MAX_HEALTH_LOG_LINES);
+  fs.writeFileSync(logFile, `${lines.join('\n')}\n`, 'utf8');
+}
+
+function run(options = {}) {
+  const root = path.resolve(options.root || path.join(__dirname, '..'));
+  const platform = options.platform || process.platform;
+  const changedFiles = [];
+
+  if (platform !== 'win32') {
+    return { status: 'skipped', issues: [], changedFiles, inspectedHooks: 0 };
+  }
+
+  const probeNode = options.probeNode || defaultProbeNode;
+  let inspection = inspect(root, probeNode);
+
+  const hasRepairableIssue = inspection.issues.some((entry) => entry.severity === 'repairable');
+  if (options.repair && hasRepairableIssue) {
+    changedFiles.push(...repairOwnedFiles(root, inspection.commands));
+    inspection = inspect(root, probeNode);
+  }
+
+  const result = {
+    status: statusFor(inspection.issues),
+    issues: inspection.issues,
+    changedFiles,
+    inspectedHooks: inspection.commands.length,
+  };
+
+  if (options.writeLog !== false) {
+    try {
+      appendHealthLog(root, result);
+    } catch (_error) {
+      // 진단 자체의 성공/실패를 부가 로그 오류로 가리지 않는다.
+    }
+  }
+  return result;
+}
+
+module.exports = {
+  collectCommandHooks,
+  commandTarget,
+  normalizeText,
+  run,
+};

--- a/.agent/scripts/windows-hook-doctor.js
+++ b/.agent/scripts/windows-hook-doctor.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const path = require('path');
+const { run } = require('../lib/windows-hook-doctor');
+
+function parseArgs(argv) {
+  const args = new Set(argv);
+  return {
+    repair: args.has('--repair'),
+    quiet: args.has('--quiet'),
+    json: args.has('--json'),
+  };
+}
+
+function summary(result) {
+  const codes = [...new Set(result.issues.map((issue) => issue.code))];
+  return [
+    `status=${result.status}`,
+    `hooks=${result.inspectedHooks}`,
+    `changed=${result.changedFiles.length}`,
+    `issues=${codes.length ? codes.join(',') : 'none'}`,
+  ].join(' ');
+}
+
+function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  const result = run({
+    root: path.join(__dirname, '..'),
+    repair: options.repair,
+  });
+
+  if (options.json) {
+    console.log(JSON.stringify(result));
+  } else if (!options.quiet || result.status === 'blocked') {
+    const output = `[giip hook doctor] ${summary(result)}`;
+    if (result.status === 'blocked') console.error(output);
+    else console.log(output);
+  }
+
+  return result.status === 'blocked' ? 2 : 0;
+}
+
+if (require.main === module) {
+  try {
+    process.exitCode = main();
+  } catch (error) {
+    console.error(`[giip hook doctor] status=blocked error=${error.message}`);
+    process.exitCode = 2;
+  }
+}
+
+module.exports = { main, parseArgs, summary };
+

--- a/.agent/tests/windows-hook-doctor.test.js
+++ b/.agent/tests/windows-hook-doctor.test.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const doctor = require('../lib/windows-hook-doctor');
+
+let passed = 0;
+const failures = [];
+
+function test(name, fn) {
+  try {
+    fn();
+    passed += 1;
+    console.log(`  ok   ${name}`);
+  } catch (error) {
+    failures.push({ name, error });
+    console.log(`  FAIL ${name}\n       ${error.stack || error.message}`);
+  }
+}
+
+function fixture(manifest, files = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'fde-hook-doctor-'));
+  fs.mkdirSync(path.join(root, 'hooks'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'hooks', 'hooks.json'), manifest, 'utf8');
+  for (const [relativePath, content] of Object.entries(files)) {
+    const target = path.join(root, relativePath);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, content, 'utf8');
+  }
+  return root;
+}
+
+function manifest(event, command) {
+  return JSON.stringify({
+    hooks: {
+      [event]: [{ hooks: [{ type: 'command', command }] }],
+    },
+  }, null, 2);
+}
+
+console.log('\nWindows Hook Doctor');
+
+test('비-Windows에서는 파일을 읽거나 변경하지 않고 skip한다', () => {
+  const root = path.join(os.tmpdir(), 'does-not-exist-fde-agent');
+  const result = doctor.run({ root, platform: 'linux', repair: true });
+  assert.strictEqual(result.status, 'skipped');
+  assert.strictEqual(result.changedFiles.length, 0);
+});
+
+test('BOM/CRLF와 PreToolUse 누락 대상을 중요 오류로 진단한다', () => {
+  const raw = `\uFEFF${manifest('PreToolUse', 'node ${CLAUDE_PLUGIN_ROOT}/scripts/missing.js').replace(/\n/g, '\r\n')}`;
+  const root = fixture(raw);
+  const result = doctor.run({ root, platform: 'win32', probeNode: () => true });
+  assert.ok(result.issues.some((issue) => issue.code === 'utf8-bom'));
+  assert.ok(result.issues.some((issue) => issue.code === 'crlf'));
+  assert.ok(result.issues.some((issue) => issue.code === 'missing-target' && issue.severity === 'critical'));
+  assert.strictEqual(result.status, 'blocked');
+});
+
+test('SessionStart 누락 대상은 경고이며 전체 실행을 막지 않는다', () => {
+  const root = fixture(manifest('SessionStart', 'node ${CLAUDE_PLUGIN_ROOT}/hooks/missing.js'));
+  const result = doctor.run({ root, platform: 'win32', probeNode: () => true });
+  assert.ok(result.issues.some((issue) => issue.code === 'missing-target' && issue.severity === 'warning'));
+  assert.strictEqual(result.status, 'warning');
+});
+
+test('복구는 BOM/CRLF를 제거하고 원본 백업을 한 번만 만든다', () => {
+  const clean = manifest('SessionStart', 'node ${CLAUDE_PLUGIN_ROOT}/hooks/start.js');
+  const root = fixture(`\uFEFF${clean.replace(/\n/g, '\r\n')}`, { 'hooks/start.js': '#!/usr/bin/env node\r\nconsole.log("ok");\r\n' });
+  const first = doctor.run({ root, platform: 'win32', repair: true, probeNode: () => true });
+  const manifestPath = path.join(root, 'hooks', 'hooks.json');
+  const backupPath = path.join(root, 'runtime', 'hook-backups', 'hooks', 'hooks.json.bak');
+  assert.strictEqual(first.status, 'healthy');
+  assert.ok(first.changedFiles.includes('hooks/hooks.json'));
+  assert.ok(first.changedFiles.includes('hooks/start.js'));
+  assert.ok(fs.existsSync(backupPath));
+  const backup = fs.readFileSync(backupPath, 'utf8');
+  doctor.run({ root, platform: 'win32', repair: true, probeNode: () => true });
+  assert.strictEqual(fs.readFileSync(backupPath, 'utf8'), backup, '기존 백업을 덮어쓰면 안 된다');
+  assert.ok(!fs.readFileSync(manifestPath, 'utf8').startsWith('\uFEFF'));
+  assert.ok(!fs.readFileSync(manifestPath, 'utf8').includes('\r\n'));
+});
+
+test('상태 로그는 절대경로를 남기지 않고 최근 50건만 유지한다', () => {
+  const root = fixture(manifest('SessionStart', 'node ${CLAUDE_PLUGIN_ROOT}/hooks/start.js'), { 'hooks/start.js': 'console.log("ok");\n' });
+  for (let index = 0; index < 55; index += 1) {
+    doctor.run({ root, platform: 'win32', probeNode: () => true });
+  }
+  const log = fs.readFileSync(path.join(root, 'runtime', 'windows-hook-health.jsonl'), 'utf8');
+  const lines = log.trim().split('\n');
+  assert.strictEqual(lines.length, 50);
+  assert.ok(!log.includes(root), '상태 로그에 절대경로를 남기면 안 된다');
+});
+
+test('agent root 밖의 대상은 중요 오류로 차단하고 수정하지 않는다', () => {
+  const root = fixture(manifest('PreToolUse', 'node ${CLAUDE_PLUGIN_ROOT}/../outside.js'));
+  const result = doctor.run({ root, platform: 'win32', repair: true, probeNode: () => true });
+  assert.ok(result.issues.some((issue) => issue.code === 'outside-agent-root' && issue.severity === 'critical'));
+  assert.strictEqual(result.status, 'blocked');
+});
+
+test('Node 런타임 기능 점검 실패는 모든 훅을 차단한다', () => {
+  const root = fixture(manifest('SessionStart', 'node ${CLAUDE_PLUGIN_ROOT}/hooks/start.js'), { 'hooks/start.js': 'console.log("ok");\n' });
+  const result = doctor.run({ root, platform: 'win32', probeNode: () => false });
+  assert.ok(result.issues.some((issue) => issue.code === 'node-unavailable' && issue.severity === 'critical'));
+  assert.strictEqual(result.status, 'blocked');
+});
+
+test('수정할 문제가 없으면 repair 모드도 중복 진단하지 않는다', () => {
+  const root = fixture(manifest('SessionStart', 'node ${CLAUDE_PLUGIN_ROOT}/hooks/start.js'), { 'hooks/start.js': 'console.log("ok");\n' });
+  let probes = 0;
+  const result = doctor.run({
+    root,
+    platform: 'win32',
+    repair: true,
+    writeLog: false,
+    probeNode: () => { probes += 1; return true; },
+  });
+  assert.strictEqual(result.status, 'healthy');
+  assert.strictEqual(probes, 1);
+});
+
+console.log(`\n${passed} passed, ${failures.length} failed`);
+if (failures.length > 0) process.exitCode = 1;

--- a/.github/workflows/windows-hook-doctor.yml
+++ b/.github/workflows/windows-hook-doctor.yml
@@ -1,0 +1,35 @@
+name: Windows Hook Doctor
+
+on:
+  pull_request:
+    paths:
+      - '.agent/hooks/**'
+      - '.agent/lib/windows-hook-doctor.js'
+      - '.agent/scripts/windows-hook-doctor.js'
+      - '.agent/tests/windows-hook-doctor.test.js'
+      - '.github/workflows/windows-hook-doctor.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.agent/hooks/**'
+      - '.agent/lib/windows-hook-doctor.js'
+      - '.agent/scripts/windows-hook-doctor.js'
+      - '.agent/tests/windows-hook-doctor.test.js'
+
+permissions:
+  contents: read
+
+jobs:
+  verify-windows-hooks:
+    runs-on: windows-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - name: Run unit tests
+        run: node .agent/tests/windows-hook-doctor.test.js
+      - name: Verify repository hooks
+        run: node .agent/scripts/windows-hook-doctor.js --json
+

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -53,3 +53,6 @@ This file tracks the history of tasks and changes performed by the GIIP Agent sy
 - 20260510 12:35:00: Fixed broken link in `docs/70-LowyOpinion/capacydiagram.md` and restored the missing `docs/02-design/DESIGN_20260415_KARPATHY_K_LAYER.md` document.
 - 20260513 13:52:00: Moved `51-features/wiki-sync` to `docs/51-features/wiki-sync` to align with the project's documentation numbering convention.
 - 20260516 13:58:00: Integrated `msitarzewski/agency-agents` repository. Added new roles (Workflow Architect, Korean Business Navigator) and skills (workflow-mapping, premium-ui-craft). Updated `update_urls.json` and workflow guidelines.
+- 20260701: k-layer.js 키워드 업데이트 및 `BASE_DIR` 처리 개선.
+- 20260703: README를 FDE Agent 정체성 중심으로 재구성하고 EN/JP를 동기화. QUICK_START, 범용 워크플로 규칙, Slack 봇의 taskmerge·타임아웃·수정요청 라우팅·워크플로 명령·결과 URL 처리를 개선.
+- 20260706: What's New 롤링 페이지를 신설하고, `paperthin` 스킬 14종과 `keep-codex-fast` 외부 저장소 정보를 등록.

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -6,23 +6,12 @@
 >
 > *(EN/JP 독자는 각 항목을 AI 에이전트에 번역 요청하세요. / Ask your AI assistant to translate entries.)*
 
-**기준일 (as of): 2026-07-06**
+**기준일 (as of): 2026-09-10**
 
 ---
 
-## 2026-07-06
-- **What's New 롤링 페이지 신설** — README 최상단에 링크. 최근 7일 갱신을 이 페이지에서 확인, 유지 규칙은 [`36_whats_new_maintenance`](../.agent/rules/36_whats_new_maintenance.md).
-- **paperthin 스킬 14종 이식 + 외부 레포 목록 등록** — [LilMGenius/paperthin](https://github.com/LilMGenius/paperthin)(MIT)의 "clean & true" 저수준 스킬(re0·shower·factchk·ssotchk·hate 등)을 `.agent/skills/`에 이식하고, `links.md` 및 `ai-repositories-index`(KR/EN/JP)에 등록. → [`.agent/skills/PAPERTHIN_NOTICE.md`](../.agent/skills/PAPERTHIN_NOTICE.md)
-- **keep-codex-fast 외부 레포 목록 등록** — [vibeforge1111/keep-codex-fast](https://github.com/vibeforge1111/keep-codex-fast)(MIT, Codex 성능 유지 스킬)를 `links.md`·`ai-repositories-index`에 등록. 스킬은 기존 이식 완료(`codex-maintenance` 워크플로 포함).
-
-## 2026-07-03
-- **README를 FDE Agent 정체성 중심으로 재구성** — FDE 정의를 Palantir "Forward Deployed Engineer"로 정정하고 EN/JP 동기화.
-- **QUICK_START 개선** — Claude 최우선 추천 + Slack 봇 연결 가이드 추가.
-- **범용 워크플로 규칙 3종 추가** — `33` repo-URL 보고 / `34` edit-approval / `35` commit-push-per-task. → [`.agent/rules/`](../.agent/rules/)
-- **slack-bot 다수 개선** — `taskmerge`(미완료 중복 태스크 통합), 처리 타임아웃 5→20분, 태스크번호 포함 수정요청 라우팅 버그 수정, `wfrun`/`wflist` 워크플로 실행·목록 명령 추가, 결과 URL 유실 버그 수정.
-
-## 2026-07-01
-- **k-layer.js 키워드 업데이트 및 `BASE_DIR` 처리 개선.**
+## 2026-09-10
+- **Windows Hook Doctor 추가** — FDE 소유 훅의 Node 실행 가능성·대상 경로·BOM/CRLF를 진단하고 backup-once 복구 후 재검증하며, Windows CI에서 회귀를 차단합니다. → [구현 계획](./plans/2026-09-10-windows-hook-doctor.md)
 
 ---
 *이 페이지는 [규칙 36 — What's New 유지](../.agent/rules/36_whats_new_maintenance.md)에 따라 갱신·정리됩니다.*

--- a/docs/plans/2026-09-10-windows-hook-doctor.md
+++ b/docs/plans/2026-09-10-windows-hook-doctor.md
@@ -1,0 +1,51 @@
+# Windows Hook Doctor 구현 계획
+
+> **For Claude:** REQUIRED SUB-SKILL: Use test-driven-development to implement this plan task by task.
+
+**Goal:** Windows에서 FDE 소유 훅의 인코딩·경로·실행 가능성을 자동 진단하고, 안전한 항목만 백업 후 복구한다.
+
+**Architecture:** `.agent/lib/windows-hook-doctor.js`가 순수 진단·복구 로직을 제공하고, `.agent/scripts/windows-hook-doctor.js`가 CLI 종료 코드와 출력을 담당한다. SessionStart는 조용한 복구 모드로 호출하며, `PreToolUse` 훅 결함은 차단 상태와 종료 코드 2로, 나머지 훅 결함은 경고로 처리한다. 외부 플러그인과 사용자 설정은 범위에서 제외한다.
+
+**Tech Stack:** Node.js CommonJS, 내장 `fs/path/child_process`, GitHub Actions Windows runner
+
+---
+
+### Task 1: 실패 테스트로 안전 경계 고정
+
+**Files:**
+- Create: `.agent/tests/windows-hook-doctor.test.js`
+
+1. 비-Windows 무변경, BOM/CRLF 탐지, backup-once, 루트 이탈 차단, 중요 훅 fail-closed 테스트를 작성한다.
+2. 테스트를 실행해 구현 모듈 부재로 실패하는지 확인한다.
+
+### Task 2: 최소 진단·복구 코어 구현
+
+**Files:**
+- Create: `.agent/lib/windows-hook-doctor.js`
+
+1. FDE 훅 매니페스트를 읽고 command 훅을 열거한다.
+2. Node 런타임을 실제 실행으로 확인하고, 참조 대상이 agent root 안에 존재하는지 검증한다.
+3. BOM/CRLF만 `.agent/runtime/hook-backups/`의 backup-once 방식으로 복구하고 다시 검증한다.
+4. 절대 경로와 명령 원문을 제외한 로컬 상태 로그를 최대 50건으로 유지한다.
+5. 단위 테스트를 통과시킨다.
+
+### Task 3: CLI와 SessionStart 연결
+
+**Files:**
+- Create: `.agent/scripts/windows-hook-doctor.js`
+- Modify: `.agent/hooks/hooks.json`
+
+1. `--repair`, `--quiet`, `--json` 옵션과 종료 코드 0/2를 구현한다.
+2. SessionStart 첫 훅으로 quiet repair를 연결한다.
+3. Linux에서는 명시적 skip, Windows 중요 훅 오류에서는 종료 코드 2인지 검증한다.
+
+### Task 4: Windows 회귀 테스트와 문서화
+
+**Files:**
+- Create: `.github/workflows/windows-hook-doctor.yml`
+- Modify: `.agent/knowledge/notes/claude-code-hooks.md`
+- Modify: `docs/WHATS_NEW.md`
+
+1. `windows-latest`에서 단위 테스트와 doctor CLI를 실행한다.
+2. 운영 범위와 fail-open/fail-closed 경계를 문서화한다.
+3. 기존 Node 회귀 테스트와 새 테스트를 함께 실행한다.


### PR DESCRIPTION
## 요약

- 외부 `win-hooks`를 직접 이식하지 않고 FDE 소유 훅 전용 Windows Hook Doctor를 추가했습니다.
- Node 자식 프로세스 기능 점검, 훅 대상 경로/루트 이탈, UTF-8 BOM/CRLF를 진단합니다.
- 복구는 `.agent/runtime/hook-backups/`에 한 번만 백업하고 안전한 인코딩 정규화만 수행한 뒤 재검증합니다.
- `PreToolUse` 누락과 Node 실행 불가는 차단 상태(exit 2), 가용성 훅 누락은 경고로 분리했습니다.
- SessionStart 자동 점검과 `windows-latest` 회귀 워크플로를 연결했습니다.

## 검증

- `node .agent/tests/windows-hook-doctor.test.js` — 8/8 통과
- `node slack-bot/tools/test-cost-optimization.js` — 101/101 통과
- 실제 저장소 훅 Windows 모의 진단 — healthy, 10 hooks
- Node 문법 검사 및 workflow YAML 파싱 통과

## 알려진 기존 상태

`.agent/scripts/validate-plugin.js`는 저장소 루트에 없는 plugin 전용 `plugin.json`, `CLAUDE.md`, `agents/`, `commands/`을 요구해 기존 구조에서도 실패합니다. 이번 변경과 무관하며 위의 대상 테스트로 검증했습니다.