### PR TITLE
feat(slack-bot): 기동 시 lssn 자동등록 + 처리마다 상태보고 (giip #2349)

### DIFF
--- a/slack-bot-minimax/index.js
+++ b/slack-bot-minimax/index.js
@@ -24,6 +24,7 @@ const { BOT_TOKEN, CHANNEL_IDS, SLACK_APP_TOKEN, AGENT_DIR, HISTORY_FILE, TASK_S
 const { loadJSON, saveJSON } = require('./state');
 const { slackGet } = require('./slack-api');
 const { onSlackMessage, drainNextQueued } = require('./handlers');
+const lssnAgent = require('./lssn-agent'); // [giip #2349] 기동 시 lssn 자동등록 + 처리마다 상태보고
 
 // ── 重複プロセス検出・自己終了 ───────────────────────────────────────────────
 function killDuplicateBots() {
@@ -183,6 +184,10 @@ async function main() {
   console.log(`[Bot] ID: ${config.getBotUserId()} (${auth.user}) PID: ${process.pid}`);
   console.log(`[Bot] 監視チャンネル: ${CHANNEL_IDS.join(', ') || '(DM のみ)'}`);
 
+  // [giip #2349] 기동 시 자신을 GIIP lssn 으로 자동등록(멱등 heartbeat). best-effort —
+  // 실패해도 registerOnStartup 이 내부에서 예외를 삼키므로 봇 기동을 막지 않는다.
+  await lssnAgent.registerOnStartup();
+
   killDuplicateBots();
   // 起動時: 再起動で孤児化した running を即 reconcile（サブプロセスは既に死亡）
   reconcileTaskState({ staleMinutes: 0 });
@@ -252,7 +257,13 @@ async function main() {
   socketClient.on('app_mention', async ({ event, ack }) => {
     await safeAck(ack);
     console.log('[Bot] app_mention:', event.channel, (event.text || '').slice(0, 60));
-    await onSlackMessage(event, conversations);
+    // [giip #2349] 처리 시작/종료를 GIIP 에 상태보고(fire-and-forget, best-effort — blocking 없음).
+    lssnAgent.reportStatus('processing', `app_mention ${event.channel}`);
+    try {
+      await onSlackMessage(event, conversations);
+    } finally {
+      lssnAgent.reportStatus('idle', 'ready');
+    }
   });
 
   // DM・スレッド返信 (message イベント — message.im / message.channels 購読時)
@@ -263,7 +274,13 @@ async function main() {
     const mentionsBot = config.getBotUserId() && (event.text || '').includes(`<@${config.getBotUserId()}>`);
     if (!isDM && mentionsBot) return; // app_mention ハンドラで処理済み — 重複スキップ
     console.log('[Bot] message:', event.channel_type, (event.text || '').slice(0, 60));
-    await onSlackMessage(event, conversations);
+    // [giip #2349] 처리 시작/종료를 GIIP 에 상태보고(fire-and-forget, best-effort — blocking 없음).
+    lssnAgent.reportStatus('processing', `message ${event.channel_type || event.channel}`);
+    try {
+      await onSlackMessage(event, conversations);
+    } finally {
+      lssnAgent.reportStatus('idle', 'ready');
+    }
   });
 
   // 全WebSocketメッセージをデバッグログ

--- a/slack-bot-minimax/lssn-agent.js
+++ b/slack-bot-minimax/lssn-agent.js
@@ -1,0 +1,108 @@
+/**
+ * lssn-agent.js — 기동 시 GIIP lssn 자동등록 + 처리마다 상태보고 (giip #2349).
+ *
+ * 목적: 이 템플릿으로 배포되는 slack-bot 이 기동 시 자신을 GIIP lsvr(lssn)로 자동 등록하고,
+ *       메시지/태스크를 처리할 때마다 현재 상태를 GIIP KVS 로 보고한다. 사람이 GIIP 콘솔에서
+ *       "이 PC의 이 봇이 지금 살아있고 무엇을 처리 중인지"를 볼 수 있게 하는 것.
+ *
+ * 설계 원칙(본 이슈 §3 회귀 방지):
+ *   - **best-effort**: 등록/상태보고 실패(네트워크·SK 미설정·RstVal≠200 등)는 봇 기동이나
+ *     메시지 처리 로직을 절대 막지 않는다. 모든 경로를 try/catch 로 감싸 예외를 삼키고 경고만 남긴다.
+ *   - **csn/SK 하드코딩 금지**: giip-accounts.resolve() 가 돌려주는 그 배포의 계정(csn/sk/apiBase)을
+ *     그대로 쓴다. 물리 호스트명은 os.hostname(). tool-slug 만 봇 변형별로 구분되는 값을 쓰되,
+ *     GIIP_TOOL_SLUG 환경변수로 배포마다 오버라이드할 수 있다(다른 PC/CSN 유연성).
+ *
+ * API 규약(https://giip.littleworld.net/ko/guides/giip-agent-api): 단일 디스패처 giipApiSk2,
+ *   항상 HTTP 200 이고 실제 성공여부는 data[0].RstVal(=200) 로 판단.
+ *   - AgentAutoRegister: text="AgentAutoRegister hostname jsondata",
+ *     jsondata={hostname:"<physical>-<slug>", os, cpu_cores, memory_gb, agent_version}
+ *     → data[0].{lssn, action("new"|"update"), RstVal}. hostname(호스트+csn)이 멱등 식별키.
+ *   - KVSPut: text="KVSPut kType kKey kFactor",
+ *     jsondata={kType:"lssn", kKey:"<lssn>", kFactor:"slackbot_status", kValue:{...}}.
+ *     소유권 검사(그 SK 의 csn 소속 lssn 이 아니면 RstVal 411) — 같은 SK 로 등록했으므로 정상 소유.
+ */
+const os = require('os');
+const accounts = require('./giip-accounts');
+const giipApi = require('./giip-api');
+
+// 이 봇 변형을 GIIP 상에서 식별하는 tool-slug. 배포마다 GIIP_TOOL_SLUG 로 덮어쓸 수 있다.
+// 기본값은 이 봇의 실행 엔진(MiniMax)과 일치시킨다.
+const TOOL_SLUG = (process.env.GIIP_TOOL_SLUG || 'minimax').trim();
+// 상태보고 KVS 의 kFactor — 다른 스크립트(admin_script_status 등)와 충돌하지 않는 이 봇 전용 값.
+const STATUS_KFACTOR = 'slackbot_status';
+
+let _lssn = null;      // AgentAutoRegister 로 발급받은 lssn(문자열). 등록 실패 시 null 유지.
+let _account = null;   // 등록에 쓴 계정(상태보고에 재사용).
+
+function hostId() {
+  return `${os.hostname()}-${TOOL_SLUG}`;
+}
+
+function agentVersion() {
+  try {
+    return require('./package.json').version || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 기동 시 1회 호출. 자신을 lssn 으로 등록/heartbeat 하고 발급된 lssn 을 모듈 전역에 보관한다.
+ * 절대 throw 하지 않는다(실패는 경고 로그만, null 반환). 반환값은 편의용(lssn|null).
+ */
+async function registerOnStartup() {
+  try {
+    const account = accounts.resolve(null); // 대표(기본) 계정 — 멀티채널이면 default/env 기준
+    if (!account || !account.sk) {
+      console.warn('[lssn-agent] giip 계정(SK) 미설정 — lssn 자동등록 건너뜀(best-effort)');
+      return null;
+    }
+    _account = account;
+    const jsondata = {
+      hostname: hostId(),
+      os: `${os.type()} ${os.release()}`,
+      cpu_cores: os.cpus() ? os.cpus().length : null,
+      memory_gb: Math.round(os.totalmem() / (1024 * 1024 * 1024)),
+      agent_version: agentVersion(),
+    };
+    const raw = await giipApi.apiCall(account, 'AgentAutoRegister hostname jsondata', jsondata);
+    const row = raw && Array.isArray(raw.data) ? raw.data[0] : null;
+    const rstVal = row && row.RstVal != null ? Number(row.RstVal) : null;
+    if (rstVal === 200 && row && row.lssn != null) {
+      _lssn = String(row.lssn);
+      console.log(`[lssn-agent] 등록 완료: lssn=${_lssn} action=${row.action || '?'} host=${hostId()}`);
+      // 등록 직후 idle 상태 1회 보고(첫 heartbeat).
+      await reportStatus('idle', 'bot started');
+      return _lssn;
+    }
+    console.warn(`[lssn-agent] 등록 실패(RstVal=${rstVal}) — 봇은 계속 진행(best-effort). host=${hostId()}`);
+    return null;
+  } catch (e) {
+    console.warn('[lssn-agent] 등록 예외(무시하고 계속):', e && e.message ? e.message : e);
+    return null;
+  }
+}
+
+/**
+ * 처리 지점마다 현재 상태를 KVSPut 으로 보고한다. best-effort — 절대 throw 하지 않는다.
+ * 메시지 처리 경로에서 await 없이 fire-and-forget 로 호출해도 안전하도록 내부에서 모든 예외를 삼킨다.
+ * @param {'idle'|'processing'|'error'} status
+ * @param {string} [message] 무엇을 처리 중인지 짧은 요약(민감정보 제외).
+ */
+async function reportStatus(status, message) {
+  try {
+    if (!_lssn || !_account) return; // 등록 안 됐으면 조용히 skip(등록 실패 시 상태보고 무의미)
+    const kValue = {
+      status,
+      message: String(message || '').slice(0, 500),
+      last_run: new Date().toISOString(),
+      hostname: hostId(),
+    };
+    const jsondata = { kType: 'lssn', kKey: _lssn, kFactor: STATUS_KFACTOR, kValue };
+    await giipApi.apiCall(_account, 'KVSPut kType kKey kFactor', jsondata);
+  } catch (e) {
+    console.warn('[lssn-agent] 상태보고 예외(무시):', e && e.message ? e.message : e);
+  }
+}
+
+module.exports = { registerOnStartup, reportStatus, hostId, getLssn: () => _lssn, TOOL_SLUG, STATUS_KFACTOR };

--- a/slack-bot-openclaw/README.md
+++ b/slack-bot-openclaw/README.md
@@ -72,6 +72,26 @@ MiniMax가 한도 소진되면 OpenClaw 자체 라우팅이 fallbacks 순서대�
 (`slack-bot-minimax`처럼 별도 쿨다운 로직을 우리가 짤 필요 없음 — OpenClaw가 provider 단위로
 이미 처리한다).
 
+## GIIP lssn 자동등록 + 상태보고 (giip #2349)
+
+`slack-bot`/`slack-bot-minimax`는 자체 Node 런타임(index.js) 안에서 기동 시 lssn 을 자동등록하고
+메시지 처리 지점마다 상태를 보고한다(각 폴더 `lssn-agent.js`). 이 openclaw 변형은 외부 게이트웨이를
+그대로 구동할 뿐 우리가 훅을 넣을 런타임 코드가 없고, 위 §"왜 이 폴더가 별도인가"대로 OpenClaw 본체
+소스는 건드리지 않는다. 그래서 "매 메시지 처리마다"의 세밀한 보고는 이 변형에서는 제공하지 않으며,
+대신 게이트웨이와 나란히 띄우는 **companion 스크립트 `lssn-heartbeat.js`** 로 기동 시 1회 등록 +
+주기적(기본 60초) 생존/대기 상태 보고를 제공한다.
+
+```bash
+# 환경변수로 이 배포의 SK/CSN 을 주입(하드코딩 금지). tool-slug 기본값은 'openclaw'.
+GIIP_SK=<이 배포의 SK> GIIP_CSN=<csn> node lssn-heartbeat.js        # 60초 주기로 상시 실행
+GIIP_SK=<...> HEARTBEAT_SEC=0 node lssn-heartbeat.js                # 등록만 1회 하고 종료(cron 용)
+```
+
+- OS 서비스로 상시 구동하려면 `openclaw gateway start` 와 동일한 방식(schtasks/launchd/systemd)으로
+  이 스크립트를 함께 등록한다. best-effort 설계라 등록/보고 실패는 로그만 남기고 게이트웨이 동작에
+  영향을 주지 않는다.
+- API 규약은 https://giip.littleworld.net/ko/guides/giip-agent-api 참조.
+
 ## 참고
 
 - MiniMax Anthropic 호환 엔드포인트: https://platform.minimax.io/docs/api-reference/text-anthropic-api

--- a/slack-bot-openclaw/lssn-heartbeat.js
+++ b/slack-bot-openclaw/lssn-heartbeat.js
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * lssn-heartbeat.js — OpenClaw 변형용 GIIP lssn 자동등록 + 주기적 상태보고 companion (giip #2349).
+ *
+ * 왜 companion 인가:
+ *   slack-bot / slack-bot-minimax 는 우리가 짠 Node 런타임이라 index.js 안에서 메시지 처리 지점마다
+ *   직접 상태보고를 넣을 수 있다(각 폴더의 lssn-agent.js). 반면 이 openclaw 변형은 외부 OpenClaw
+ *   게이트웨이 프로세스를 그대로 구동할 뿐 자체 런타임 코드가 없고, 이 폴더 설계상 OpenClaw 본체
+ *   소스는 건드리지 않는다(README §"왜 이 폴더가 별도인가"). 따라서 "매 메시지 처리마다"의 세밀한
+ *   상태보고는 OpenClaw 소스를 고치지 않고는 불가능하다. 그 대신 이 companion 을 게이트웨이와 나란히
+ *   OS 서비스로 띄워, 기동 시 1회 등록 + 일정 주기(HEARTBEAT_SEC, 기본 60s)로 살아있음/처리대기
+ *   상태를 보고한다. 이렇게 하면 GIIP 콘솔에서 이 봇의 생존/최근 heartbeat 를 다른 두 변형과 동일하게
+ *   볼 수 있다.
+ *
+ * 의존성 없음: Node 내장 https/os 만 사용(OpenClaw 폴더는 자체 node_modules 를 두지 않으므로).
+ *
+ * 설정(환경변수 — csn/SK 하드코딩 금지, 배포마다 주입):
+ *   GIIP_SK        (필수) 이 배포의 Secret Key.
+ *   GIIP_CSN       (선택) 참고용. hostname 식별키에는 안 들어가지만 소유권은 SK 로 판정된다.
+ *   GIIP_API_BASE  (선택) 기본 https://giipfaw.azurewebsites.net/api
+ *   GIIP_TOOL_SLUG (선택) 기본 'openclaw'. 물리호스트명-<slug> 형태의 식별키에 쓰인다.
+ *   HEARTBEAT_SEC  (선택) 상태보고 주기(초). 기본 60. 0 이하면 등록만 하고 즉시 종료.
+ *
+ * API 규약: https://giip.littleworld.net/ko/guides/giip-agent-api (giipApiSk2 단일 디스패처,
+ *   항상 HTTP 200, 실제 성공은 data[0].RstVal===200).
+ */
+const https = require('https');
+const os = require('os');
+const { URL } = require('url');
+
+const SK = process.env.GIIP_SK || '';
+const API_BASE = process.env.GIIP_API_BASE || 'https://giipfaw.azurewebsites.net/api';
+const TOOL_SLUG = (process.env.GIIP_TOOL_SLUG || 'openclaw').trim();
+const HEARTBEAT_SEC = process.env.HEARTBEAT_SEC != null ? Number(process.env.HEARTBEAT_SEC) : 60;
+const STATUS_KFACTOR = 'slackbot_status';
+
+let _lssn = null;
+
+function hostId() {
+  return `${os.hostname()}-${TOOL_SLUG}`;
+}
+
+function form(params) {
+  return Object.entries(params)
+    .filter(([, v]) => v != null)
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join('&');
+}
+
+function apiCall(verb, jsondata) {
+  return new Promise((resolve) => {
+    try {
+      const u = new URL(`${API_BASE}/giipApiSk2`);
+      const params = { text: verb, token: SK, usertoken: SK };
+      if (jsondata) params.jsondata = JSON.stringify(jsondata);
+      const body = form(params);
+      const req = https.request(
+        {
+          method: 'POST',
+          hostname: u.hostname,
+          port: u.port || 443,
+          path: u.pathname + u.search,
+          headers: {
+            'x-api-key': SK,
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'Content-Length': Buffer.byteLength(body),
+          },
+        },
+        (res) => {
+          let chunks = '';
+          res.on('data', (d) => (chunks += d));
+          res.on('end', () => {
+            try { resolve(JSON.parse(chunks)); } catch { resolve(null); }
+          });
+        }
+      );
+      req.on('error', (e) => { console.warn('[lssn-heartbeat] 요청 오류(무시):', e.message); resolve(null); });
+      req.setTimeout(30000, () => req.destroy(new Error('timeout')));
+      req.write(body);
+      req.end();
+    } catch (e) {
+      console.warn('[lssn-heartbeat] apiCall 예외(무시):', e && e.message ? e.message : e);
+      resolve(null);
+    }
+  });
+}
+
+async function register() {
+  const jsondata = {
+    hostname: hostId(),
+    os: `${os.type()} ${os.release()}`,
+    cpu_cores: os.cpus() ? os.cpus().length : null,
+    memory_gb: Math.round(os.totalmem() / (1024 * 1024 * 1024)),
+  };
+  const raw = await apiCall('AgentAutoRegister hostname jsondata', jsondata);
+  const row = raw && Array.isArray(raw.data) ? raw.data[0] : null;
+  const rstVal = row && row.RstVal != null ? Number(row.RstVal) : null;
+  if (rstVal === 200 && row && row.lssn != null) {
+    _lssn = String(row.lssn);
+    console.log(`[lssn-heartbeat] 등록 완료: lssn=${_lssn} action=${row.action || '?'} host=${hostId()}`);
+    return _lssn;
+  }
+  console.warn(`[lssn-heartbeat] 등록 실패(RstVal=${rstVal}) host=${hostId()}`);
+  return null;
+}
+
+async function heartbeat(status) {
+  if (!_lssn) return;
+  const kValue = { status, message: 'openclaw gateway heartbeat', last_run: new Date().toISOString(), hostname: hostId() };
+  await apiCall('KVSPut kType kKey kFactor', { kType: 'lssn', kKey: _lssn, kFactor: STATUS_KFACTOR, kValue });
+}
+
+async function main() {
+  if (!SK) {
+    console.warn('[lssn-heartbeat] GIIP_SK 미설정 — 등록/보고 건너뜀(best-effort 종료).');
+    return;
+  }
+  await register();
+  await heartbeat('idle');
+  if (!Number.isFinite(HEARTBEAT_SEC) || HEARTBEAT_SEC <= 0) return; // 등록만 하고 종료
+  setInterval(() => { heartbeat('idle').catch(() => {}); }, HEARTBEAT_SEC * 1000);
+  console.log(`[lssn-heartbeat] ${HEARTBEAT_SEC}s 주기 상태보고 시작 (host=${hostId()})`);
+}
+
+if (require.main === module) {
+  main().catch((e) => console.warn('[lssn-heartbeat] main 예외(무시):', e && e.message ? e.message : e));
+}
+
+module.exports = { register, heartbeat, hostId };

--- a/slack-bot/index.js
+++ b/slack-bot/index.js
@@ -25,6 +25,7 @@ const { BOT_TOKEN, CHANNEL_IDS, SLACK_APP_TOKEN, AGENT_DIR, HISTORY_FILE, TASK_S
 const { loadJSON, saveJSON, isBotEngagedThread } = require('./state');
 const { slackGet } = require('./slack-api');
 const { onSlackMessage, drainNextQueued } = require('./handlers');
+const lssnAgent = require('./lssn-agent'); // [giip #2349] 기동 시 lssn 자동등록 + 처리마다 상태보고
 
 // ── 重複プロセス検出・自己終了 ───────────────────────────────────────────────
 function killDuplicateBots() {
@@ -220,6 +221,10 @@ async function main() {
     ? `[Bot] 実行エンジン: MiniMax(${mmBoot.model}) 優先 → 失敗時 Claude フォールバック`
     : '[Bot] 実行エンジン: Claude のみ (MINIMAX_API_KEY 未設定 → MiniMax スキップ)');
 
+  // [giip #2349] 기동 시 자신을 GIIP lssn 으로 자동등록(멱등 heartbeat). best-effort —
+  // 실패해도 registerOnStartup 이 내부에서 예외를 삼키므로 봇 기동을 막지 않는다.
+  await lssnAgent.registerOnStartup();
+
   killDuplicateBots();
   // 起動時: 再起動で孤児化した running を即 reconcile（サブプロセスは既に死亡）
   reconcileTaskState({ staleMinutes: 0 });
@@ -304,7 +309,13 @@ async function main() {
     if (!isAllowedUser(event.user)) return; // 발신자 검증
     if (!isAllowedChannel(event.channel)) return; // 채널 검증
     console.log('[Bot] app_mention:', event.channel, (event.text || '').slice(0, 60));
-    await onSlackMessage(event, conversations);
+    // [giip #2349] 처리 시작/종료를 GIIP 에 상태보고(fire-and-forget, best-effort — blocking 없음).
+    lssnAgent.reportStatus('processing', `app_mention ${event.channel}`);
+    try {
+      await onSlackMessage(event, conversations);
+    } finally {
+      lssnAgent.reportStatus('idle', 'ready');
+    }
   });
 
   // DM・スレッド返信 (message イベント — message.im / message.channels 購読時)
@@ -326,7 +337,13 @@ async function main() {
       if (!isBotEngagedThread(event.channel, event.thread_ts)) return; // 미관여 채널 발화는 무시
     }
     console.log('[Bot] message:', event.channel_type, (event.text || '').slice(0, 60));
-    await onSlackMessage(event, conversations);
+    // [giip #2349] 처리 시작/종료를 GIIP 에 상태보고(fire-and-forget, best-effort — blocking 없음).
+    lssnAgent.reportStatus('processing', `message ${event.channel_type || event.channel}`);
+    try {
+      await onSlackMessage(event, conversations);
+    } finally {
+      lssnAgent.reportStatus('idle', 'ready');
+    }
   });
 
   // 全WebSocketメッセージをデバッグログ

--- a/slack-bot/lssn-agent.js
+++ b/slack-bot/lssn-agent.js
@@ -1,0 +1,108 @@
+/**
+ * lssn-agent.js — 기동 시 GIIP lssn 자동등록 + 처리마다 상태보고 (giip #2349).
+ *
+ * 목적: 이 템플릿으로 배포되는 slack-bot 이 기동 시 자신을 GIIP lsvr(lssn)로 자동 등록하고,
+ *       메시지/태스크를 처리할 때마다 현재 상태를 GIIP KVS 로 보고한다. 사람이 GIIP 콘솔에서
+ *       "이 PC의 이 봇이 지금 살아있고 무엇을 처리 중인지"를 볼 수 있게 하는 것.
+ *
+ * 설계 원칙(본 이슈 §3 회귀 방지):
+ *   - **best-effort**: 등록/상태보고 실패(네트워크·SK 미설정·RstVal≠200 등)는 봇 기동이나
+ *     메시지 처리 로직을 절대 막지 않는다. 모든 경로를 try/catch 로 감싸 예외를 삼키고 경고만 남긴다.
+ *   - **csn/SK 하드코딩 금지**: giip-accounts.resolve() 가 돌려주는 그 배포의 계정(csn/sk/apiBase)을
+ *     그대로 쓴다. 물리 호스트명은 os.hostname(). tool-slug 만 봇 변형별로 구분되는 값을 쓰되,
+ *     GIIP_TOOL_SLUG 환경변수로 배포마다 오버라이드할 수 있다(다른 PC/CSN 유연성).
+ *
+ * API 규약(https://giip.littleworld.net/ko/guides/giip-agent-api): 단일 디스패처 giipApiSk2,
+ *   항상 HTTP 200 이고 실제 성공여부는 data[0].RstVal(=200) 로 판단.
+ *   - AgentAutoRegister: text="AgentAutoRegister hostname jsondata",
+ *     jsondata={hostname:"<physical>-<slug>", os, cpu_cores, memory_gb, agent_version}
+ *     → data[0].{lssn, action("new"|"update"), RstVal}. hostname(호스트+csn)이 멱등 식별키.
+ *   - KVSPut: text="KVSPut kType kKey kFactor",
+ *     jsondata={kType:"lssn", kKey:"<lssn>", kFactor:"slackbot_status", kValue:{...}}.
+ *     소유권 검사(그 SK 의 csn 소속 lssn 이 아니면 RstVal 411) — 같은 SK 로 등록했으므로 정상 소유.
+ */
+const os = require('os');
+const accounts = require('./giip-accounts');
+const giipApi = require('./giip-api');
+
+// 이 봇 변형을 GIIP 상에서 식별하는 tool-slug. 배포마다 GIIP_TOOL_SLUG 로 덮어쓸 수 있다.
+// 기본값은 이 봇의 기동 배너 정체성(giipclaude Bot)과 일치시킨다.
+const TOOL_SLUG = (process.env.GIIP_TOOL_SLUG || 'giipclaude').trim();
+// 상태보고 KVS 의 kFactor — 다른 스크립트(admin_script_status 등)와 충돌하지 않는 이 봇 전용 값.
+const STATUS_KFACTOR = 'slackbot_status';
+
+let _lssn = null;      // AgentAutoRegister 로 발급받은 lssn(문자열). 등록 실패 시 null 유지.
+let _account = null;   // 등록에 쓴 계정(상태보고에 재사용).
+
+function hostId() {
+  return `${os.hostname()}-${TOOL_SLUG}`;
+}
+
+function agentVersion() {
+  try {
+    return require('./package.json').version || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 기동 시 1회 호출. 자신을 lssn 으로 등록/heartbeat 하고 발급된 lssn 을 모듈 전역에 보관한다.
+ * 절대 throw 하지 않는다(실패는 경고 로그만, null 반환). 반환값은 편의용(lssn|null).
+ */
+async function registerOnStartup() {
+  try {
+    const account = accounts.resolve(null); // 대표(기본) 계정 — 멀티채널이면 default/env 기준
+    if (!account || !account.sk) {
+      console.warn('[lssn-agent] giip 계정(SK) 미설정 — lssn 자동등록 건너뜀(best-effort)');
+      return null;
+    }
+    _account = account;
+    const jsondata = {
+      hostname: hostId(),
+      os: `${os.type()} ${os.release()}`,
+      cpu_cores: os.cpus() ? os.cpus().length : null,
+      memory_gb: Math.round(os.totalmem() / (1024 * 1024 * 1024)),
+      agent_version: agentVersion(),
+    };
+    const raw = await giipApi.apiCall(account, 'AgentAutoRegister hostname jsondata', jsondata);
+    const row = raw && Array.isArray(raw.data) ? raw.data[0] : null;
+    const rstVal = row && row.RstVal != null ? Number(row.RstVal) : null;
+    if (rstVal === 200 && row && row.lssn != null) {
+      _lssn = String(row.lssn);
+      console.log(`[lssn-agent] 등록 완료: lssn=${_lssn} action=${row.action || '?'} host=${hostId()}`);
+      // 등록 직후 idle 상태 1회 보고(첫 heartbeat).
+      await reportStatus('idle', 'bot started');
+      return _lssn;
+    }
+    console.warn(`[lssn-agent] 등록 실패(RstVal=${rstVal}) — 봇은 계속 진행(best-effort). host=${hostId()}`);
+    return null;
+  } catch (e) {
+    console.warn('[lssn-agent] 등록 예외(무시하고 계속):', e && e.message ? e.message : e);
+    return null;
+  }
+}
+
+/**
+ * 처리 지점마다 현재 상태를 KVSPut 으로 보고한다. best-effort — 절대 throw 하지 않는다.
+ * 메시지 처리 경로에서 await 없이 fire-and-forget 로 호출해도 안전하도록 내부에서 모든 예외를 삼킨다.
+ * @param {'idle'|'processing'|'error'} status
+ * @param {string} [message] 무엇을 처리 중인지 짧은 요약(민감정보 제외).
+ */
+async function reportStatus(status, message) {
+  try {
+    if (!_lssn || !_account) return; // 등록 안 됐으면 조용히 skip(등록 실패 시 상태보고 무의미)
+    const kValue = {
+      status,
+      message: String(message || '').slice(0, 500),
+      last_run: new Date().toISOString(),
+      hostname: hostId(),
+    };
+    const jsondata = { kType: 'lssn', kKey: _lssn, kFactor: STATUS_KFACTOR, kValue };
+    await giipApi.apiCall(_account, 'KVSPut kType kKey kFactor', jsondata);
+  } catch (e) {
+    console.warn('[lssn-agent] 상태보고 예외(무시):', e && e.message ? e.message : e);
+  }
+}
+
+module.exports = { registerOnStartup, reportStatus, hostId, getLssn: () => _lssn, TOOL_SLUG, STATUS_KFACTOR };


### PR DESCRIPTION
## 개요 (giip #2349)
giip-fde-agent 저장소의 slack-bot 변형들이 기동 시 자신을 GIIP lssn 으로 자동등록하고, 메시지/태스크를 처리할 때마다 상태를 GIIP KVS 로 보고하도록 코드에 내장한다.

## 변경
- **slack-bot / slack-bot-minimax** (자체 Node 런타임): 자기완결형 `lssn-agent.js` 추가.
  - `registerOnStartup()` — 기동 시 `AgentAutoRegister`(멱등 heartbeat), 발급 lssn 모듈 전역 보관.
  - `reportStatus(status, message)` — `app_mention`/`message` 처리 시작(`processing`)/종료(`idle`)마다 `KVSPut`.
  - `index.js` 훅: 기동부에서 `await registerOnStartup()`, 두 이벤트 핸들러에서 fire-and-forget 상태보고(blocking 없음).
- **slack-bot-openclaw** (외부 OpenClaw 프레임워크 구동, 자체 런타임 없음): 소스 미변경 원칙 유지. companion `lssn-heartbeat.js`(의존성 없음, 기동 등록 + 주기 heartbeat) + README 안내 추가. per-message 세밀 보고는 이 변형에서 제공 불가함을 문서에 명시.

## 설계 원칙 (본 이슈 §3 회귀 방지)
- **best-effort**: 등록/상태보고 실패(네트워크·SK 미설정·RstVal≠200)는 전부 try/catch 로 삼켜 봇 기동/메시지 처리를 절대 막지 않음.
- **하드코딩 금지**: csn/SK/apiBase 는 기존 `giip-accounts.resolve()` 재사용. tool-slug 만 봇별 기본값(`giipclaude`/`minimax`/`openclaw`) + `GIIP_TOOL_SLUG` env 오버라이드.

## 검증 (라이브)
- `AgentAutoRegister` → RstVal=200, lssn=71294 (action new→update, host `Lowy-DP01-giipclaude`, csn 33).
- `KVSPut` → RstVal=200 (소유권 검사 통과).
- 모듈 경로 `registerOnStartup()` 실측: slack-bot lssn 반환 정상, 계정 미설정(minimax) 시 throw 없이 skip.
- `node -c` 전 변경 파일 통과.

## Test Procedure
1. `node -c slack-bot/index.js && node -c slack-bot/lssn-agent.js && node -c slack-bot-minimax/index.js && node -c slack-bot-minimax/lssn-agent.js && node -c slack-bot-openclaw/lssn-heartbeat.js` → 전부 exit 0.
2. slack-bot 폴더에서 `node -e "require('./lssn-agent').registerOnStartup().then(l=>console.log('lssn',l))"` → `[lssn-agent] 등록 완료: lssn=<n> action=update` 로그 + lssn 반환 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)